### PR TITLE
chore: Align naming for Roles and Permissions

### DIFF
--- a/clerk/instance_organization_permissions.go
+++ b/clerk/instance_organization_permissions.go
@@ -4,28 +4,12 @@ import (
 	"net/http"
 )
 
-type OrganizationPermission struct {
-	Object      string `json:"object"`
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Key         string `json:"key"`
-	Description string `json:"description"`
-	Type        string `json:"type"`
-	CreatedAt   int64  `json:"created_at"`
-	UpdatedAt   int64  `json:"updated_at"`
-}
-
-type OrganizationPermissionsResponse struct {
-	Data       []OrganizationPermission `json:"data"`
-	TotalCount int64                    `json:"total_count"`
-}
-
 type ListInstanceOrganizationPermissionsParams struct {
 	Limit  *int `json:"limit,omitempty"`
 	Offset *int `json:"offset,omitempty"`
 }
 
-func (s *InstanceService) ListOrganizationPermissions(params ListInstanceOrganizationPermissionsParams) (*OrganizationPermissionsResponse, error) {
+func (s *InstanceService) ListOrganizationPermissions(params ListInstanceOrganizationPermissionsParams) (*PermissionsResponse, error) {
 	req, _ := s.client.NewRequest(http.MethodGet, OrganizationPermissionsUrl)
 
 	paginationParams := PaginationParams{Limit: params.Limit, Offset: params.Offset}
@@ -33,7 +17,7 @@ func (s *InstanceService) ListOrganizationPermissions(params ListInstanceOrganiz
 	addPaginationParams(query, paginationParams)
 	req.URL.RawQuery = query.Encode()
 
-	response := &OrganizationPermissionsResponse{}
+	response := &PermissionsResponse{}
 	_, err := s.client.Do(req, response)
 	if err != nil {
 		return nil, err

--- a/clerk/instance_organization_permissions_test.go
+++ b/clerk/instance_organization_permissions_test.go
@@ -33,7 +33,7 @@ func TestInstanceService_List_happyPathWithParameters(t *testing.T) {
 		fmt.Fprint(w, expectedResponse)
 	})
 
-	want := &OrganizationPermissionsResponse{}
+	want := &PermissionsResponse{}
 	_ = json.Unmarshal([]byte(expectedResponse), want)
 
 	got, _ := client.Instances().ListOrganizationPermissions(ListInstanceOrganizationPermissionsParams{

--- a/clerk/instance_organization_roles.go
+++ b/clerk/instance_organization_roles.go
@@ -3,36 +3,19 @@ package clerk
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 )
 
-type InsOrgRole struct {
-	Object      string                   `json:"object"`
-	ID          string                   `json:"id"`
-	Name        string                   `json:"name"`
-	Key         string                   `json:"key"`
-	Description string                   `json:"description"`
-	Permissions []OrganizationPermission `json:"permissions"`
-	CreatedAt   int64                    `json:"created_at"`
-	UpdatedAt   int64                    `json:"updated_at"`
-}
-
-type InsOrgRolesResponse struct {
-	Data       []InsOrgRole `json:"data"`
-	TotalCount int64        `json:"total_count"`
-}
-
-type CreateInsOrgRoleParams struct {
+type CreateInstanceOrganizationRoleParams struct {
 	Name        string   `json:"name"`
 	Key         string   `json:"key"`
 	Description string   `json:"description"`
 	Permissions []string `json:"permissions,omitempty"`
 }
 
-func (s *InstanceService) CreateOrganizationRole(params CreateInsOrgRoleParams) (*InsOrgRole, error) {
+func (s *InstanceService) CreateOrganizationRole(params CreateInstanceOrganizationRoleParams) (*Role, error) {
 	req, _ := s.client.NewRequest(http.MethodPost, OrganizationRolesUrl, &params)
 
-	var orgRole InsOrgRole
+	var orgRole Role
 	_, err := s.client.Do(req, &orgRole)
 	if err != nil {
 		return nil, err
@@ -40,24 +23,20 @@ func (s *InstanceService) CreateOrganizationRole(params CreateInsOrgRoleParams) 
 	return &orgRole, nil
 }
 
-type ListInsOrgRoleParams struct {
+type ListInstanceOrganizationRoleParams struct {
 	Limit  *int `json:"limit,omitempty"`
 	Offset *int `json:"offset,omitempty"`
 }
 
-func (s *InstanceService) ListOrganizationRole(params ListInsOrgRoleParams) (*InsOrgRolesResponse, error) {
+func (s *InstanceService) ListOrganizationRole(params ListInstanceOrganizationRoleParams) (*RolesResponse, error) {
 	req, _ := s.client.NewRequest(http.MethodGet, OrganizationRolesUrl)
 
+	paginationParams := PaginationParams{Limit: params.Limit, Offset: params.Offset}
 	query := req.URL.Query()
-	if params.Limit != nil {
-		query.Set("limit", strconv.Itoa(*params.Limit))
-	}
-	if params.Offset != nil {
-		query.Set("offset", strconv.Itoa(*params.Offset))
-	}
+	addPaginationParams(query, paginationParams)
 	req.URL.RawQuery = query.Encode()
 
-	var orgRolesResponse *InsOrgRolesResponse
+	var orgRolesResponse *RolesResponse
 	_, err := s.client.Do(req, &orgRolesResponse)
 	if err != nil {
 		return nil, err
@@ -65,13 +44,13 @@ func (s *InstanceService) ListOrganizationRole(params ListInsOrgRoleParams) (*In
 	return orgRolesResponse, nil
 }
 
-func (s *InstanceService) ReadOrganizationRole(orgRoleID string) (*InsOrgRole, error) {
+func (s *InstanceService) ReadOrganizationRole(orgRoleID string) (*Role, error) {
 	req, err := s.client.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", OrganizationRolesUrl, orgRoleID))
 	if err != nil {
 		return nil, err
 	}
 
-	var orgRole InsOrgRole
+	var orgRole Role
 	_, err = s.client.Do(req, &orgRole)
 	if err != nil {
 		return nil, err
@@ -86,10 +65,10 @@ type UpdateInsOrgRoleParams struct {
 	Permissions *[]string `json:"permissions,omitempty"`
 }
 
-func (s *InstanceService) UpdateOrganizationRole(orgRoleID string, params UpdateInsOrgRoleParams) (*InsOrgRole, error) {
+func (s *InstanceService) UpdateOrganizationRole(orgRoleID string, params UpdateInsOrgRoleParams) (*Role, error) {
 	req, _ := s.client.NewRequest(http.MethodPatch, fmt.Sprintf("%s/%s", OrganizationRolesUrl, orgRoleID), &params)
 
-	var orgRole InsOrgRole
+	var orgRole Role
 	_, err := s.client.Do(req, &orgRole)
 	if err != nil {
 		return nil, err

--- a/clerk/instance_organization_roles_test.go
+++ b/clerk/instance_organization_roles_test.go
@@ -23,7 +23,7 @@ func TestInstanceService_CreateOrgRole(t *testing.T) {
 		_, _ = fmt.Fprint(w, expectedResponse)
 	})
 
-	createParams := CreateInsOrgRoleParams{
+	createParams := CreateInstanceOrganizationRoleParams{
 		Name:        "custom role",
 		Key:         "org:custom_role",
 		Description: "my org custom role",
@@ -33,7 +33,7 @@ func TestInstanceService_CreateOrgRole(t *testing.T) {
 	got, err := client.Instances().CreateOrganizationRole(createParams)
 	assert.NoError(t, err)
 
-	var want InsOrgRole
+	var want Role
 	err = json.Unmarshal([]byte(expectedResponse), &want)
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +61,7 @@ func TestOrganizationRolesService_Read(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var want InsOrgRole
+	var want Role
 	err = json.Unmarshal([]byte(expectedResponse), &want)
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +90,7 @@ func TestOrganizationRolesService_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var want InsOrgRole
+	var want Role
 	err = json.Unmarshal([]byte(expectedResponse), &want)
 	if err != nil {
 		t.Fatal(err)
@@ -127,10 +127,10 @@ func TestOrganizationsService_List_happyPath(t *testing.T) {
 		fmt.Fprint(w, expectedResponse)
 	})
 
-	var want *InsOrgRolesResponse
+	var want *RolesResponse
 	_ = json.Unmarshal([]byte(expectedResponse), &want)
 
-	got, _ := client.Instances().ListOrganizationRole(ListInsOrgRoleParams{})
+	got, _ := client.Instances().ListOrganizationRole(ListInstanceOrganizationRoleParams{})
 	if len(got.Data) != len(want.Data) {
 		t.Errorf("Was expecting %d organization roles to be returned, instead got %d", len(want.Data), len(got.Data))
 	}
@@ -162,14 +162,12 @@ func TestOrganizationsService_List_happyPathWithParameters(t *testing.T) {
 		fmt.Fprint(w, expectedResponse)
 	})
 
-	var want *InsOrgRolesResponse
+	var want *RolesResponse
 	_ = json.Unmarshal([]byte(expectedResponse), &want)
 
-	limit := 5
-	offset := 6
-	got, _ := client.Instances().ListOrganizationRole(ListInsOrgRoleParams{
-		Limit:  &limit,
-		Offset: &offset,
+	got, _ := client.Instances().ListOrganizationRole(ListInstanceOrganizationRoleParams{
+		Limit:  intToPtr(5),
+		Offset: intToPtr(6),
 	})
 	if len(got.Data) != len(want.Data) {
 		t.Errorf("Was expecting %d organization roles to be returned, instead got %d", len(want.Data), len(got.Data))
@@ -183,7 +181,7 @@ func TestOrganizationsService_List_happyPathWithParameters(t *testing.T) {
 func TestOrganizationsService_List_invalidServer(t *testing.T) {
 	client, _ := NewClient("token")
 
-	orgRoles, err := client.Instances().ListOrganizationRole(ListInsOrgRoleParams{})
+	orgRoles, err := client.Instances().ListOrganizationRole(ListInstanceOrganizationRoleParams{})
 	if err == nil {
 		t.Errorf("Expected error to be returned")
 	}

--- a/clerk/permissions.go
+++ b/clerk/permissions.go
@@ -1,0 +1,17 @@
+package clerk
+
+type Permission struct {
+	Object      string `json:"object"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Key         string `json:"key"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	CreatedAt   int64  `json:"created_at"`
+	UpdatedAt   int64  `json:"updated_at"`
+}
+
+type PermissionsResponse struct {
+	Data       []Permission `json:"data"`
+	TotalCount int64        `json:"total_count"`
+}

--- a/clerk/roles.go
+++ b/clerk/roles.go
@@ -1,0 +1,17 @@
+package clerk
+
+type Role struct {
+	Object      string       `json:"object"`
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Key         string       `json:"key"`
+	Description string       `json:"description"`
+	Permissions []Permission `json:"permissions"`
+	CreatedAt   int64        `json:"created_at"`
+	UpdatedAt   int64        `json:"updated_at"`
+}
+
+type RolesResponse struct {
+	Data       []Role `json:"data"`
+	TotalCount int64  `json:"total_count"`
+}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [x] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

In this commit we align the naming for the Role and Permission resources with the rest of our SDKs. We will use a more generic term of Role and Permission for every related endpoint

**The feature that uses these endpoints are under active development, thus these changes are not considered breaking**

### Related Issue (optional)

<!--- Please link to the issue here: -->
