### PR TITLE
chore: Rename UpdateInsOrgRoleParams to UpdateInstanceOrganizationRoleParams

### DIFF
--- a/clerk/instance_organization_roles.go
+++ b/clerk/instance_organization_roles.go
@@ -58,14 +58,14 @@ func (s *InstanceService) ReadOrganizationRole(orgRoleID string) (*Role, error) 
 	return &orgRole, nil
 }
 
-type UpdateInsOrgRoleParams struct {
+type UpdateInstanceOrganizationRoleParams struct {
 	Name        *string   `json:"name,omitempty"`
 	Key         *string   `json:"key,omitempty"`
 	Description *string   `json:"description,omitempty"`
 	Permissions *[]string `json:"permissions,omitempty"`
 }
 
-func (s *InstanceService) UpdateOrganizationRole(orgRoleID string, params UpdateInsOrgRoleParams) (*Role, error) {
+func (s *InstanceService) UpdateOrganizationRole(orgRoleID string, params UpdateInstanceOrganizationRoleParams) (*Role, error) {
 	req, _ := s.client.NewRequest(http.MethodPatch, fmt.Sprintf("%s/%s", OrganizationRolesUrl, orgRoleID), &params)
 
 	var orgRole Role

--- a/clerk/instance_organization_roles_test.go
+++ b/clerk/instance_organization_roles_test.go
@@ -75,7 +75,7 @@ func TestOrganizationRolesService_Read(t *testing.T) {
 func TestOrganizationRolesService_Update(t *testing.T) {
 	client, mux, _, teardown := setup("token")
 	defer teardown()
-	var payload UpdateInsOrgRoleParams
+	var payload UpdateInstanceOrganizationRoleParams
 	_ = json.Unmarshal([]byte(dummyUpdateOrgRoleJson), &payload)
 
 	expectedResponse := dummyOrgRoleJson
@@ -103,7 +103,7 @@ func TestOrganizationRolesService_Update(t *testing.T) {
 
 func TestOrganizationRolesService_Update_invalidServer(t *testing.T) {
 	client, _ := NewClient("token")
-	var payload UpdateInsOrgRoleParams
+	var payload UpdateInstanceOrganizationRoleParams
 	_ = json.Unmarshal([]byte(dummyUpdateOrgRoleJson), &payload)
 
 	_, err := client.Instances().UpdateOrganizationRole("someOrgRoleId", payload)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

In the previous commit we missed to rename the struct we are using to update an instance organization role as well

**The feature that uses these endpoints are under active development, thus these changes are not considered breaking**

### Related Issue (optional)

<!--- Please link to the issue here: -->
