### PR TITLE
feat: Support 'order_by' & 'query' parameters on Organization Role & Permission List methods

### DIFF
--- a/clerk/instance_organization_permissions.go
+++ b/clerk/instance_organization_permissions.go
@@ -5,8 +5,10 @@ import (
 )
 
 type ListInstanceOrganizationPermissionsParams struct {
-	Limit  *int `json:"limit,omitempty"`
-	Offset *int `json:"offset,omitempty"`
+	Limit   *int
+	Offset  *int
+	Query   *string
+	OrderBy *string
 }
 
 func (s *InstanceService) ListOrganizationPermissions(params ListInstanceOrganizationPermissionsParams) (*PermissionsResponse, error) {
@@ -15,6 +17,14 @@ func (s *InstanceService) ListOrganizationPermissions(params ListInstanceOrganiz
 	paginationParams := PaginationParams{Limit: params.Limit, Offset: params.Offset}
 	query := req.URL.Query()
 	addPaginationParams(query, paginationParams)
+
+	if params.Query != nil {
+		query.Set("query", *params.Query)
+	}
+	if params.OrderBy != nil {
+		query.Set("order_by", *params.OrderBy)
+	}
+
 	req.URL.RawQuery = query.Encode()
 
 	response := &PermissionsResponse{}

--- a/clerk/instance_organization_permissions_test.go
+++ b/clerk/instance_organization_permissions_test.go
@@ -26,8 +26,10 @@ func TestInstanceService_List_happyPathWithParameters(t *testing.T) {
 
 		actualQuery := req.URL.Query()
 		expectedQuery := url.Values(map[string][]string{
-			"limit":  {"3"},
-			"offset": {"2"},
+			"limit":    {"3"},
+			"offset":   {"2"},
+			"query":    {"my-query"},
+			"order_by": {"created_at"},
 		})
 		assert.Equal(t, expectedQuery, actualQuery)
 		fmt.Fprint(w, expectedResponse)
@@ -37,8 +39,10 @@ func TestInstanceService_List_happyPathWithParameters(t *testing.T) {
 	_ = json.Unmarshal([]byte(expectedResponse), want)
 
 	got, _ := client.Instances().ListOrganizationPermissions(ListInstanceOrganizationPermissionsParams{
-		Limit:  intToPtr(3),
-		Offset: intToPtr(2),
+		Limit:   intToPtr(3),
+		Offset:  intToPtr(2),
+		Query:   stringToPtr("my-query"),
+		OrderBy: stringToPtr("created_at"),
 	})
 	if len(got.Data) != len(want.Data) {
 		t.Errorf("Was expecting %d organization permissions to be returned, instead got %d", len(want.Data), len(got.Data))

--- a/clerk/instance_organization_roles.go
+++ b/clerk/instance_organization_roles.go
@@ -24,8 +24,10 @@ func (s *InstanceService) CreateOrganizationRole(params CreateInstanceOrganizati
 }
 
 type ListInstanceOrganizationRoleParams struct {
-	Limit  *int `json:"limit,omitempty"`
-	Offset *int `json:"offset,omitempty"`
+	Limit   *int
+	Offset  *int
+	Query   *string
+	OrderBy *string
 }
 
 func (s *InstanceService) ListOrganizationRole(params ListInstanceOrganizationRoleParams) (*RolesResponse, error) {
@@ -34,6 +36,14 @@ func (s *InstanceService) ListOrganizationRole(params ListInstanceOrganizationRo
 	paginationParams := PaginationParams{Limit: params.Limit, Offset: params.Offset}
 	query := req.URL.Query()
 	addPaginationParams(query, paginationParams)
+
+	if params.Query != nil {
+		query.Set("query", *params.Query)
+	}
+	if params.OrderBy != nil {
+		query.Set("order_by", *params.OrderBy)
+	}
+
 	req.URL.RawQuery = query.Encode()
 
 	var orgRolesResponse *RolesResponse

--- a/clerk/instance_organization_roles_test.go
+++ b/clerk/instance_organization_roles_test.go
@@ -124,13 +124,27 @@ func TestOrganizationsService_List_happyPath(t *testing.T) {
 	mux.HandleFunc("/organization_roles", func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "GET")
 		testHeader(t, req, "Authorization", "Bearer token")
+
+		expectedQuery := url.Values{
+			"limit":    {"5"},
+			"offset":   {"6"},
+			"query":    {"my-query"},
+			"order_by": {"created_at"},
+		}
+		assert.Equal(t, expectedQuery, req.URL.Query())
+
 		fmt.Fprint(w, expectedResponse)
 	})
 
 	var want *RolesResponse
 	_ = json.Unmarshal([]byte(expectedResponse), &want)
 
-	got, _ := client.Instances().ListOrganizationRole(ListInstanceOrganizationRoleParams{})
+	got, _ := client.Instances().ListOrganizationRole(ListInstanceOrganizationRoleParams{
+		Limit:   intToPtr(5),
+		Offset:  intToPtr(6),
+		Query:   stringToPtr("my-query"),
+		OrderBy: stringToPtr("created_at"),
+	})
 	if len(got.Data) != len(want.Data) {
 		t.Errorf("Was expecting %d organization roles to be returned, instead got %d", len(want.Data), len(got.Data))
 	}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

As part of the List operations for Organization Roles & Permissions, we now support the 'order_by' & 'query' parameters along with the regular pagination

### Related Issue (optional)

<!--- Please link to the issue here: -->
