### PR TITLE
feat: Add active organization's permission in session claims

### DIFF
--- a/clerk/tokens.go
+++ b/clerk/tokens.go
@@ -18,12 +18,13 @@ type TokenClaims struct {
 
 type SessionClaims struct {
 	jwt.Claims
-	SessionID              string          `json:"sid"`
-	AuthorizedParty        string          `json:"azp"`
-	ActiveOrganizationID   string          `json:"org_id"`
-	ActiveOrganizationSlug string          `json:"org_slug"`
-	ActiveOrganizationRole string          `json:"org_role"`
-	Actor                  json.RawMessage `json:"act,omitempty"`
+	SessionID                     string          `json:"sid"`
+	AuthorizedParty               string          `json:"azp"`
+	ActiveOrganizationID          string          `json:"org_id"`
+	ActiveOrganizationSlug        string          `json:"org_slug"`
+	ActiveOrganizationRole        string          `json:"org_role"`
+	ActiveOrganizationPermissions []string        `json:"org_permissions"`
+	Actor                         json.RawMessage `json:"act,omitempty"`
 }
 
 // DecodeToken decodes a jwt token without verifying it.

--- a/clerk/tokens_test.go
+++ b/clerk/tokens_test.go
@@ -48,11 +48,12 @@ var (
 			Expiry:   nil,
 			IssuedAt: nil,
 		},
-		SessionID:              "session_id",
-		AuthorizedParty:        "authorized_party",
-		ActiveOrganizationID:   "org_id",
-		ActiveOrganizationSlug: "org_slug",
-		ActiveOrganizationRole: "org_role",
+		SessionID:                     "session_id",
+		AuthorizedParty:               "authorized_party",
+		ActiveOrganizationID:          "org_id",
+		ActiveOrganizationSlug:        "org_slug",
+		ActiveOrganizationRole:        "org_role",
+		ActiveOrganizationPermissions: []string{"org:billing:manage", "org:report:view"},
 	}
 )
 


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

When decoding and verifying a session token, we are now parsing any organization permissions that might be included and make them available as part of the SessionClaims struct

### Related Issue (optional)

<!--- Please link to the issue here: -->
