### PR TITLE
feat: Denote if organization role can be used as the creator

### DIFF
--- a/clerk/instance_organization_roles_test.go
+++ b/clerk/instance_organization_roles_test.go
@@ -285,7 +285,49 @@ const dummyOrgRoleJson = `{
 	"name": "custom role",
 	"key": "org:custom_role",
 	"description": "my org custom role",
-	"permissions": [],
+	"permissions": [
+		{
+			"object": "permission",
+			"id": "perm_2YDDmdVaAyCjmQq6RhrvNsyuUbC",
+			"name": "Read members",
+			"key": "org:sys_memberships:read",
+			"description": "Permission to read the members of an organization.",
+			"type": "system",
+			"created_at": 1700051416222,
+			"updated_at": 1700051416222
+		},
+		{
+			"object": "permission",
+			"id": "perm_2YDDmcGvIxBiLyPB8mUhLbWhWqG",
+			"name": "Manage members",
+			"key": "org:sys_memberships:manage",
+			"description": "Permission to manage the members of an organization.",
+			"type": "system",
+			"created_at": 1700051416224,
+			"updated_at": 1700051416224
+		},
+		{
+			"object": "permission",
+			"id": "perm_2YDDmbh2v71OSrvPK5WtUrh8FyX",
+			"name": "Delete organization",
+			"key": "org:sys_profile:delete",
+			"description": "Permission to delete an organization.",
+			"type": "system",
+			"created_at": 1700051416221,
+			"updated_at": 1700051416221
+		},
+		{
+			"object": "permission",
+			"id": "perm_2YDDmeXfQl3rdJr0FgkIclA1v5I",
+			"name": "View reports",
+			"key": "org:report:view",
+			"description": "Permission to have the ability to view reports.",
+			"type": "user",
+			"created_at": 1700051416227,
+			"updated_at": 1700051416227
+		}
+	],
+	"is_creator_eligible": true,
 	"created_at": 1610783813,
 	"updated_at": 1610783813
 }`
@@ -296,7 +338,29 @@ const dummyUpdateOrgRoleJson = `{
 	"name": "custom org 2",
 	"key": "org:custom_role_2",
 	"description": "my org custom role",
-	"permissions": [],
+	"permissions": [
+		{
+			"object": "permission",
+			"id": "perm_2YDDmdVaAyCjmQq6RhrvNsyuUbC",
+			"name": "Read members",
+			"key": "org:sys_memberships:read",
+			"description": "Permission to read the members of an organization.",
+			"type": "system",
+			"created_at": 1700051416222,
+			"updated_at": 1700051416222
+		},
+		{
+			"object": "permission",
+			"id": "perm_2YDDmeXfQl3rdJr0FgkIclA1v5I",
+			"name": "View reports",
+			"key": "org:report:view",
+			"description": "Permission to have the ability to view reports.",
+			"type": "user",
+			"created_at": 1700051416227,
+			"updated_at": 1700051416227
+		}
+	],
+	"is_creator_eligible": false,
 	"created_at": 1610783813,
 	"updated_at": 1610783813
 }`

--- a/clerk/roles.go
+++ b/clerk/roles.go
@@ -1,14 +1,15 @@
 package clerk
 
 type Role struct {
-	Object      string       `json:"object"`
-	ID          string       `json:"id"`
-	Name        string       `json:"name"`
-	Key         string       `json:"key"`
-	Description string       `json:"description"`
-	Permissions []Permission `json:"permissions"`
-	CreatedAt   int64        `json:"created_at"`
-	UpdatedAt   int64        `json:"updated_at"`
+	Object            string       `json:"object"`
+	ID                string       `json:"id"`
+	Name              string       `json:"name"`
+	Key               string       `json:"key"`
+	Description       string       `json:"description"`
+	Permissions       []Permission `json:"permissions"`
+	IsCreatorEligible bool         `json:"is_creator_eligible"`
+	CreatedAt         int64        `json:"created_at"`
+	UpdatedAt         int64        `json:"updated_at"`
 }
 
 type RolesResponse struct {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

We expose a new property as part of the role response, which denotes if the role can be used as the default organization creator role. We also align the dummy Role JSON objects with real response objects

### Related Issue (optional)

<!--- Please link to the issue here: -->
