### PR TITLE
feat: Allow providing the domains default role ID when updating instance's organization settings

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -88,19 +88,21 @@ type OrganizationSettingsResponse struct {
 	Object                 string   `json:"object"`
 	Enabled                bool     `json:"enabled"`
 	MaxAllowedMemberships  int      `json:"max_allowed_memberships"`
+	CreatorRole            string   `json:"creator_role"`
 	AdminDeleteEnabled     bool     `json:"admin_delete_enabled"`
 	DomainsEnabled         bool     `json:"domains_enabled"`
 	DomainsEnrollmentModes []string `json:"domains_enrollment_modes"`
-	CreatorRole            string   `json:"creator_role"`
+	DomainsDefaultRole     string   `json:"domains_default_role"`
 }
 
 type UpdateOrganizationSettingsParams struct {
 	Enabled                *bool    `json:"enabled,omitempty"`
 	MaxAllowedMemberships  *int     `json:"max_allowed_memberships,omitempty"`
+	CreatorRoleID          *string  `json:"creator_role_id,omitempty"`
 	AdminDeleteEnabled     *bool    `json:"admin_delete_enabled,omitempty"`
 	DomainsEnabled         *bool    `json:"domains_enabled,omitempty"`
 	DomainsEnrollmentModes []string `json:"domains_enrollment_modes,omitempty"`
-	CreatorRoleID          *string  `json:"creator_role_id,omitempty"`
+	DomainsDefaultRoleID   *string  `json:"domains_default_role_id"`
 }
 
 func (s *InstanceService) UpdateOrganizationSettings(params UpdateOrganizationSettingsParams) (*OrganizationSettingsResponse, error) {

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -104,6 +104,7 @@ func TestInstanceService_UpdateOrganizationSettings_happyPath(t *testing.T) {
 	dummyOrganizationSettingsResponseJSON := `{
 		"enabled": true,
 		"max_allowed_memberships": 2,
+		"creator_role": "org:custom_admin",
 		"admin_delete_enabled": true,
 		"domains_enabled": true,
 		"domains_enrollment_modes": [
@@ -111,7 +112,7 @@ func TestInstanceService_UpdateOrganizationSettings_happyPath(t *testing.T) {
 			"automatic_invitation",
 			"automatic_suggestion"
 		],
-		"creator_role": "org:custom_admin"
+		"domains_default_role": "org:custom_domains"
 	}`
 	var organizationSettingsResponse OrganizationSettingsResponse
 	_ = json.Unmarshal([]byte(dummyOrganizationSettingsResponseJSON), &organizationSettingsResponse)
@@ -127,8 +128,9 @@ func TestInstanceService_UpdateOrganizationSettings_happyPath(t *testing.T) {
 
 	enabled := true
 	got, _ := client.Instances().UpdateOrganizationSettings(UpdateOrganizationSettingsParams{
-		Enabled:       &enabled,
-		CreatorRoleID: stringToPtr("role_2XcSZn6swGCjX59Nk0XbGer22jb"),
+		Enabled:              &enabled,
+		CreatorRoleID:        stringToPtr("role_2XcSZn6swGCjX59Nk0XbGer22jb"),
+		DomainsDefaultRoleID: stringToPtr("role_2XZCQwxfLbXOz2hoBXKFVRjwmGc"),
 	})
 
 	assert.Equal(t, &organizationSettingsResponse, got)


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Add support for defining the domains default role ID as well, when updating the organization settings of an instance

### Related Issue (optional)

<!--- Please link to the issue here: -->
