### PR TITLE
fix: Add omitempty tag on 'domains_default_role_id' property for updating the instance organization settings

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -102,7 +102,7 @@ type UpdateOrganizationSettingsParams struct {
 	AdminDeleteEnabled     *bool    `json:"admin_delete_enabled,omitempty"`
 	DomainsEnabled         *bool    `json:"domains_enabled,omitempty"`
 	DomainsEnrollmentModes []string `json:"domains_enrollment_modes,omitempty"`
-	DomainsDefaultRoleID   *string  `json:"domains_default_role_id"`
+	DomainsDefaultRoleID   *string  `json:"domains_default_role_id,omitempty"`
 }
 
 func (s *InstanceService) UpdateOrganizationSettings(params UpdateOrganizationSettingsParams) (*OrganizationSettingsResponse, error) {


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

As the 'domains_default_role_id' is an optional property, we should use the omitempty tag in order to end up with an empty string as the request body

### Related Issue (optional)

<!--- Please link to the issue here: -->
