### PR TITLE
feat: Introduce users.last_active_at field and allow filtering in List

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ if err != nil {
 }
 
 // List all users for current application
-users, err := client.Users().ListAll()
+users, err := client.Users().ListAll(clerk.ListAllUsersParams{})
 ```
 
 The services exposed in the `clerk.Client` divide the API into logical chunks and

--- a/clerk/http_utils_test.go
+++ b/clerk/http_utils_test.go
@@ -58,3 +58,7 @@ func stringToPtr(input string) *string {
 func intToPtr(input int) *int {
 	return &input
 }
+
+func int64ToPtr(input int64) *int64 {
+	return &input
+}

--- a/clerk/users.go
+++ b/clerk/users.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 type UsersService service
@@ -41,6 +42,7 @@ type User struct {
 	ExternalID                    *string        `json:"external_id"`
 	CreatedAt                     int64          `json:"created_at"`
 	UpdatedAt                     int64          `json:"updated_at"`
+	LastActiveAt                  *int64         `json:"last_active_at"`
 }
 
 type UserOAuthAccessToken struct {
@@ -91,16 +93,17 @@ func (s *UsersService) Create(params CreateUserParams) (*User, error) {
 }
 
 type ListAllUsersParams struct {
-	Limit          *int
-	Offset         *int
-	EmailAddresses []string
-	ExternalIDs    []string
-	PhoneNumbers   []string
-	Web3Wallets    []string
-	Usernames      []string
-	UserIDs        []string
-	Query          *string
-	OrderBy        *string
+	Limit             *int
+	Offset            *int
+	EmailAddresses    []string
+	ExternalIDs       []string
+	PhoneNumbers      []string
+	Web3Wallets       []string
+	Usernames         []string
+	UserIDs           []string
+	Query             *string
+	LastActiveAtSince *int64
+	OrderBy           *string
 }
 
 func (s *UsersService) ListAll(params ListAllUsersParams) ([]User, error) {
@@ -176,6 +179,9 @@ func (s *UsersService) addUserSearchParamsToRequest(r *http.Request, params List
 	}
 	if params.Query != nil {
 		query.Add("query", *params.Query)
+	}
+	if params.LastActiveAtSince != nil {
+		query.Add("last_active_at_since", strconv.Itoa(int(*params.LastActiveAtSince)))
 	}
 	r.URL.RawQuery = query.Encode()
 }

--- a/clerk/users_test.go
+++ b/clerk/users_test.go
@@ -80,15 +80,16 @@ func TestUsersService_ListAll_happyPathWithParameters(t *testing.T) {
 
 		actualQuery := req.URL.Query()
 		expectedQuery := url.Values(map[string][]string{
-			"limit":         {"5"},
-			"offset":        {"6"},
-			"email_address": {"email1", "email2"},
-			"phone_number":  {"phone1", "phone2"},
-			"web3_wallet":   {"wallet1", "wallet2"},
-			"username":      {"username1", "username2"},
-			"user_id":       {"userid1", "userid2"},
-			"query":         {"my-query"},
-			"order_by":      {"created_at"},
+			"limit":                {"5"},
+			"offset":               {"6"},
+			"email_address":        {"email1", "email2"},
+			"phone_number":         {"phone1", "phone2"},
+			"web3_wallet":          {"wallet1", "wallet2"},
+			"username":             {"username1", "username2"},
+			"user_id":              {"userid1", "userid2"},
+			"query":                {"my-query"},
+			"last_active_at_since": {"1700690400000"},
+			"order_by":             {"created_at"},
 		})
 		assert.Equal(t, expectedQuery, actualQuery)
 		fmt.Fprint(w, expectedResponse)
@@ -98,15 +99,16 @@ func TestUsersService_ListAll_happyPathWithParameters(t *testing.T) {
 	_ = json.Unmarshal([]byte(expectedResponse), &want)
 
 	got, _ := client.Users().ListAll(ListAllUsersParams{
-		Limit:          intToPtr(5),
-		Offset:         intToPtr(6),
-		EmailAddresses: []string{"email1", "email2"},
-		PhoneNumbers:   []string{"phone1", "phone2"},
-		Web3Wallets:    []string{"wallet1", "wallet2"},
-		Usernames:      []string{"username1", "username2"},
-		UserIDs:        []string{"userid1", "userid2"},
-		Query:          stringToPtr("my-query"),
-		OrderBy:        stringToPtr("created_at"),
+		Limit:             intToPtr(5),
+		Offset:            intToPtr(6),
+		EmailAddresses:    []string{"email1", "email2"},
+		PhoneNumbers:      []string{"phone1", "phone2"},
+		Web3Wallets:       []string{"wallet1", "wallet2"},
+		Usernames:         []string{"username1", "username2"},
+		UserIDs:           []string{"userid1", "userid2"},
+		Query:             stringToPtr("my-query"),
+		LastActiveAtSince: int64ToPtr(int64(1700690400000)),
+		OrderBy:           stringToPtr("created_at"),
 	})
 	if len(got) != len(want) {
 		t.Errorf("Was expecting %d user to be returned, instead got %d", len(want), len(got))
@@ -513,11 +515,12 @@ const dummyUserJson = `{
 		"private_metadata": {
 			"app_id": 5
 		},
-		"last_sign_in_at": 1610783813,
+		"last_sign_in_at": 1610783813000,
 		"banned": false,
 		"locked": false,
 		"lockout_expires_in_seconds": null,
-		"verification_attempts_remaining": null
+		"verification_attempts_remaining": null,
+		"last_active_at": 1700690400000
     }`
 
 const dummyUserOAuthAccessTokensJson = `[


### PR DESCRIPTION

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

- The query parameter `last_active_at_since` can now be used to filter users based on their latest session activity date.
- Field `last_active_at` is now included in the User response fields.

### Related Issue (optional)

<!--- Please link to the issue here: -->
