### PR TITLE
feat!: When creating a SAML Connection you are also required to provide the provider type

### DIFF
--- a/clerk/saml_connections.go
+++ b/clerk/saml_connections.go
@@ -81,6 +81,7 @@ func (s SAMLConnectionsService) Read(id string) (*SAMLConnection, error) {
 type CreateSAMLConnectionParams struct {
 	Name           string  `json:"name"`
 	Domain         string  `json:"domain"`
+	Provider       string  `json:"provider"`
 	IdpEntityID    *string `json:"idp_entity_id,omitempty"`
 	IdpSsoURL      *string `json:"idp_sso_url,omitempty"`
 	IdpCertificate *string `json:"idp_certificate,omitempty"`

--- a/clerk/saml_connections_test.go
+++ b/clerk/saml_connections_test.go
@@ -93,6 +93,7 @@ func TestSAMLConnectionsService_Create(t *testing.T) {
 	createParams := &CreateSAMLConnectionParams{
 		Name:           "Testing SAML",
 		Domain:         "example.com",
+		Provider:       "saml_custom",
 		IdpEntityID:    stringToPtr("test-idp-entity-id"),
 		IdpSsoURL:      stringToPtr("https://example.com/saml/sso"),
 		IdpCertificate: stringToPtr(dummySAMLConnectionCertificate),


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🌟 New feature (non-breaking change which adds functionality)
- [x] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [ ] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

We update our SAML Connection Create() method in order to also require the 'provider' property as Backend API from now on requires to be present. 
_This is a breaking change as it concerns the API, but the SAML feature is still in Beta_

### Related Issue (optional)

<!--- Please link to the issue here: -->
