### PR TITLE
fix: Params interface

### DIFF
--- a/actortoken/actor_token.go
+++ b/actortoken/actor_token.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/url"
 
 	"github.com/clerk/clerk-sdk-go/v2"
 )
@@ -32,7 +31,7 @@ func Create(ctx context.Context, params *CreateParams) (*clerk.ActorToken, error
 // Revoke revokes a pending actor token.
 func Revoke(ctx context.Context, id string) (*clerk.ActorToken, error) {
 	token := &clerk.ActorToken{}
-	path, err := url.JoinPath(path, id, "revoke")
+	path, err := clerk.JoinPath(path, id, "revoke")
 	if err != nil {
 		return token, err
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -4,7 +4,6 @@ package domain
 import (
 	"context"
 	"net/http"
-	"net/url"
 
 	"github.com/clerk/clerk-sdk-go/v2"
 )
@@ -36,7 +35,7 @@ type UpdateParams struct {
 
 // Update updates a domain's properties.
 func Update(ctx context.Context, id string, params *UpdateParams) (*clerk.Domain, error) {
-	path, err := url.JoinPath(path, id)
+	path, err := clerk.JoinPath(path, id)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +49,7 @@ func Update(ctx context.Context, id string, params *UpdateParams) (*clerk.Domain
 
 // Delete removes a domain.
 func Delete(ctx context.Context, id string) (*clerk.DeletedResource, error) {
-	path, err := url.JoinPath(path, id)
+	path, err := clerk.JoinPath(path, id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Type of change

<!--- What types of changes does your code introduce? Put an `x` in the box that apply: -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🌟 New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality)
- [x] 📖 Docs change / refactoring / dependency upgrade to change)

## Description

Changed the Queryable interface to Params. Instead of operating on a url.Values object, implementing types should return a url.Values object. When we set the params to the querystring, we'll use the new interface method.

Added a custom implementation to join URL paths. The new implementation will preserve any query parameters in the URL. We can now replace url.JoinPath, which required us to use Go v1.19 and upwards.


### Related Issue (optional)

<!--- Please link to the issue here: -->
