### PR TITLE
feat: Ability to configure a SAML Connection via IdP Metadata URL

### DIFF
--- a/clerk/saml_connections.go
+++ b/clerk/saml_connections.go
@@ -15,6 +15,7 @@ type SAMLConnection struct {
 	IdpEntityID        *string `json:"idp_entity_id"`
 	IdpSsoURL          *string `json:"idp_sso_url"`
 	IdpCertificate     *string `json:"idp_certificate"`
+	IdpMetadataURL     *string `json:"idp_metadata_url"`
 	AcsURL             string  `json:"acs_url"`
 	SPEntityID         string  `json:"sp_entity_id"`
 	SPMetadataURL      string  `json:"sp_metadata_url"`
@@ -85,6 +86,7 @@ type CreateSAMLConnectionParams struct {
 	IdpEntityID    *string `json:"idp_entity_id,omitempty"`
 	IdpSsoURL      *string `json:"idp_sso_url,omitempty"`
 	IdpCertificate *string `json:"idp_certificate,omitempty"`
+	IdpMetadataURL *string `json:"idp_metadata_url,omitempty"`
 }
 
 func (s SAMLConnectionsService) Create(params *CreateSAMLConnectionParams) (*SAMLConnection, error) {
@@ -107,6 +109,7 @@ type UpdateSAMLConnectionParams struct {
 	IdpEntityID        *string `json:"idp_entity_id,omitempty"`
 	IdpSsoURL          *string `json:"idp_sso_url,omitempty"`
 	IdpCertificate     *string `json:"idp_certificate,omitempty"`
+	IdpMetadataURL     *string `json:"idp_metadata_url,omitempty"`
 	Active             *bool   `json:"active,omitempty"`
 	SyncUserAttributes *bool   `json:"sync_user_attributes,omitempty"`
 }

--- a/clerk/saml_connections_test.go
+++ b/clerk/saml_connections_test.go
@@ -131,6 +131,7 @@ func TestSAMLConnectionsService_Update(t *testing.T) {
 		Name:               &expectedName,
 		Active:             &expectedActive,
 		SyncUserAttributes: &expectedSyncUserAttributes,
+		IdpMetadataURL:     stringToPtr("https://example.com/saml/metadata"),
 	}
 
 	got, err := c.SAMLConnections().Update(dummySAMLConnectionID, updateParams)
@@ -183,6 +184,7 @@ const (
 	"idp_entity_id": "test-idp-entity-id",
 	"idp_sso_url": "https://example.com/saml/sso",
 	"idp_certificate": "` + dummySAMLConnectionCertificate + `",
+	"idp_metadata_url": "https://example.com/saml/metadata",
 	"acs_url": "` + "https://clerk.example.com/v1/saml/acs/" + dummySAMLConnectionID + `",
 	"sp_entity_id": "` + "https://clerk.example.com/saml/" + dummySAMLConnectionID + `",
 	"sp_metadata_url": "` + "https://clerk.example.com/v1/saml/metadata/" + dummySAMLConnectionID + `",
@@ -201,6 +203,7 @@ const (
 	"idp_entity_id": "test-idp-entity-id",
 	"idp_sso_url": "https://example.com/saml/sso",
 	"idp_certificate": "` + dummySAMLConnectionCertificate + `",
+	"idp_metadata_url": "https://example.com/saml/metadata",
 	"acs_url": "` + "https://clerk.example.com/v1/saml/acs/" + dummySAMLConnectionID + `",
 	"sp_entity_id": "` + "https://clerk.example.com/saml/" + dummySAMLConnectionID + `",
 	"sp_metadata_url": "` + "https://clerk.example.com/v1/saml/metadata/" + dummySAMLConnectionID + `",


### PR DESCRIPTION
Some IdP providers, expose a metadata url which contains all their necessary information in order to configure an integration. We update our SAML Connection Create & Update operations to accept this new url as the 'idp_metadata_url' property