### PR TITLE
Increase timeout

### DIFF
--- a/clerk/clerk.go
+++ b/clerk/clerk.go
@@ -41,7 +41,7 @@ const (
 	JWTTemplatesUrl    = "jwt_templates"
 )
 
-var defaultHTTPClient = &http.Client{Timeout: time.Second * 5}
+var defaultHTTPClient = &http.Client{Timeout: time.Second * 6}
 
 type Client interface {
 	NewRequest(method, url string, body ...interface{}) (*http.Request, error)


### PR DESCRIPTION
Regarding this issue https://github.com/clerk/clerk-sdk-go/issues/216 that I opened.
After much trouble, out of desperation, I increased timeout by 1 more second and it worked?. 

I'm not sure what caused this delay, I would guess 5 seconds is too much for key verification, and I had to increase it by 1. do you think this was my work env's fault?

I'm able to fetch the user data and update records by this update.