### PR TITLE
feat: Support define SAML Connection Attribute mapping

### DIFF
--- a/clerk/saml_connections.go
+++ b/clerk/saml_connections.go
@@ -8,23 +8,31 @@ import (
 type SAMLConnectionsService service
 
 type SAMLConnection struct {
-	ID                 string  `json:"id"`
-	Object             string  `json:"object"`
-	Name               string  `json:"name"`
-	Domain             string  `json:"domain"`
-	IdpEntityID        *string `json:"idp_entity_id"`
-	IdpSsoURL          *string `json:"idp_sso_url"`
-	IdpCertificate     *string `json:"idp_certificate"`
-	IdpMetadataURL     *string `json:"idp_metadata_url"`
-	AcsURL             string  `json:"acs_url"`
-	SPEntityID         string  `json:"sp_entity_id"`
-	SPMetadataURL      string  `json:"sp_metadata_url"`
-	Active             bool    `json:"active"`
-	Provider           string  `json:"provider"`
-	UserCount          int64   `json:"user_count"`
-	SyncUserAttributes bool    `json:"sync_user_attributes"`
-	CreatedAt          int64   `json:"created_at"`
-	UpdatedAt          int64   `json:"updated_at"`
+	ID                 string                         `json:"id"`
+	Object             string                         `json:"object"`
+	Name               string                         `json:"name"`
+	Domain             string                         `json:"domain"`
+	IdpEntityID        *string                        `json:"idp_entity_id"`
+	IdpSsoURL          *string                        `json:"idp_sso_url"`
+	IdpCertificate     *string                        `json:"idp_certificate"`
+	IdpMetadataURL     *string                        `json:"idp_metadata_url"`
+	AcsURL             string                         `json:"acs_url"`
+	SPEntityID         string                         `json:"sp_entity_id"`
+	SPMetadataURL      string                         `json:"sp_metadata_url"`
+	AttributeMapping   SAMLConnectionAttributeMapping `json:"attribute_mapping"`
+	Active             bool                           `json:"active"`
+	Provider           string                         `json:"provider"`
+	UserCount          int64                          `json:"user_count"`
+	SyncUserAttributes bool                           `json:"sync_user_attributes"`
+	CreatedAt          int64                          `json:"created_at"`
+	UpdatedAt          int64                          `json:"updated_at"`
+}
+
+type SAMLConnectionAttributeMapping struct {
+	UserID       string `json:"user_id"`
+	EmailAddress string `json:"email_address"`
+	FirstName    string `json:"first_name"`
+	LastName     string `json:"last_name"`
 }
 
 type ListSAMLConnectionsResponse struct {
@@ -80,13 +88,14 @@ func (s SAMLConnectionsService) Read(id string) (*SAMLConnection, error) {
 }
 
 type CreateSAMLConnectionParams struct {
-	Name           string  `json:"name"`
-	Domain         string  `json:"domain"`
-	Provider       string  `json:"provider"`
-	IdpEntityID    *string `json:"idp_entity_id,omitempty"`
-	IdpSsoURL      *string `json:"idp_sso_url,omitempty"`
-	IdpCertificate *string `json:"idp_certificate,omitempty"`
-	IdpMetadataURL *string `json:"idp_metadata_url,omitempty"`
+	Name             string                          `json:"name"`
+	Domain           string                          `json:"domain"`
+	Provider         string                          `json:"provider"`
+	IdpEntityID      *string                         `json:"idp_entity_id,omitempty"`
+	IdpSsoURL        *string                         `json:"idp_sso_url,omitempty"`
+	IdpCertificate   *string                         `json:"idp_certificate,omitempty"`
+	IdpMetadataURL   *string                         `json:"idp_metadata_url,omitempty"`
+	AttributeMapping *SAMLConnectionAttributeMapping `json:"attribute_mapping,omitempty"`
 }
 
 func (s SAMLConnectionsService) Create(params *CreateSAMLConnectionParams) (*SAMLConnection, error) {
@@ -104,14 +113,15 @@ func (s SAMLConnectionsService) Create(params *CreateSAMLConnectionParams) (*SAM
 }
 
 type UpdateSAMLConnectionParams struct {
-	Name               *string `json:"name,omitempty"`
-	Domain             *string `json:"domain,omitempty"`
-	IdpEntityID        *string `json:"idp_entity_id,omitempty"`
-	IdpSsoURL          *string `json:"idp_sso_url,omitempty"`
-	IdpCertificate     *string `json:"idp_certificate,omitempty"`
-	IdpMetadataURL     *string `json:"idp_metadata_url,omitempty"`
-	Active             *bool   `json:"active,omitempty"`
-	SyncUserAttributes *bool   `json:"sync_user_attributes,omitempty"`
+	Name               *string                         `json:"name,omitempty"`
+	Domain             *string                         `json:"domain,omitempty"`
+	IdpEntityID        *string                         `json:"idp_entity_id,omitempty"`
+	IdpSsoURL          *string                         `json:"idp_sso_url,omitempty"`
+	IdpCertificate     *string                         `json:"idp_certificate,omitempty"`
+	IdpMetadataURL     *string                         `json:"idp_metadata_url,omitempty"`
+	AttributeMapping   *SAMLConnectionAttributeMapping `json:"attribute_mapping,omitempty"`
+	Active             *bool                           `json:"active,omitempty"`
+	SyncUserAttributes *bool                           `json:"sync_user_attributes,omitempty"`
 }
 
 func (s SAMLConnectionsService) Update(id string, params *UpdateSAMLConnectionParams) (*SAMLConnection, error) {

--- a/clerk/saml_connections_test.go
+++ b/clerk/saml_connections_test.go
@@ -132,6 +132,12 @@ func TestSAMLConnectionsService_Update(t *testing.T) {
 		Active:             &expectedActive,
 		SyncUserAttributes: &expectedSyncUserAttributes,
 		IdpMetadataURL:     stringToPtr("https://example.com/saml/metadata"),
+		AttributeMapping: &SAMLConnectionAttributeMapping{
+			UserID:       "custom_user_id",
+			EmailAddress: "custom_email",
+			FirstName:    "custom_first",
+			LastName:     "custom_last",
+		},
 	}
 
 	got, err := c.SAMLConnections().Update(dummySAMLConnectionID, updateParams)
@@ -188,6 +194,12 @@ const (
 	"acs_url": "` + "https://clerk.example.com/v1/saml/acs/" + dummySAMLConnectionID + `",
 	"sp_entity_id": "` + "https://clerk.example.com/saml/" + dummySAMLConnectionID + `",
 	"sp_metadata_url": "` + "https://clerk.example.com/v1/saml/metadata/" + dummySAMLConnectionID + `",
+	"attribute_mapping": {
+		"user_id": "id",
+		"email_address": "mail",
+		"first_name": "firstName",
+		"last_name": "lastName"
+	},
 	"active": false,
 	"provider": "saml_custom",
 	"user_count": 3,
@@ -207,6 +219,12 @@ const (
 	"acs_url": "` + "https://clerk.example.com/v1/saml/acs/" + dummySAMLConnectionID + `",
 	"sp_entity_id": "` + "https://clerk.example.com/saml/" + dummySAMLConnectionID + `",
 	"sp_metadata_url": "` + "https://clerk.example.com/v1/saml/metadata/" + dummySAMLConnectionID + `",
+	"attribute_mapping": {
+		"user_id": "custom_id",
+		"email_address": "custom_email",
+		"first_name": "custom_first",
+		"last_name": "custom_last"
+	},
 	"active": true,
 	"provider": "saml_custom",
 	"user_count": 3,


### PR DESCRIPTION
As part of the SAML Connection Create and Update operations, allow to define the attribute mapping of IdP properties to Clerk's user properties