### PR TITLE
feat: Introduce 'allow_subdomains' SAML Connection property

### DIFF
--- a/clerk/saml_connections.go
+++ b/clerk/saml_connections.go
@@ -24,6 +24,7 @@ type SAMLConnection struct {
 	Provider           string                         `json:"provider"`
 	UserCount          int64                          `json:"user_count"`
 	SyncUserAttributes bool                           `json:"sync_user_attributes"`
+	AllowSubdomains    bool                           `json:"allow_subdomains"`
 	CreatedAt          int64                          `json:"created_at"`
 	UpdatedAt          int64                          `json:"updated_at"`
 }
@@ -122,6 +123,7 @@ type UpdateSAMLConnectionParams struct {
 	AttributeMapping   *SAMLConnectionAttributeMapping `json:"attribute_mapping,omitempty"`
 	Active             *bool                           `json:"active,omitempty"`
 	SyncUserAttributes *bool                           `json:"sync_user_attributes,omitempty"`
+	AllowSubdomains    *bool                           `json:"allow_subdomains,omitempty"`
 }
 
 func (s SAMLConnectionsService) Update(id string, params *UpdateSAMLConnectionParams) (*SAMLConnection, error) {

--- a/clerk/saml_connections_test.go
+++ b/clerk/saml_connections_test.go
@@ -114,6 +114,7 @@ func TestSAMLConnectionsService_Update(t *testing.T) {
 	expectedName := "New name for Testing SAML"
 	expectedActive := true
 	expectedSyncUserAttributes := false
+	expectedAllowSubdomains := true
 	dummyResponse := dummySAMLConnectionUpdatedJSON
 
 	c, mux, _, teardown := setup("token")
@@ -138,6 +139,7 @@ func TestSAMLConnectionsService_Update(t *testing.T) {
 			FirstName:    "custom_first",
 			LastName:     "custom_last",
 		},
+		AllowSubdomains: &expectedAllowSubdomains,
 	}
 
 	got, err := c.SAMLConnections().Update(dummySAMLConnectionID, updateParams)
@@ -203,7 +205,8 @@ const (
 	"active": false,
 	"provider": "saml_custom",
 	"user_count": 3,
-	"sync_user_attributes": true
+	"sync_user_attributes": true,
+	"allow_subdomains": false
 }`
 
 	dummySAMLConnectionUpdatedJSON = `
@@ -228,7 +231,8 @@ const (
 	"active": true,
 	"provider": "saml_custom",
 	"user_count": 3,
-	"sync_user_attributes": false
+	"sync_user_attributes": false,
+	"allow_subdomains": true
 }`
 
 	dummySAMLConnectionCertificate = `MIIDBzCCAe+gAwIBAgIJAPr/Mrlc8EGhMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTAeFw0xNTEyMjgxOTE5NDVaFw0yNTEyMjUxOTE5NDVaMBoxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANDoWzLos4LWxTn8Gyu2lEbl4WcelUbgLN5zYm4ron8Ahs+rvcsu2zkdD/s6jdGJI8WqJKhYK2u61ygnXgAZqC6ggtFPnBpizcDzjgND2g+aucSoUODHt67f0fQuAmupN/zp5MZysJ6IHLJnYLNpfJYk96lRz9ODnO1Mpqtr9PWxm+pz7nzq5F0vRepkgpcRxv6ufQBjlrFytccyEVdXrvFtkjXcnhVVNSR4kHuOOMS6D7pebSJ1mrCmshbD5SX1jXPBKFPAjozYX6PxqLxUx1Y4faFEf4MBBVcInyB4oURNB2s59hEEi2jq9izNE7EbEK6BY5sEhoCPl9m32zE6ljkCAwEAAaNQME4wHQYDVR0OBBYEFB9ZklC1Ork2zl56zg08ei7ss/+iMB8GA1UdIwQYMBaAFB9ZklC1Ork2zl56zg08ei7ss/+iMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAAVoTSQ5pAirw8OR9FZ1bRSuTDhY9uxzl/OL7lUmsv2cMNeCB3BRZqm3mFt+cwN8GsH6f3uvNONIhgFpTGN5LEcXQz89zJEzB+qaHqmbFpHQl/sx2B8ezNgT/882H2IH00dXESEfy/+1gHg2pxjGnhRBN6el/gSaDiySIMKbilDrffuvxiCfbpPN0NRRiPJhd2ay9KuL/RxQRl1gl9cHaWiouWWba1bSBb2ZPhv2rPMUsFo98ntkGCObDX6Y1SpkqmoTbrsbGFsTG2DLxnvr4GdN1BSr0Uu/KV3adj47WkXVPeMYQti/bQmxQB8tRFhrw80qakTLUzreO96WzlBBMtY=`


### PR DESCRIPTION
We now expose a new property 'allow_subdomains' as part of the SAML Connection response. You can also define it during Create and Update operations. Default value is false