### PR TITLE
feat: Handler to check azp claim

### DIFF
--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -62,3 +62,36 @@ func TestRequireHeaderAuthorization_InvalidAuthorization(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusForbidden, res.StatusCode)
 }
+
+func TestAuthorizedPartyFunc(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		azp     string
+		parties []string
+		want    bool
+	}{
+		{
+			azp:     "clerk.com",
+			parties: []string{"clerk.com", "clerk.dev"},
+			want:    true,
+		},
+		{
+			azp:     "clerk.com",
+			parties: []string{"clerk.dev"},
+			want:    false,
+		},
+		{
+			azp:     "",
+			parties: []string{"clerk.com"},
+			want:    true,
+		},
+		{
+			azp:     "clerk.com",
+			parties: []string{},
+			want:    true,
+		},
+	} {
+		fn := AuthorizedPartyMatches(tc.parties...)
+		require.Equal(t, tc.want, fn(tc.azp))
+	}
+}


### PR DESCRIPTION
The JWT verification function accepts a handler that can be used to validate the 'azp' claim of the token.

The WithHeaderAuthorization middleware accepts either a handler or a list of authorized parties that must contain the 'azp' claim.

You can use the option in two ways.

```go
func checkAZP(azp string) bool {
  // do whatever you want with the azp claim
}

WithHeaderAuthorization(AuthorizedParty(checkAZP))
// OR
// This will check that the 'azp' claim is one of the provided values
WithHeaderAuthorization(AuthorizedPartyFunc("clerk.com", "clerk.dev"))
```