### PR TITLE
fix: Change User-Agent header

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -251,7 +251,7 @@ func (b *defaultBackend) newRequest(ctx context.Context, apiReq *APIRequest) (*h
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", b.Key))
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("User-Agent", fmt.Sprintf("Clerk/%s SDK-Go/%s", clerkAPIVersion, sdkVersion))
+	req.Header.Add("User-Agent", fmt.Sprintf("clerk/clerk-sdk-go@%s", sdkVersion))
 	req.Header.Add("X-Clerk-SDK", fmt.Sprintf("go/%s", sdkVersion))
 	req = req.WithContext(ctx)
 

--- a/clerk_test.go
+++ b/clerk_test.go
@@ -182,10 +182,10 @@ func TestBackendCall_RequestHeaders(t *testing.T) {
 		// The client sets the Authorization header correctly.
 		assert.Equal(t, fmt.Sprintf("Bearer %s", secretKey), r.Header.Get("Authorization"))
 		// The client sets the User-Agent header.
-		assert.Equal(t, "Clerk/v1 SDK-Go/v2.0.0", r.Header.Get("User-Agent"))
+		assert.Equal(t, fmt.Sprintf("clerk/clerk-sdk-go@%s", sdkVersion), r.Header.Get("User-Agent"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 		// The client includes a custom header with the SDK version.
-		assert.Equal(t, "go/v2.0.0", r.Header.Get("X-Clerk-SDK"))
+		assert.Equal(t, fmt.Sprintf("go/%s", sdkVersion), r.Header.Get("X-Clerk-SDK"))
 
 		_, err := w.Write([]byte(`{}`))
 		require.NoError(t, err)


### PR DESCRIPTION
Changed the User-Agent header to match the rest of our SDKs. The pattern is package@version.