### PR TITLE
feat: JWT parsing with custom claims

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -188,11 +188,30 @@ func AuthorizedPartyMatches(parties ...string) func(string) bool {
 	}
 }
 
-// CustomClaims allows to pass a type (e.g. struct), which will be populated with the token claims based on json tags.
-// You must pass a pointer for this option to work.
-func CustomClaims(claims any) AuthorizationOption {
+// CustomClaimsConstructor allows to pass a constructor function
+// which returns a pointer to a type (struct) to hold custom token
+// claims.
+// The instance of the custom claims type will be then made available
+// through the clerk.SessionClaims struct.
+//
+//	// Define a type to describe the custom claims.
+//	type MyCustomClaims struct {
+//		ACustomClaim string `json:"a_custom_claim"`
+//	}
+//
+//	// In your HTTP server mux, configure the middleware with
+//	// the custom claims constructor.
+//	WithHeaderAuthorization(CustomClaimsConstructor(func(_ context.Context) any {
+//		return &MyCustomClaims{}
+//	})
+//
+//	// In the HTTP handler, access the active session claims. The
+//	// custom claims are available in the SessionClaims.Custom field.
+//	sessionClaims, ok := clerk.SessionClaimsFromContext(r.Context())
+//	customClaims, ok := sessionClaims.Custom.(*MyCustomClaims)
+func CustomClaimsConstructor(constructor func(context.Context) any) AuthorizationOption {
 	return func(params *AuthorizationParams) error {
-		params.CustomClaims = claims
+		params.CustomClaimsConstructor = constructor
 		return nil
 	}
 }

--- a/jwt.go
+++ b/jwt.go
@@ -34,6 +34,8 @@ type SessionClaims struct {
 	ActiveOrganizationRole        string          `json:"org_role"`
 	ActiveOrganizationPermissions []string        `json:"org_permissions"`
 	Actor                         json.RawMessage `json:"act,omitempty"`
+	// Custom can hold any custom claims that might be found in a JWT.
+	Custom any `json:"-"`
 }
 
 // HasPermission checks if the session claims contain the provided


### PR DESCRIPTION
Replaced the CustomClaims parameter with a CustomClaimsConstructor function when verifying a session JWT. The option is also available in the HTTP middleware.

The constructor function will be called when the JWT is parsed, producing a new struct instance instead of writing on a single instance. 

The custom claims will be made available in the SessionClaims.Custom field.