### PR TITLE
fix: Don't expose jose types

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,33 +139,35 @@ import (
     "github.com/clerk/clerk-sdk-go/v2/user"
 )
 
-// Each operation requires a context.Context as the first argument.
-ctx := context.Background()
+func main() {
+    // Each operation requires a context.Context as the first argument.
+    ctx := context.Background()
 
-// Set the API key
-clerk.SetKey("sk_live_XXX")
+    // Set the API key
+    clerk.SetKey("sk_live_XXX")
 
-// Create an organization
-org, err := organization.Create(ctx, &organization.CreateParams{
-    Name: clerk.String("Clerk Inc"),
-})
+    // Create an organization
+    org, err := organization.Create(ctx, &organization.CreateParams{
+        Name: clerk.String("Clerk Inc"),
+    })
 
-// Update the organization
-org, err = organization.Update(ctx, org.ID, &organization.UpdateParams{
-    Slug: clerk.String("clerk"),
-})
+    // Update the organization
+    org, err = organization.Update(ctx, org.ID, &organization.UpdateParams{
+        Slug: clerk.String("clerk"),
+    })
 
-// List organization memberships
-listParams := organizationmembership.ListParams{}
-listParams.Limit = clerk.Int64(10)
-memberships, err := organizationmembership.List(ctx, params)
-if memberships.TotalCount < 0 {
-    return
+    // List organization memberships
+    listParams := organizationmembership.ListParams{}
+    listParams.Limit = clerk.Int64(10)
+    memberships, err := organizationmembership.List(ctx, params)
+    if memberships.TotalCount < 0 {
+        return
+    }
+    membership := memberships[0]
+
+    // Get a user
+    usr, err := user.Get(ctx, membership.UserID)
 }
-membership := memberships[0]
-
-// Get a user
-usr, err := user.Get(ctx, membership.UserID)
 ```
 
 ### Accessing API responses

--- a/jwk.go
+++ b/jwk.go
@@ -10,16 +10,16 @@ import (
 
 type JSONWebKeySet struct {
 	APIResource
-	Keys []JSONWebKey `json:"keys"`
+	Keys []*JSONWebKey `json:"keys"`
 }
 
 type JSONWebKey struct {
 	APIResource
-	raw       jose.JSONWebKey
 	Key       any    `json:"key"`
 	KeyID     string `json:"kid"`
 	Algorithm string `json:"alg"`
 	Use       string `json:"use"`
+	raw       jose.JSONWebKey
 }
 
 func (k *JSONWebKey) UnmarshalJSON(data []byte) error {

--- a/jwt.go
+++ b/jwt.go
@@ -3,6 +3,7 @@ package clerk
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
 )
@@ -26,16 +27,22 @@ func SessionClaimsFromContext(ctx context.Context) (*SessionClaims, bool) {
 
 // SessionClaims represents Clerk specific JWT claims.
 type SessionClaims struct {
-	jwt.Claims
-	SessionID                     string          `json:"sid"`
-	AuthorizedParty               string          `json:"azp"`
-	ActiveOrganizationID          string          `json:"org_id"`
-	ActiveOrganizationSlug        string          `json:"org_slug"`
-	ActiveOrganizationRole        string          `json:"org_role"`
-	ActiveOrganizationPermissions []string        `json:"org_permissions"`
-	Actor                         json.RawMessage `json:"act,omitempty"`
+	// Standard IANA JWT claims
+	RegisteredClaims
+	// Clerk specific JWT claims
+	Claims
+
 	// Custom can hold any custom claims that might be found in a JWT.
 	Custom any `json:"-"`
+}
+
+func (s *SessionClaims) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &s.RegisteredClaims)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(data, &s.Claims)
+	return err
 }
 
 // HasPermission checks if the session claims contain the provided
@@ -62,10 +69,70 @@ func (s *SessionClaims) HasRole(role string) bool {
 	return s.ActiveOrganizationRole == role
 }
 
-// Claims holds generic JWT claims.
+// RegisteredClaims holds public claim values (as specified in RFC 7519).
+type RegisteredClaims struct {
+	Issuer    string   `json:"iss,omitempty"`
+	Subject   string   `json:"sub,omitempty"`
+	Audience  []string `json:"aud,omitempty"`
+	Expiry    *int64   `json:"exp,omitempty"`
+	NotBefore *int64   `json:"nbf,omitempty"`
+	IssuedAt  *int64   `json:"iat,omitempty"`
+	ID        string   `json:"jti,omitempty"`
+	raw       jwt.Claims
+}
+
+func (c *RegisteredClaims) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &c.raw)
+	if err != nil {
+		return err
+	}
+	c.Issuer = c.raw.Issuer
+	c.Subject = c.raw.Subject
+	c.Audience = c.raw.Audience
+	c.ID = c.raw.ID
+	if c.raw.Expiry != nil {
+		c.Expiry = Int64(c.raw.Expiry.Time().Unix())
+	}
+	if c.raw.NotBefore != nil {
+		c.NotBefore = Int64(c.raw.NotBefore.Time().Unix())
+	}
+	if c.raw.IssuedAt != nil {
+		c.IssuedAt = Int64(c.raw.IssuedAt.Time().Unix())
+	}
+	return nil
+}
+
+// ValidateWithLeeway checks expiration and issuance claims against
+// an expected time.
+// You may pass a zero value to check the time values with no leeway,
+// but it is not recommended.
+// The leeway gives some extra time to the token from the server's
+// point of view. That is, if the token is expired, ValidateWithLeeway
+// will still accept the token for 'leeway' amount of time.
+func (c *RegisteredClaims) ValidateWithLeeway(expected time.Time, leeway time.Duration) error {
+	return c.raw.ValidateWithLeeway(jwt.Expected{Time: expected}, leeway)
+}
+
+// Claims represents private JWT claims that are defined and used
+// by Clerk.
 type Claims struct {
-	jwt.Claims
+	SessionID                     string          `json:"sid"`
+	AuthorizedParty               string          `json:"azp"`
+	ActiveOrganizationID          string          `json:"org_id"`
+	ActiveOrganizationSlug        string          `json:"org_slug"`
+	ActiveOrganizationRole        string          `json:"org_role"`
+	ActiveOrganizationPermissions []string        `json:"org_permissions"`
+	Actor                         json.RawMessage `json:"act,omitempty"`
+}
+
+// UnverifiedToken holds the result of a JWT decoding without any
+// verification.
+// The UnverifiedToken includes registered and custom claims, as
+// well as the KeyID (kid) header.
+type UnverifiedToken struct {
+	RegisteredClaims
 	// Any headers not recognized get unmarshalled
 	// from JSON in a generic manner and placed in this map.
 	Extra map[string]any
+	KeyID string
 }

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/clerk/clerk-sdk-go/v2"
 	"github.com/clerk/clerk-sdk-go/v2/clerktest"
@@ -131,6 +132,96 @@ func TestVerify_InvalidParams(t *testing.T) {
 	require.Contains(t, err.Error(), "authorized party")
 }
 
+func TestVerify_PublicClaims(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kid := "kid"
+
+	exp := time.Now().Add(10 * time.Hour).Unix()
+	nbf := time.Now().Add(-10 * time.Hour).Unix()
+	// Generate a JWT for the following custom claims.
+	tokenClaims := map[string]any{
+		"orgs": map[string]string{
+			"org_123": "org:admin",
+			"org_456": "org:member",
+		},
+		"org_id":          "org_123",
+		"org_role":        "org:admin",
+		"org_permissions": []string{"org:create"},
+		"org_slug":        "acmeinc",
+		"sid":             "sess_123",
+		"sub":             "user_123",
+		"iss":             "https://clerk.com",
+		"nbf":             nbf,
+		"exp":             exp,
+	}
+	token, pubKey := clerktest.GenerateJWT(t, tokenClaims, kid)
+	claims, err := Verify(ctx, &VerifyParams{
+		Token: token,
+		JWK: &clerk.JSONWebKey{
+			Key:       pubKey,
+			KeyID:     kid,
+			Algorithm: string(jose.RS256),
+			Use:       "sig",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "sess_123", claims.SessionID)
+	require.Equal(t, "user_123", claims.Subject)
+	require.Equal(t, "org_123", claims.ActiveOrganizationID)
+	require.Equal(t, "acmeinc", claims.ActiveOrganizationSlug)
+	require.Equal(t, "org:admin", claims.ActiveOrganizationRole)
+	require.Equal(t, 1, len(claims.ActiveOrganizationPermissions))
+	require.Equal(t, "org:create", claims.ActiveOrganizationPermissions[0])
+	require.NotNil(t, claims.NotBefore)
+}
+
+// TestVerify_TimeValues tests that Verify validates that the token's
+// not before (nbf) and expiry (exp) claims are respected.
+func TestVerify_TimeValues(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kid := "kid"
+
+	// Generate a JWT that's expired.
+	exp := time.Now().Add(-1 * time.Minute).Unix()
+	tokenClaims := map[string]any{
+		"iss": "https://clerk.com",
+		"exp": exp,
+	}
+	token, pubKey := clerktest.GenerateJWT(t, tokenClaims, kid)
+	_, err := Verify(ctx, &VerifyParams{
+		Token: token,
+		JWK: &clerk.JSONWebKey{
+			Key:       pubKey,
+			KeyID:     kid,
+			Algorithm: string(jose.RS256),
+			Use:       "sig",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exp")
+
+	// Generate a JWT that should be used after a date in the future.
+	nbf := time.Now().Add(10 * time.Hour).Unix()
+	tokenClaims = map[string]any{
+		"iss": "https://clerk.com",
+		"nbf": nbf,
+	}
+	token, pubKey = clerktest.GenerateJWT(t, tokenClaims, kid)
+	_, err = Verify(ctx, &VerifyParams{
+		Token: token,
+		JWK: &clerk.JSONWebKey{
+			Key:       pubKey,
+			KeyID:     kid,
+			Algorithm: string(jose.RS256),
+			Use:       "sig",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nbf")
+}
+
 type testCustomClaims struct {
 	Domain      string `json:"domain"`
 	Environment string `json:"environment"`
@@ -168,4 +259,52 @@ func TestVerify_CustomClaims(t *testing.T) {
 	require.Equal(t, "user_123", claims.Subject)
 	require.Equal(t, "clerk.com", customClaims.Domain)
 	require.Equal(t, "production", customClaims.Environment)
+}
+
+func TestDecode_KeyID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kid := "kid"
+
+	// Generate a JWT for the following custom claims.
+	tokenClaims := map[string]any{
+		"org_slug": "acmeinc",
+		"sid":      "sess_123",
+		"sub":      "user_123",
+		"iss":      "https://clerk.com",
+	}
+	token, _ := clerktest.GenerateJWT(t, tokenClaims, kid)
+	claims, err := Decode(ctx, &DecodeParams{
+		Token: token,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "sess_123", claims.Extra["sid"])
+	require.Equal(t, "acmeinc", claims.Extra["org_slug"])
+	require.Equal(t, "user_123", claims.Subject)
+	require.Equal(t, "https://clerk.com", claims.Issuer)
+	require.Equal(t, kid, claims.KeyID)
+}
+
+// TestDecode_IsUnsafe tests that Decode does not do any validations
+// on the token, like checking if it's expired.
+func TestDecode_IsUnsafe(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kid := "kid"
+
+	// Generate a JWT that's expired and should be used in the future.
+	// What matters is that time values are invalid.
+	exp := time.Now().Add(-1 * time.Minute).Unix()
+	nbf := time.Now().Add(20 * time.Minute).Unix()
+	tokenClaims := map[string]any{
+		"iss": "https://clerk.com",
+		"exp": exp,
+		"nbf": nbf,
+	}
+	token, _ := clerktest.GenerateJWT(t, tokenClaims, kid)
+	claims, err := Decode(ctx, &DecodeParams{
+		Token: token,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://clerk.com", claims.Issuer)
 }

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -24,9 +24,8 @@ func TestSessionClaimsHasRole(t *testing.T) {
 			want:   true,
 		},
 	} {
-		claims := SessionClaims{
-			ActiveOrganizationRole: tc.active,
-		}
+		claims := SessionClaims{}
+		claims.ActiveOrganizationRole = tc.active
 		require.Equal(t, claims.HasRole(tc.role), tc.want)
 	}
 }
@@ -54,9 +53,8 @@ func TestSessionClaimsHasPermission(t *testing.T) {
 			want:       false,
 		},
 	} {
-		claims := SessionClaims{
-			ActiveOrganizationPermissions: tc.active,
-		}
+		claims := SessionClaims{}
+		claims.ActiveOrganizationPermissions = tc.active
 		require.Equal(t, claims.HasPermission(tc.permission), tc.want)
 	}
 }


### PR DESCRIPTION
Made sure that no go-jose types are exported from our package. 

Had to add more exported types for JWT claims, so that we can re-use go-jose's unmarshaling features.

We now have the following types for JWT claims:
- **RegisteredClaims** These are 'standard' public JWT claims registered in IANA.
- **Claims** These are Clerk-specific private claims, like session ID and active organization ID.
- **SessionClaims** These are the claims that are included in Clerk issued JWTs. They include RegisteredClaims, Claims and any other Custom keys from custom JWT templates. 

Another change introduced here is that the jwt.Decode function will now expose the Key ID header, if the JWT contains it. 

We need access to the kid header when implementing a custom JWT verification flow and jwt.Decode already does most of the work to parse a token. It makes sense for the function to return the Key ID as well.

Here's a sample flow that illustrates why the Key ID is needed.
```go
func someHandler(w http.ResponseWriter, r *http.Request) {
  token := getTokenFromAuthorizationHeader(r)
  decoded, err := jwt.Decode(r.Context(), &jwt.DecodeParams{
    Token: token,
  })
  if err != nil {
    w.WriteHeader(http.StatusUnauthorized)
    return
  }
  jwks, err := jwks.Get(r.Context(), &jwks.GetParams{})
  if err != nil {
    w.WriteHeader(http.StatusUnauthorized)
    return
  }
  var jwk clerk.JSONWebKey
  for _, k := range jwks.Keys {
    if k.KeyID == kid {
      jwk = &k
      break
    }
  }
  if jwk == nil {
    w.WriteHeader(http.StatusUnauthorized)
    return
  }
  claims, err := jwt.Verify(r.Context(), &jwt.VerifyParams{
    Token: token,
     JWK: jwk,
  })
  if err != nil {
    w.WriteHeader(http.StatusUnauthorized)
    return
  }
  w.Write([]byte(claims.SessionID))
}
```