### PR TITLE
fix: http.AuthorizedPartyMatches sets middleware params

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -156,18 +156,21 @@ func AuthorizedParty(handler func(string) bool) AuthorizationOption {
 
 // AuthorizedPartyMatches registers a handler that checks that the
 // 'azp' claim's value is included in the provided parties.
-func AuthorizedPartyMatches(parties ...string) func(string) bool {
+func AuthorizedPartyMatches(parties ...string) AuthorizationOption {
 	authorizedParties := make(map[string]struct{})
 	for _, p := range parties {
 		authorizedParties[p] = struct{}{}
 	}
 
-	return func(azp string) bool {
-		if azp == "" || len(authorizedParties) == 0 {
-			return true
+	return func(params *AuthorizationParams) error {
+		params.AuthorizedPartyHandler = func(azp string) bool {
+			if azp == "" || len(authorizedParties) == 0 {
+				return true
+			}
+			_, ok := authorizedParties[azp]
+			return ok
 		}
-		_, ok := authorizedParties[azp]
-		return ok
+		return nil
 	}
 }
 

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -91,7 +91,9 @@ func TestAuthorizedPartyFunc(t *testing.T) {
 			want:    true,
 		},
 	} {
-		fn := AuthorizedPartyMatches(tc.parties...)
-		require.Equal(t, tc.want, fn(tc.azp))
+		options := &AuthorizationParams{}
+		err := AuthorizedPartyMatches(tc.parties...)(options)
+		require.NoError(t, err)
+		require.Equal(t, tc.want, options.AuthorizedPartyHandler(tc.azp))
 	}
 }


### PR DESCRIPTION
Instead of returning a AuthorizedPartyHandler, the AuthorizedPartyMatches function will now set the AuthorizedPartyHandler parameter directly.

The different return type of AuthorizedParty and AuthorizedPartyMatches caused confusion.