### PR TITLE
fix: JWKS API uses client

### DIFF
--- a/jwks/client.go
+++ b/jwks/client.go
@@ -36,6 +36,6 @@ func (c *Client) Get(ctx context.Context, params *GetParams) (*clerk.JSONWebKeyS
 	req := clerk.NewAPIRequest(http.MethodGet, path)
 	req.SetParams(params)
 	resource := &clerk.JSONWebKeySet{}
-	err := clerk.GetBackend().Call(ctx, req, resource)
+	err := c.Backend.Call(ctx, req, resource)
 	return resource, err
 }


### PR DESCRIPTION
Fixed a bug where the jwks.Client.Get method would use the default Backend instead of the one attached to the client.