### PR TITLE
feat: Same type for API client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ import (
 ctx := context.Background()
 
 // Initialize a client with an API key
-config := &$resource$.ClientConfig{}
+config := &clerk.ClientConfig{}
 config.Key = "sk_live_XXX"
 client := $resource$.NewClient(config)
 

--- a/actortoken/client.go
+++ b/actortoken/client.go
@@ -18,11 +18,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/allowlistidentifier/client.go
+++ b/allowlistidentifier/client.go
@@ -18,11 +18,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/blocklistidentifier/client.go
+++ b/blocklistidentifier/client.go
@@ -18,11 +18,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/blocklistidentifier/client_test.go
+++ b/blocklistidentifier/client_test.go
@@ -16,7 +16,7 @@ func TestBlocklistIdentifierClientCreate(t *testing.T) {
 	t.Parallel()
 	identifier := "foo@bar.com"
 	id := "blid_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -37,7 +37,7 @@ func TestBlocklistIdentifierClientCreate(t *testing.T) {
 
 func TestBlocklistIdentifierClientCreate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -63,7 +63,7 @@ func TestBlocklistIdentifierClientCreate_Error(t *testing.T) {
 func TestBlocklistIdentifierClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "blid_456"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -81,7 +81,7 @@ func TestBlocklistIdentifierClientDelete(t *testing.T) {
 
 func TestBlocklistIdentifierClientList(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,

--- a/clerk.go
+++ b/clerk.go
@@ -442,6 +442,12 @@ func (params ListParams) ToQuery() url.Values {
 	return q
 }
 
+// ClientConfig is used to configure a new Client that can invoke
+// API operations.
+type ClientConfig struct {
+	BackendConfig
+}
+
 // Regular expression that matches multiple backslashes in a row.
 var extraBackslashesRE = regexp.MustCompile("([^:])//+")
 

--- a/client/client.go
+++ b/client/client.go
@@ -19,11 +19,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,7 +16,7 @@ import (
 func TestClientClientGet(t *testing.T) {
 	t.Parallel()
 	id := "client_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -35,7 +35,7 @@ func TestClientClientVerify(t *testing.T) {
 	t.Parallel()
 	id := "client_123"
 	token := "the-token"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -55,7 +55,7 @@ func TestClientClientVerify(t *testing.T) {
 
 func TestClientClientList(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,

--- a/domain/client.go
+++ b/domain/client.go
@@ -17,11 +17,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/emailaddress/client.go
+++ b/emailaddress/client.go
@@ -17,11 +17,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/emailaddress/client_test.go
+++ b/emailaddress/client_test.go
@@ -17,7 +17,7 @@ func TestEmailAddressClientCreate(t *testing.T) {
 	email := "foo@bar.com"
 	userID := "user_123"
 	id := "idn_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -40,7 +40,7 @@ func TestEmailAddressClientCreate(t *testing.T) {
 
 func TestEmailAddressClientCreate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -66,7 +66,7 @@ func TestEmailAddressClientCreate_Error(t *testing.T) {
 func TestEmailAddressClientUpdate(t *testing.T) {
 	t.Parallel()
 	id := "idn_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -87,7 +87,7 @@ func TestEmailAddressClientUpdate(t *testing.T) {
 
 func TestEmailAddressClientUpdate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -113,7 +113,7 @@ func TestEmailAddressClientUpdate_Error(t *testing.T) {
 func TestEmailAddressClientGet(t *testing.T) {
 	t.Parallel()
 	id := "idn_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -132,7 +132,7 @@ func TestEmailAddressClientGet(t *testing.T) {
 func TestEmailAddressClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "idn_456"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/instancesettings/client.go
+++ b/instancesettings/client.go
@@ -17,11 +17,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/instancesettings/client_test.go
+++ b/instancesettings/client_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestInstanceClientUpdate(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -32,7 +32,7 @@ func TestInstanceClientUpdate(t *testing.T) {
 
 func TestInstanceClientUpdate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -57,7 +57,7 @@ func TestInstanceClientUpdate_Error(t *testing.T) {
 
 func TestInstanceClientUpdateRestrictions(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -78,7 +78,7 @@ func TestInstanceClientUpdateRestrictions(t *testing.T) {
 
 func TestInstanceClientUpdateRestrictions_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -103,7 +103,7 @@ func TestInstanceClientUpdateRestrictions_Error(t *testing.T) {
 
 func TestInstanceClientUpdateOrganizationSettings(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -124,7 +124,7 @@ func TestInstanceClientUpdateOrganizationSettings(t *testing.T) {
 
 func TestInstanceClientUpdateOrganizationSettings_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/jwks/client.go
+++ b/jwks/client.go
@@ -17,11 +17,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/jwttemplate/client.go
+++ b/jwttemplate/client.go
@@ -19,11 +19,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/jwttemplate/client_test.go
+++ b/jwttemplate/client_test.go
@@ -17,7 +17,7 @@ func TestJWTTemplateClientCreate(t *testing.T) {
 	t.Parallel()
 	name := "the-name"
 	id := "jtmpl_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -38,7 +38,7 @@ func TestJWTTemplateClientCreate(t *testing.T) {
 
 func TestJWTTemplateClientCreate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -65,7 +65,7 @@ func TestJWTTemplateClientGet(t *testing.T) {
 	t.Parallel()
 	id := "jtmpl_123"
 	name := "the-name"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -85,7 +85,7 @@ func TestJWTTemplateClientUpdate(t *testing.T) {
 	t.Parallel()
 	id := "jtmpl_123"
 	name := "the-name"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -106,7 +106,7 @@ func TestJWTTemplateClientUpdate(t *testing.T) {
 
 func TestJWTTemplateClientUpdate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -132,7 +132,7 @@ func TestJWTTemplateClientUpdate_Error(t *testing.T) {
 func TestJWTTemplateClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "jtmpl_456"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -150,7 +150,7 @@ func TestJWTTemplateClientDelete(t *testing.T) {
 
 func TestJWTTemplateClientList(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,

--- a/organization/client.go
+++ b/organization/client.go
@@ -23,11 +23,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -18,7 +18,7 @@ func TestOrganizationClientCreate(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
 	name := "Acme Inc"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -39,7 +39,7 @@ func TestOrganizationClientCreate(t *testing.T) {
 
 func TestOrganizationClientCreate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -66,7 +66,7 @@ func TestOrganizationClientGet(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
 	name := "Acme Inc"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -86,7 +86,7 @@ func TestOrganizationClientUpdate(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
 	name := "Acme Inc"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -107,7 +107,7 @@ func TestOrganizationClientUpdate(t *testing.T) {
 
 func TestOrganizationClientUpdate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -133,7 +133,7 @@ func TestOrganizationClientUpdate_Error(t *testing.T) {
 func TestOrganizationClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -151,7 +151,7 @@ func TestOrganizationClientDelete(t *testing.T) {
 
 func TestOrganizationClientList(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,
@@ -198,7 +198,7 @@ func TestOrganizationClientUpdateLogo(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
 	userID := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -219,7 +219,7 @@ func TestOrganizationClientUpdateLogo(t *testing.T) {
 func TestOrganizationClientDeleteLogo(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -238,7 +238,7 @@ func TestOrganizationClientUpdateMetadata(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
 	metadata := `{"foo":"bar"}`
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/organizationinvitation/client.go
+++ b/organizationinvitation/client.go
@@ -18,11 +18,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/organizationinvitation/client_test.go
+++ b/organizationinvitation/client_test.go
@@ -17,7 +17,7 @@ func TestOrganizationInvitationClientCreate(t *testing.T) {
 	id := "orginv_123"
 	organizationID := "org_123"
 	emailAddress := "foo@bar.com"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -40,7 +40,7 @@ func TestOrganizationInvitationClientCreate(t *testing.T) {
 
 func TestOrganizationInvitationClientCreate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/organizationmembership/client.go
+++ b/organizationmembership/client.go
@@ -18,11 +18,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/organizationmembership/client_test.go
+++ b/organizationmembership/client_test.go
@@ -19,7 +19,7 @@ func TestOrganizationMembershipClientCreate(t *testing.T) {
 	organizationID := "org_123"
 	userID := "user_123"
 	role := "admin"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:  t,
@@ -50,7 +50,7 @@ func TestOrganizationMembershipClientCreate(t *testing.T) {
 
 func TestOrganizationMembershipClientCreate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -79,7 +79,7 @@ func TestOrganizationMembershipClientUpdate(t *testing.T) {
 	organizationID := "org_123"
 	userID := "user_123"
 	role := "admin"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:  t,
@@ -110,7 +110,7 @@ func TestOrganizationMembershipClientUpdate(t *testing.T) {
 
 func TestOrganizationMembershipClientUpdate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -138,7 +138,7 @@ func TestOrganizationMembershipClientDelete(t *testing.T) {
 	id := "orgmem_123"
 	organizationID := "org_123"
 	userID := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,
@@ -168,7 +168,7 @@ func TestOrganizationMembershipClientList(t *testing.T) {
 	id := "orgmem_123"
 	organizationID := "org_123"
 	userID := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,

--- a/phonenumber/client.go
+++ b/phonenumber/client.go
@@ -17,11 +17,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/phonenumber/client_test.go
+++ b/phonenumber/client_test.go
@@ -17,7 +17,7 @@ func TestPhoneNumberClientCreate(t *testing.T) {
 	phone := "+10123456789"
 	userID := "user_123"
 	id := "idn_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -41,7 +41,7 @@ func TestPhoneNumberClientCreate(t *testing.T) {
 func TestPhoneNumberClientUpdate(t *testing.T) {
 	t.Parallel()
 	id := "idn_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -63,7 +63,7 @@ func TestPhoneNumberClientUpdate(t *testing.T) {
 func TestPhoneNumberClientGet(t *testing.T) {
 	t.Parallel()
 	id := "idn_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -82,7 +82,7 @@ func TestPhoneNumberClientGet(t *testing.T) {
 func TestPhoneNumberClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "idn_456"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/proxycheck/client.go
+++ b/proxycheck/client.go
@@ -20,11 +20,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/proxycheck/client_test.go
+++ b/proxycheck/client_test.go
@@ -17,7 +17,7 @@ func TestProxyCheckClientCreate(t *testing.T) {
 	id := "proxchk_123"
 	proxyURL := "https://clerk.com/__proxy"
 	domainID := "dmn_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/redirecturl/client.go
+++ b/redirecturl/client.go
@@ -18,11 +18,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/redirecturl/client_test.go
+++ b/redirecturl/client_test.go
@@ -16,7 +16,7 @@ func TestRedirectURLClientCreate(t *testing.T) {
 	t.Parallel()
 	id := "ru_123"
 	url := "https://example.com"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -37,7 +37,7 @@ func TestRedirectURLClientCreate(t *testing.T) {
 
 func TestRedirectURLClientCreate_Error(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -64,7 +64,7 @@ func TestRedirectURLClientGet(t *testing.T) {
 	t.Parallel()
 	id := "ru_123"
 	url := "https://example.com"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -83,7 +83,7 @@ func TestRedirectURLClientGet(t *testing.T) {
 func TestRedirectURLClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "ru_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -101,7 +101,7 @@ func TestRedirectURLClientDelete(t *testing.T) {
 
 func TestRedirectURLClientList(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,

--- a/session/client.go
+++ b/session/client.go
@@ -19,11 +19,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/session/client_test.go
+++ b/session/client_test.go
@@ -17,7 +17,7 @@ func TestSessionClientGet(t *testing.T) {
 	t.Parallel()
 	id := "sess_123"
 	status := "active"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -35,7 +35,7 @@ func TestSessionClientGet(t *testing.T) {
 
 func TestSessionClientList(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,
@@ -71,7 +71,7 @@ func TestSessionClientRevoke(t *testing.T) {
 	t.Parallel()
 	id := "sess_123"
 	status := "revoked"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -92,7 +92,7 @@ func TestSessionClientRevoke(t *testing.T) {
 func TestSessionClientVerify(t *testing.T) {
 	t.Parallel()
 	id := "sess_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/svixwebhook/client.go
+++ b/svixwebhook/client.go
@@ -17,11 +17,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/svixwebhook/client_test.go
+++ b/svixwebhook/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/clerk/clerk-sdk-go/v2"
 	"github.com/clerk/clerk-sdk-go/v2/clerktest"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +15,7 @@ import (
 func TestSvixWebhookClientCreate(t *testing.T) {
 	t.Parallel()
 	svixURL := "https://foo.com/webhook"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -31,7 +32,7 @@ func TestSvixWebhookClientCreate(t *testing.T) {
 
 func TestSvixWebhookClientDelete(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -47,7 +48,7 @@ func TestSvixWebhookClientDelete(t *testing.T) {
 func TestSvixWebhookClientRefreshURL(t *testing.T) {
 	t.Parallel()
 	svixURL := "https://foo.com/webhook"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/template/client.go
+++ b/template/client.go
@@ -18,11 +18,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/template/client_test.go
+++ b/template/client_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestTemplateClientList(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,
@@ -45,7 +45,7 @@ func TestTemplateClientGet(t *testing.T) {
 	t.Parallel()
 	templateType := clerk.TemplateTypeSMS
 	slug := "the-slug"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -69,7 +69,7 @@ func TestTemplateClientUpdate(t *testing.T) {
 	templateType := clerk.TemplateTypeEmail
 	subject := "subject"
 	slug := "the-slug"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -95,7 +95,7 @@ func TestTemplateClientDelete(t *testing.T) {
 	t.Parallel()
 	templateType := clerk.TemplateTypeEmail
 	slug := "the-slug"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -118,7 +118,7 @@ func TestTemplateClientRevert(t *testing.T) {
 	t.Parallel()
 	templateType := clerk.TemplateTypeEmail
 	slug := "the-slug"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -141,7 +141,7 @@ func TestTemplateClientPreview(t *testing.T) {
 	templateType := clerk.TemplateTypeEmail
 	slug := "the-slug"
 	body := "body"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -166,7 +166,7 @@ func TestTemplateClientToggleDelivery(t *testing.T) {
 	templateType := clerk.TemplateTypeEmail
 	slug := "the-slug"
 	deliveredByClerk := true
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,

--- a/user/client.go
+++ b/user/client.go
@@ -21,11 +21,7 @@ type Client struct {
 	Backend clerk.Backend
 }
 
-type ClientConfig struct {
-	clerk.BackendConfig
-}
-
-func NewClient(config *ClientConfig) *Client {
+func NewClient(config *clerk.ClientConfig) *Client {
 	return &Client{
 		Backend: clerk.NewBackend(&config.BackendConfig),
 	}

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -19,7 +19,7 @@ func TestUserClientCreate(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
 	username := "username"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -40,7 +40,7 @@ func TestUserClientCreate(t *testing.T) {
 
 func TestUserClientList_Request(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -79,7 +79,7 @@ func TestUserClientList_Response(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.URL = clerk.String(ts.URL)
 	config.HTTPClient = ts.Client()
 	client := NewClient(config)
@@ -92,7 +92,7 @@ func TestUserClientList_Response(t *testing.T) {
 
 func TestUserClientCount(t *testing.T) {
 	t.Parallel()
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -124,7 +124,7 @@ func TestUserClientGet(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
 	username := "username"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -143,7 +143,7 @@ func TestUserClientGet(t *testing.T) {
 func TestUserClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -163,7 +163,7 @@ func TestUserClientUpdate(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
 	username := "username"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -186,7 +186,7 @@ func TestUserClientUpdateMetadata(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
 	metadata := json.RawMessage(`{"foo":"bar"}`)
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -209,7 +209,7 @@ func TestUserClientListOAuthAccessTokens(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
 	provider := "oauth_custom"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,
@@ -242,7 +242,7 @@ func TestUserClientListOAuthAccessTokens(t *testing.T) {
 func TestUserClientDeleteMFA(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -262,7 +262,7 @@ func TestUserClientDeleteMFA(t *testing.T) {
 func TestUserClientBan(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -281,7 +281,7 @@ func TestUserClientBan(t *testing.T) {
 func TestUserClientUnban(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -300,7 +300,7 @@ func TestUserClientUnban(t *testing.T) {
 func TestUserClientLock(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -319,7 +319,7 @@ func TestUserClientLock(t *testing.T) {
 func TestUserClientUnlock(t *testing.T) {
 	t.Parallel()
 	id := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
@@ -340,7 +340,7 @@ func TestUserClientListOrganizationMemberships(t *testing.T) {
 	membershipID := "orgmem_123"
 	organizationID := "org_123"
 	userID := "user_123"
-	config := &ClientConfig{}
+	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T: t,

--- a/v2_migration_guide.md
+++ b/v2_migration_guide.md
@@ -116,7 +116,7 @@ import (
 
 func main() {
     ctx := context.Background()
-    config := &organization.ClientConfig{}
+    config := &clerk.ClientConfig{}
     config.Key = "sk_live_XXX"
     client := organization.NewClient(config)
 
@@ -291,7 +291,7 @@ import (
 )
 
 func main() {
-    config := &jwks.ClientConfig{}
+    config := &clerk.ClientConfig{}
     config.Key = "sk_live_XXX"
     client := jwks.NewClient(config)
     mux := http.NewServeMux()


### PR DESCRIPTION
All API client constructors get the same type for their configuration. 

Instead of having a ClientConfig type per API package, we use a central clerk.ClientConfig type.