### PR TITLE
feat: Clock interface as a time source

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -448,6 +448,32 @@ type ClientConfig struct {
 	BackendConfig
 }
 
+// Clock is an interface that can be used with the library instead
+// of the [time] package.
+// The interface is useful for testing time sensitive paths or
+// feeding the library with an authoritative source of time, like
+// an external time generator.
+type Clock interface {
+	Now() time.Time
+}
+
+// A default implementation of a Clock, keeping the real time by
+// using the [time] package directly.
+type defaultClock struct{}
+
+// Now returns the current time.
+func (c *defaultClock) Now() time.Time {
+	return time.Now()
+}
+
+// NewClock returns a default clock implementation which calls
+// the [time] package internally.
+// Please note that the return type is an interface because the
+// Clock is not supposed to be used directly.
+func NewClock() Clock {
+	return &defaultClock{}
+}
+
 // Regular expression that matches multiple backslashes in a row.
 var extraBackslashesRE = regexp.MustCompile("([^:])//+")
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/go-jose/go-jose/v3 v3.0.1 h1:pWmKFVtt+Jl0vBZTIpz/eAKwsm6LkIxDVVbFHKkc
 github.com/go-jose/go-jose/v3 v3.0.1/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -26,6 +26,10 @@ type VerifyParams struct {
 	// JWK the custom JSON Web Key that will be used to verify the
 	// Token with. Required.
 	JWK *clerk.JSONWebKey
+	// Clock can be used to keep track of time and will replace usage of
+	// the [time] package. Pass a custom Clock to control the source of
+	// time or facilitate testing chronologically sensitive flows.
+	Clock clerk.Clock
 	// CustomClaimsConstructor will be called when parsing the Token's
 	// claims. It's useful for parsing custom claims into user-defined
 	// types.
@@ -77,7 +81,11 @@ func Verify(ctx context.Context, params *VerifyParams) (*clerk.SessionClaims, er
 		return nil, err
 	}
 
-	err = claims.ValidateWithLeeway(time.Now().UTC(), params.Leeway)
+	clock := params.Clock
+	if clock == nil {
+		clock = clerk.NewClock()
+	}
+	err = claims.ValidateWithLeeway(clock.Now().UTC(), params.Leeway)
 	if err != nil {
 		return nil, err
 	}

--- a/v2_migration_guide.md
+++ b/v2_migration_guide.md
@@ -324,6 +324,7 @@ Name in v1 | Name in v2
 `WithSatelliteDomain` | `Satellite`
 `WithProxyURL` | `ProxyURL`
 `WithCustomClaims` | `CustomClaimsConstructor`
+n/a | `Clock`
 n/a | `JWKSClient`
 
 ## Verify tokens


### PR DESCRIPTION
Verifying a session JWT includes time sensitive validations, like checking token expiration, or that the token can be used now ('nbf' claim).

The HTTP middleware caches JSON web keys for one hour. After that, the cache is considered invalid and a new request to fetch the JSON web key set will be issued.

These are both flows that depend on the current time and time comparisons.

Various system architectures with a distributed nature might not be synchronized. A clock skew is expected.
In such cases it's common to share a "time source" so that all nodes can coordinate on what the perceived current time is.

This commit adds a new clerk.Clock interface which can be passed as a dependency in the http middleware functions and the jwt.Verify function. We also add a dependency to the clockwork project, in order to use a fake clock for our tests.