### PR TITLE
feat: Helper for json.RawMessage pointers

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -87,10 +87,11 @@ available in the server, and a slice with the operation results.
 
 ### Every field in API operation parameters is a pointer
 
-The `v2` version of the library introduces helper functions to generate pointers from basic type values. These are:
+The `v2` version of the library introduces helper functions to generate pointers from various type values. These are:
 - `clerk.String`
 - `clerk.Bool`
 - `clerk.Int64`
+- `clerk.JSONRawMessage`
 
 Using the helpers above, here's how you can invoke an API operation with a `*Params` struct.
 

--- a/clerk.go
+++ b/clerk.go
@@ -515,3 +515,8 @@ func Int64(v int64) *int64 {
 func Bool(v bool) *bool {
 	return &v
 }
+
+// JSONRawMessage returns a pointer to the provided json.RawMessage value.
+func JSONRawMessage(v json.RawMessage) *json.RawMessage {
+	return &v
+}

--- a/v2_migration_guide.md
+++ b/v2_migration_guide.md
@@ -186,10 +186,11 @@ of new fields have been added. Deprecated struct fields have been dropped.
 The `v2` version of Clerk SDK Go introduces another important change about types that can be used as API operation
 parameters. Every field for these structs is a pointer.
 
-The `v2` version of the library introduces helper functions to cast basic type values to pointers. These are:
+The `v2` version of the library introduces helper functions to cast various type values to pointers. These are:
 - `clerk.String`
 - `clerk.Bool`
 - `clerk.Int64`
+- `clerk.JSONRawMessage`
 
 Using the helpers above, here's how you can invoke an API operation with a `*Params` struct.
 


### PR DESCRIPTION
Similar to our clerk.String, clerk.Bool and clerk.Int64 helpers, this commit adds a clerk.JSONRawMessage function that returns a pointer of the provided json.RawMessage value.