### PR TITLE
feat: jwt.Verify fetches the JSON web key

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -219,5 +219,15 @@ The `clerk.VerifyToken` method in version `v1` of the Clerk Go SDK has been rena
 
 The method accepts the same parameters, with two important differences.
 
-- The JSON web key with which the token will be verified is a required parameter.
+- You can provide the JSON web key with which the token will be verified.
+- If you don't provide the JSON web key, you can provide a jwks.Client that will be used to retrieve it. If you don't provide a jwks.Client, one with default configuration will be used.
 - The method will not cache the JSON web key.
+
+```go
+sessionToken := "the-clerk-session-jwt"
+- client := clerk.NewClient("sk_live_XXXX")
+- claims, err := client.VerifyToken(sessionToken)
++ claims, err := jwt.Verify(context.Background(), &jwt.VerifyParams{
++   Token: sessionToken,
++ })
+```

--- a/v2_migration_guide.md
+++ b/v2_migration_guide.md
@@ -340,12 +340,38 @@ The method accepts the same parameters, with two important differences.
 In the `v1` version, the `clerk.VerifyToken` method would trigger an HTTP request to the Clerk Backend API to
 fetch the JSON web key and would cache its value for one hour.
 
-The new `jwt.Verify` method that is included in `v2` accepts the JSON web key as a required parameter. It is up
+The new `jwt.Verify` method that is included in `v2` accepts the JSON web key that is used to verify the token. It is up
 to the caller to get access to the key and pass it to `jwt.Verify`.
 
 Please note that both HTTP middleware functions, `WithHeaderAuthorization` and `RequireHeaderAuthorization` will cache
 the  JSON web key by default.
 
+You can fetch the JSON web key with the `jwt.GetJSONWebKey` method.
+
+```go
+ctx := context.Background()
+token := "the-clerk-session-jwt"
+decoded, err := jwt.Decode(ctx, &jwt.DecodeParams{Token: token})
+if err != nil {
+    panic(err)
+}
+
+// Fetch the JSON web key for your instance.
+// It is advised to cache the JSON web key until your instance secret
+// key changes.
+jwk, err := jwt.GetJSONWebKey(ctx, &jwt.GetJSONWebKeyParams{
+    KeyID: decoded.KeyID,
+})
+if err != nil {
+    panic(err)
+}
+claims, err := jwt.Verify(ctx, &jwt.VerifyParams{
+    Token: token,
+    JWK: jwk,
+})
+```
+
+If you don't have access to the JSON web key, you can
 ## Feedback and omissions
 
 Please let us know about your experience upgrading to the `v2` version of the Clerk Go SDK.


### PR DESCRIPTION
In order to reduce friction when manually verifying a session JWT, the jwt.Verify function will fetch the JSON web key if it's not passed in the params.

Users can specify the jwks.Client that will be used to invoke the API GET /v1/jwks method.

Exported the method which fetches the JSON web key, since it can be re-used by the middleware. It can also be used for consumers who wish to fetch the JSON web key once and cache it. Caching is recommended.

```go
// Fetch the JWK once
decoded, _ := jwt.Decode(ctx, &jwt.DecodeParams{Token: token})
jwk, _ := jwt.GetJSONWebKey(ctx, &jwt.GetJSONWebKeyParams{KeyID: decoded.KeyID})

// Use the JWK to verify the token
claims, _ := jwt.Verify(ctx, &jwt.VerifyParams{
  Token: token,
  JWK: jwk,
})
```