### PR TITLE
fix: Return the current time in UTC

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -463,7 +463,7 @@ type defaultClock struct{}
 
 // Now returns the current time.
 func (c *defaultClock) Now() time.Time {
-	return time.Now()
+	return time.Now().UTC()
 }
 
 // NewClock returns a default clock implementation which calls


### PR DESCRIPTION
Calling the UTC() method when getting the current time might be helpful in time zone conversions.