### PR TITLE
feat: Allow SAML Connection configuration with IdP Metadata

### DIFF
--- a/clerk/saml_connections.go
+++ b/clerk/saml_connections.go
@@ -16,6 +16,7 @@ type SAMLConnection struct {
 	IdpSsoURL          *string                        `json:"idp_sso_url"`
 	IdpCertificate     *string                        `json:"idp_certificate"`
 	IdpMetadataURL     *string                        `json:"idp_metadata_url"`
+	IdpMetadata        *string                        `json:"idp_metadata"`
 	AcsURL             string                         `json:"acs_url"`
 	SPEntityID         string                         `json:"sp_entity_id"`
 	SPMetadataURL      string                         `json:"sp_metadata_url"`
@@ -97,6 +98,7 @@ type CreateSAMLConnectionParams struct {
 	IdpSsoURL        *string                         `json:"idp_sso_url,omitempty"`
 	IdpCertificate   *string                         `json:"idp_certificate,omitempty"`
 	IdpMetadataURL   *string                         `json:"idp_metadata_url,omitempty"`
+	IdpMetadata      *string                         `json:"idp_metadata,omitempty"`
 	AttributeMapping *SAMLConnectionAttributeMapping `json:"attribute_mapping,omitempty"`
 }
 
@@ -121,6 +123,7 @@ type UpdateSAMLConnectionParams struct {
 	IdpSsoURL          *string                         `json:"idp_sso_url,omitempty"`
 	IdpCertificate     *string                         `json:"idp_certificate,omitempty"`
 	IdpMetadataURL     *string                         `json:"idp_metadata_url,omitempty"`
+	IdpMetadata        *string                         `json:"idp_metadata,omitempty"`
 	AttributeMapping   *SAMLConnectionAttributeMapping `json:"attribute_mapping,omitempty"`
 	Active             *bool                           `json:"active,omitempty"`
 	SyncUserAttributes *bool                           `json:"sync_user_attributes,omitempty"`

--- a/clerk/saml_connections_test.go
+++ b/clerk/saml_connections_test.go
@@ -134,6 +134,7 @@ func TestSAMLConnectionsService_Update(t *testing.T) {
 		Active:             &expectedActive,
 		SyncUserAttributes: &expectedSyncUserAttributes,
 		IdpMetadataURL:     stringToPtr("https://example.com/saml/metadata"),
+		IdpMetadata:        stringToPtr(dummyIdpMetadata),
 		AttributeMapping: &SAMLConnectionAttributeMapping{
 			UserID:       "custom_user_id",
 			EmailAddress: "custom_email",
@@ -222,6 +223,7 @@ const (
 	"idp_sso_url": "https://example.com/saml/sso",
 	"idp_certificate": "` + dummySAMLConnectionCertificate + `",
 	"idp_metadata_url": "https://example.com/saml/metadata",
+	"idp_metadata": "` + dummyIdpMetadata + `",
 	"acs_url": "` + "https://clerk.example.com/v1/saml/acs/" + dummySAMLConnectionID + `",
 	"sp_entity_id": "` + "https://clerk.example.com/saml/" + dummySAMLConnectionID + `",
 	"sp_metadata_url": "` + "https://clerk.example.com/v1/saml/metadata/" + dummySAMLConnectionID + `",
@@ -240,4 +242,6 @@ const (
 }`
 
 	dummySAMLConnectionCertificate = `MIIDBzCCAe+gAwIBAgIJAPr/Mrlc8EGhMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTAeFw0xNTEyMjgxOTE5NDVaFw0yNTEyMjUxOTE5NDVaMBoxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANDoWzLos4LWxTn8Gyu2lEbl4WcelUbgLN5zYm4ron8Ahs+rvcsu2zkdD/s6jdGJI8WqJKhYK2u61ygnXgAZqC6ggtFPnBpizcDzjgND2g+aucSoUODHt67f0fQuAmupN/zp5MZysJ6IHLJnYLNpfJYk96lRz9ODnO1Mpqtr9PWxm+pz7nzq5F0vRepkgpcRxv6ufQBjlrFytccyEVdXrvFtkjXcnhVVNSR4kHuOOMS6D7pebSJ1mrCmshbD5SX1jXPBKFPAjozYX6PxqLxUx1Y4faFEf4MBBVcInyB4oURNB2s59hEEi2jq9izNE7EbEK6BY5sEhoCPl9m32zE6ljkCAwEAAaNQME4wHQYDVR0OBBYEFB9ZklC1Ork2zl56zg08ei7ss/+iMB8GA1UdIwQYMBaAFB9ZklC1Ork2zl56zg08ei7ss/+iMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAAVoTSQ5pAirw8OR9FZ1bRSuTDhY9uxzl/OL7lUmsv2cMNeCB3BRZqm3mFt+cwN8GsH6f3uvNONIhgFpTGN5LEcXQz89zJEzB+qaHqmbFpHQl/sx2B8ezNgT/882H2IH00dXESEfy/+1gHg2pxjGnhRBN6el/gSaDiySIMKbilDrffuvxiCfbpPN0NRRiPJhd2ay9KuL/RxQRl1gl9cHaWiouWWba1bSBb2ZPhv2rPMUsFo98ntkGCObDX6Y1SpkqmoTbrsbGFsTG2DLxnvr4GdN1BSr0Uu/KV3adj47WkXVPeMYQti/bQmxQB8tRFhrw80qakTLUzreO96WzlBBMtY=`
+
+	dummyIdpMetadata = `<?xml version=\"1.0\" encoding=\"UTF-8\"?><md:EntityDescriptor entityID=\"test-idp-entity-id\" xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\"><md:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>MIIDBzCCAe+gAwIBAgIJAPr/Mrlc8EGhMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTAeFw0xNTEyMjgxOTE5NDVaFw0yNTEyMjUxOTE5NDVaMBoxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANDoWzLos4LWxTn8Gyu2lEbl4WcelUbgLN5zYm4ron8Ahs+rvcsu2zkdD/s6jdGJI8WqJKhYK2u61ygnXgAZqC6ggtFPnBpizcDzjgND2g+aucSoUODHt67f0fQuAmupN/zp5MZysJ6IHLJnYLNpfJYk96lRz9ODnO1Mpqtr9PWxm+pz7nzq5F0vRepkgpcRxv6ufQBjlrFytccyEVdXrvFtkjXcnhVVNSR4kHuOOMS6D7pebSJ1mrCmshbD5SX1jXPBKFPAjozYX6PxqLxUx1Y4faFEf4MBBVcInyB4oURNB2s59hEEi2jq9izNE7EbEK6BY5sEhoCPl9m32zE6ljkCAwEAAaNQME4wHQYDVR0OBBYEFB9ZklC1Ork2zl56zg08ei7ss/+iMB8GA1UdIwQYMBaAFB9ZklC1Ork2zl56zg08ei7ss/+iMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAAVoTSQ5pAirw8OR9FZ1bRSuTDhY9uxzl/OL7lUmsv2cMNeCB3BRZqm3mFt+cwN8GsH6f3uvNONIhgFpTGN5LEcXQz89zJEzB+qaHqmbFpHQl/sx2B8ezNgT/882H2IH00dXESEfy/+1gHg2pxjGnhRBN6el/gSaDiySIMKbilDrffuvxiCfbpPN0NRRiPJhd2ay9KuL/RxQRl1gl9cHaWiouWWba1bSBb2ZPhv2rPMUsFo98ntkGCObDX6Y1SpkqmoTbrsbGFsTG2DLxnvr4GdN1BSr0Uu/KV3adj47WkXVPeMYQti/bQmxQB8tRFhrw80qakTLUzreO96WzlBBMtY=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat><md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat><md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://example.com/saml/sso\"/></md:IDPSSODescriptor></md:EntityDescriptor>`
 )


### PR DESCRIPTION
Our SAML Connection Create/Update operations now accepts a new optional property 'IdpMetadata' which you can use in order to configure an IdP using the metadata file. If provided, we also include it in the response as well