### PR TITLE
fix: Pagination parameters for samlconnection.List

### DIFF
--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -4,6 +4,7 @@ package samlconnection
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/clerk/clerk-sdk-go/v2"
 )
@@ -107,6 +108,12 @@ func (c *Client) Delete(ctx context.Context, id string) (*clerk.DeletedResource,
 
 type ListParams struct {
 	clerk.APIParams
+	clerk.ListParams
+}
+
+// ToQuery returns query string values from the params.
+func (params *ListParams) ToQuery() url.Values {
+	return params.ListParams.ToQuery()
 }
 
 // List returns a list of SAML Connections.

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/clerk/clerk-sdk-go/v2"
@@ -174,10 +175,15 @@ func TestSAMLConnectionClientList(t *testing.T) {
 }`, id, name, domain, provider)),
 			Method: http.MethodGet,
 			Path:   "/v1/saml_connections",
+			Query: &url.Values{
+				"limit": []string{"1"},
+			},
 		},
 	}
 	client := NewClient(config)
-	list, err := client.List(context.Background(), &ListParams{})
+	params := &ListParams{}
+	params.Limit = clerk.Int64(1)
+	list, err := client.List(context.Background(), params)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), list.TotalCount)
 	require.Equal(t, 1, len(list.SAMLConnections))


### PR DESCRIPTION
The List operation of the SAML connections API supports pagination with limit and offset query string parameters.