### PR TITLE
fix: Adds missing params for listing SAML connections

### DIFF
--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -109,11 +109,20 @@ func (c *Client) Delete(ctx context.Context, id string) (*clerk.DeletedResource,
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
+	Query   *string `json:"query,omitempty"`
+	OrderBy *string `json:"order_by,omitempty"`
 }
 
 // ToQuery returns query string values from the params.
 func (params *ListParams) ToQuery() url.Values {
-	return params.ListParams.ToQuery()
+	q := params.ListParams.ToQuery()
+	if params.Query != nil {
+		q.Set("query", *params.Query)
+	}
+	if params.OrderBy != nil {
+		q.Set("order_by", *params.OrderBy)
+	}
+	return q
 }
 
 // List returns a list of SAML Connections.

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -176,13 +176,20 @@ func TestSAMLConnectionClientList(t *testing.T) {
 			Method: http.MethodGet,
 			Path:   "/v1/saml_connections",
 			Query: &url.Values{
-				"limit": []string{"1"},
+				"limit":    []string{"1"},
+				"query":    []string{"Acme"},
+				"order_by": []string{"-created_at"},
 			},
 		},
 	}
 	client := NewClient(config)
-	params := &ListParams{}
-	params.Limit = clerk.Int64(1)
+	params := &ListParams{
+		ListParams: clerk.ListParams{
+			Limit: clerk.Int64(1),
+		},
+		Query:   clerk.String("Acme"),
+		OrderBy: clerk.String("-created_at"),
+	}
 	list, err := client.List(context.Background(), params)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), list.TotalCount)


### PR DESCRIPTION
Listing SAML connections also supports `query` and `order_by`.
This PR includes these two options.
