### PR TITLE
feat: Add `external_account_id` to OAuth access token response

### DIFF
--- a/clerk/users.go
+++ b/clerk/users.go
@@ -46,13 +46,14 @@ type User struct {
 }
 
 type UserOAuthAccessToken struct {
-	Object         string          `json:"object"`
-	Token          string          `json:"token"`
-	Provider       string          `json:"provider"`
-	PublicMetadata json.RawMessage `json:"public_metadata"`
-	Label          *string         `json:"label"`
-	Scopes         []string        `json:"scopes"`
-	TokenSecret    *string         `json:"token_secret"`
+	ExternalAccountID string          `json:"external_account_id"`
+	Object            string          `json:"object"`
+	Token             string          `json:"token"`
+	Provider          string          `json:"provider"`
+	PublicMetadata    json.RawMessage `json:"public_metadata"`
+	Label             *string         `json:"label"`
+	Scopes            []string        `json:"scopes"`
+	TokenSecret       *string         `json:"token_secret"`
 }
 
 type IdentificationLink struct {

--- a/clerk/users_test.go
+++ b/clerk/users_test.go
@@ -525,6 +525,7 @@ const dummyUserJson = `{
 
 const dummyUserOAuthAccessTokensJson = `[
 		{
+			"external_account_id": "eac_2dYS7stz9bgxQsSRvNqEAHhuxvW",
 			"object": "oauth_access_token",
 			"token": "test_token",
 			"provider": "oauth_testProvider",


### PR DESCRIPTION
Add support for the new field in the OAuth access token response.