### PR TITLE
feat: Add `external_account_id` to OAuth access token response (v2)

### DIFF
--- a/oauth_access_token.go
+++ b/oauth_access_token.go
@@ -3,11 +3,12 @@ package clerk
 import "encoding/json"
 
 type OAuthAccessToken struct {
-	Object         string          `json:"object"`
-	Token          string          `json:"token"`
-	Provider       string          `json:"provider"`
-	PublicMetadata json.RawMessage `json:"public_metadata"`
-	Label          *string         `json:"label"`
+	ExternalAccountID string          `json:"external_account_id"`
+	Object            string          `json:"object"`
+	Token             string          `json:"token"`
+	Provider          string          `json:"provider"`
+	PublicMetadata    json.RawMessage `json:"public_metadata"`
+	Label             *string         `json:"label"`
 	// Only set in OAuth 2.0 tokens
 	Scopes []string `json:"scopes,omitempty"`
 	// Only set in OAuth 1.0 tokens

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -215,6 +215,7 @@ func TestUserClientListOAuthAccessTokens(t *testing.T) {
 			T: t,
 			Out: json.RawMessage(fmt.Sprintf(`{
 "data":[{
+	"external_account_id":"eac_2dYS7stz9bgxQsSRvNqEAHhuxvW",
 	"provider":"%s",
 	"token":"the-token"
 }],
@@ -236,6 +237,7 @@ func TestUserClientListOAuthAccessTokens(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), list.TotalCount)
 	require.Equal(t, 1, len(list.OAuthAccessTokens))
+	require.Equal(t, "eac_2dYS7stz9bgxQsSRvNqEAHhuxvW", list.OAuthAccessTokens[0].ExternalAccountID)
 	require.Equal(t, provider, list.OAuthAccessTokens[0].Provider)
 }
 


### PR DESCRIPTION
Add support for the new field in the OAuth access token response.