### PR TITLE
feat: Test clock

### DIFF
--- a/clerktest/clerktest.go
+++ b/clerktest/clerktest.go
@@ -10,7 +10,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -87,4 +89,28 @@ func GenerateJWT(t *testing.T, claims any, kid string) (string, crypto.PublicKey
 	require.NoError(t, err)
 
 	return token, privKey.Public()
+}
+
+// Clock provides a test clock which can be manually advanced through time.
+type Clock struct {
+	mu sync.RWMutex
+	// The current time of this test clock.
+	time time.Time
+}
+
+// NewClockAt returns a Clock initialized at the given time.
+func NewClockAt(t time.Time) *Clock {
+	return &Clock{time: t}
+}
+
+// Now returns the clock's current time.
+func (c *Clock) Now() time.Time {
+	return c.time
+}
+
+// Advance moves the test clock to a new point in time.
+func (c *Clock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.time = c.time.Add(d)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/go-jose/go-jose/v3 v3.0.1 h1:pWmKFVtt+Jl0vBZTIpz/eAKwsm6LkIxDVVbFHKkc
 github.com/go-jose/go-jose/v3 v3.0.1/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
-github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/clerk/clerk-sdk-go/v2"
 	"github.com/clerk/clerk-sdk-go/v2/clerktest"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,7 +68,7 @@ func TestRequireHeaderAuthorization_InvalidAuthorization(t *testing.T) {
 
 func TestWithHeaderAuthorization_Caching(t *testing.T) {
 	kid := "kid"
-	clock := clockwork.NewFakeClockAt(time.Now().UTC())
+	clock := clerktest.NewClockAt(time.Now().UTC())
 
 	// Mock the Clerk API server. We expect requests to GET /jwks.
 	totalJWKSRequests := 0


### PR DESCRIPTION
Removed the clockwork dependency in favor of a custom test clock implementation.

We don't need all the functionality that the clockwork module has to offer and it's best we keep dependencies to a minimum.