### PR TITLE
fix: User list memberships id

### DIFF
--- a/user/api.go
+++ b/user/api.go
@@ -76,8 +76,8 @@ func Unlock(ctx context.Context, id string) (*clerk.User, error) {
 }
 
 // ListOrganizationMemberships lists all the user's organization memberships.
-func ListOrganizationMemberships(ctx context.Context, params *ListOrganizationMembershipsParams) (*clerk.OrganizationMembershipList, error) {
-	return getClient().ListOrganizationMemberships(ctx, params)
+func ListOrganizationMemberships(ctx context.Context, id string, params *ListOrganizationMembershipsParams) (*clerk.OrganizationMembershipList, error) {
+	return getClient().ListOrganizationMemberships(ctx, id, params)
 }
 
 func getClient() *Client {

--- a/user/client.go
+++ b/user/client.go
@@ -347,7 +347,6 @@ func (c *Client) Unlock(ctx context.Context, id string) (*clerk.User, error) {
 type ListOrganizationMembershipsParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	ID string `json:"-"`
 }
 
 // ToQuery returns url.Values from the params.
@@ -356,8 +355,8 @@ func (params *ListOrganizationMembershipsParams) ToQuery() url.Values {
 }
 
 // ListOrganizationMemberships lists all the user's organization memberships.
-func (c *Client) ListOrganizationMemberships(ctx context.Context, params *ListOrganizationMembershipsParams) (*clerk.OrganizationMembershipList, error) {
-	path, err := clerk.JoinPath(path, params.ID, "/organization_memberships")
+func (c *Client) ListOrganizationMemberships(ctx context.Context, id string, params *ListOrganizationMembershipsParams) (*clerk.OrganizationMembershipList, error) {
+	path, err := clerk.JoinPath(path, id, "/organization_memberships")
 	if err != nil {
 		return nil, err
 	}

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -364,12 +364,10 @@ func TestUserClientListOrganizationMemberships(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	params := &ListOrganizationMembershipsParams{
-		ID: userID,
-	}
+	params := &ListOrganizationMembershipsParams{}
 	params.Limit = clerk.Int64(1)
 	params.Offset = clerk.Int64(2)
-	list, err := client.ListOrganizationMemberships(context.Background(), params)
+	list, err := client.ListOrganizationMemberships(context.Background(), userID, params)
 	require.NoError(t, err)
 	require.Equal(t, membershipID, list.OrganizationMemberships[0].ID)
 	require.Equal(t, organizationID, list.OrganizationMemberships[0].Organization.ID)


### PR DESCRIPTION
Changed the user.ListOrganizationMemberships API operation so that the user ID is provided as a separate parameter, avoiding confusion as to which resource the ID refers to (user, organization or organization membership).