### PR TITLE
Add IgnoreDotsForGmailAddresses on SDK restriction resource

### DIFF
--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -64,7 +64,7 @@ type InstanceRestrictionsResponse struct {
 	Blocklist                   bool   `json:"blocklist"`
 	BlockEmailSubaddresses      bool   `json:"block_email_subaddresses"`
 	BlockDisposableEmailDomains bool   `json:"block_disposable_email_domains"`
-	IgnoreDotsForGmailAddresses *bool  `json:"ignore_dots_for_gmail_addresses,omitempty"`
+	IgnoreDotsForGmailAddresses bool   `json:"ignore_dots_for_gmail_addresses"`
 }
 
 type UpdateRestrictionsParams struct {

--- a/clerk/instances.go
+++ b/clerk/instances.go
@@ -64,6 +64,7 @@ type InstanceRestrictionsResponse struct {
 	Blocklist                   bool   `json:"blocklist"`
 	BlockEmailSubaddresses      bool   `json:"block_email_subaddresses"`
 	BlockDisposableEmailDomains bool   `json:"block_disposable_email_domains"`
+	IgnoreDotsForGmailAddresses *bool  `json:"ignore_dots_for_gmail_addresses,omitempty"`
 }
 
 type UpdateRestrictionsParams struct {
@@ -71,6 +72,7 @@ type UpdateRestrictionsParams struct {
 	Blocklist                   *bool `json:"blocklist,omitempty"`
 	BlockEmailSubaddresses      *bool `json:"block_email_subaddresses,omitempty"`
 	BlockDisposableEmailDomains *bool `json:"block_disposable_email_domains,omitempty"`
+	IgnoreDotsForGmailAddresses *bool `json:"ignore_dots_for_gmail_addresses,omitempty"`
 }
 
 func (s *InstanceService) UpdateRestrictions(params UpdateRestrictionsParams) (*InstanceRestrictionsResponse, error) {

--- a/clerk/instances_test.go
+++ b/clerk/instances_test.go
@@ -81,6 +81,7 @@ func TestInstanceService_UpdateRestrictions_happyPath(t *testing.T) {
 		Blocklist:                   &enabled,
 		BlockEmailSubaddresses:      &enabled,
 		BlockDisposableEmailDomains: &enabled,
+		IgnoreDotsForGmailAddresses: &enabled,
 	})
 
 	assert.Equal(t, &restrictionsResponse, got)

--- a/tests/integration/instances_test.go
+++ b/tests/integration/instances_test.go
@@ -41,6 +41,7 @@ func TestInstanceRestrictions(t *testing.T) {
 	assert.True(t, restrictionsResponse.Blocklist)
 	assert.False(t, restrictionsResponse.BlockEmailSubaddresses)
 	assert.False(t, restrictionsResponse.BlockDisposableEmailDomains)
+	assert.False(t, restrictionsResponse.IgnoreDotsForGmailAddresses)
 }
 
 func TestInstanceOrganizationSettings(t *testing.T) {


### PR DESCRIPTION
- **feat: add IgnoreDotsForGmailAddresses restriction on sdk**
- **test: IgnoreDotsForGmailAddresses restriction**

> **DO NOT MERGE**
>This PR depends [on](https://github.com/clerk/clerk_go/pull/6369)