### PR TITLE
Allowing the base url to be empty

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -474,8 +474,8 @@ func NewClock() Clock {
 	return &defaultClock{}
 }
 
-// Regular expression that matches multiple backslashes in a row.
-var extraBackslashesRE = regexp.MustCompile("([^:])//+")
+// Regular expression that matches multiple forward slashes in a row.
+var extraForwardslashesRE = regexp.MustCompile("(^/+|([^:])//+)")
 
 // JoinPath returns a URL string with the provided path elements joined
 // with the base path.
@@ -487,11 +487,12 @@ func JoinPath(base string, elem ...string) (string, error) {
 		sb.WriteString("/")
 		sb.WriteString(el)
 	}
-	// Trim leading and trailing backslashes, replace all occurrences of
-	// multiple backslashes in a row with one backslash, preserve the
-	// protocol's two backslashes.
+	// Trim leading and trailing forward slashes, replace all occurrences of
+	// multiple forward slashes in a row with one forward slash, preserve the
+	// protocol's two forward slashes.
 	// e.g. http://foo.com//bar/ will become http://foo.com/bar
-	res := extraBackslashesRE.ReplaceAllString(strings.TrimRight(sb.String(), "/"), "$1/")
+	trimRightForwardSlashes := strings.TrimRight(sb.String(), "/")
+	res := extraForwardslashesRE.ReplaceAllString(trimRightForwardSlashes, "$2/")
 
 	// Make sure we have a valid URL.
 	u, err := url.Parse(res)

--- a/clerk_test.go
+++ b/clerk_test.go
@@ -471,6 +471,11 @@ func TestJoinPath(t *testing.T) {
 		{base: "https://clerk.com", paths: []string{"//baz/", "/1/"}, want: "https://clerk.com/baz/1"},
 		{base: "https://clerk.com", paths: []string{"//baz/", "///1/"}, want: "https://clerk.com/baz/1"},
 		{base: "https://clerk.com", paths: []string{"/baz/", "/1?foo=bar&baz=bar/"}, want: "https://clerk.com/baz/1?foo=bar&baz=bar"},
+
+		// Tests an empty basepath, which should only be necessary when attempting
+		// to intercept the sdk's calls to the clerk API.
+		{base: "", paths: []string{"/baz"}, want: "/baz"},
+		{base: "/", paths: []string{"/baz"}, want: "/baz"},
 	} {
 		got, err := JoinPath(tc.base, tc.paths...)
 		require.NoError(t, err)


### PR DESCRIPTION
## What changed?

Prior to this, if the [clerk backend config url](https://github.com/clerk/clerk-sdk-go/blob/2d117c9e9511d5e460a408ff958af45c179d2b1e/clerk.go#L182) was left as empty, the SDK would prepend an extra `/` to all paths. So a request to `/foo` would become `//foo`.

This change updates our slash-stripping regex to remove leading slashes from the final URL.