### PR TITLE
feat: Expose template.enabled property & can_toggle permission

### DIFF
--- a/template.go
+++ b/template.go
@@ -19,9 +19,11 @@ type Template struct {
 	Position           int          `json:"position"`
 	CanRevert          bool         `json:"can_revert"`
 	CanDelete          bool         `json:"can_delete"`
+	CanToggle          bool         `json:"can_toggle"`
 	FromEmailName      *string      `json:"from_email_name,omitempty"`
 	ReplyToEmailName   *string      `json:"reply_to_email_name,omitempty"`
 	DeliveredByClerk   bool         `json:"delivered_by_clerk"`
+	Enabled            bool         `json:"enabled"`
 	Subject            string       `json:"subject"`
 	Markup             string       `json:"markup"`
 	Body               string       `json:"body"`


### PR DESCRIPTION
~`template.can_disable`~ (`template.can_toggle`) permission will instruct the front end on whether it can show a toggle to disable a template.

`template.enabled` shows the enabled status of a template.