### PR TITLE
Add True-Client-IP custom header to be passed along to BAPI

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -160,7 +160,8 @@ type Params interface {
 // CustomRequestHeaders contains predefined values that can be
 // used as custom headers in Backend API requests.
 type CustomRequestHeaders struct {
-	Application string
+	Application  string
+	TrueClientIP string
 }
 
 // Apply the custom headers to the HTTP request.
@@ -169,6 +170,7 @@ func (h *CustomRequestHeaders) apply(req *http.Request) {
 		return
 	}
 	req.Header.Add("X-Clerk-Application", h.Application)
+	req.Header.Add("X-Clerk-True-Client-IP", h.TrueClientIP)
 }
 
 // BackendConfig is used to configure a new Clerk Backend.

--- a/clerk_test.go
+++ b/clerk_test.go
@@ -175,7 +175,8 @@ func TestBackendCall_RequestHeaders(t *testing.T) {
 	path := "/resources"
 	secretKey := "sk_test_123"
 	customHeaders := CustomRequestHeaders{
-		Application: "custom-application",
+		Application:  "custom-application",
+		TrueClientIP: "127.0.0.1",
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -193,6 +194,7 @@ func TestBackendCall_RequestHeaders(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("go/%s", sdkVersion), r.Header.Get("X-Clerk-SDK"))
 		// Custom headers are added correctly.
 		assert.Equal(t, customHeaders.Application, r.Header.Get("X-Clerk-Application"))
+		assert.Equal(t, customHeaders.TrueClientIP, r.Header.Get("X-Clerk-True-Client-IP"))
 
 		_, err := w.Write([]byte(`{}`))
 		require.NoError(t, err)


### PR DESCRIPTION
This PR adds the `True-Client-IP` header on the custom headers map in order to pass it along our APIs. We are introducing request info on the webhook and that will enable us to know who has called other than the user-agent.