### PR TITLE
Sessions: Fix typo in tokens url for CreateTokenFromTemplate

### DIFF
--- a/clerk/sessions.go
+++ b/clerk/sessions.go
@@ -120,7 +120,7 @@ func (s *SessionsService) Verify(sessionId, token string) (*Session, error) {
 }
 
 func (s *SessionsService) CreateTokenFromTemplate(sessionID, templateSlug string) (*SessionToken, error) {
-	sessionURL := fmt.Sprintf("%s/%s/token/%s", SessionsUrl, sessionID, templateSlug)
+	sessionURL := fmt.Sprintf("%s/%s/tokens/%s", SessionsUrl, sessionID, templateSlug)
 	req, _ := s.client.NewRequest("POST", sessionURL)
 
 	var sessionToken SessionToken

--- a/clerk/sessions_test.go
+++ b/clerk/sessions_test.go
@@ -256,7 +256,7 @@ func TestSessionsService_CreateTokenFromTemplate_Success(t *testing.T) {
 	clerkClient, mux, _, teardown := setup(token)
 	defer teardown()
 
-	mux.HandleFunc(fmt.Sprintf("/%s/%s/token/%s", SessionsUrl, sessionID, templateSlug), func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/%s/%s/tokens/%s", SessionsUrl, sessionID, templateSlug), func(w http.ResponseWriter, req *http.Request) {
 		testHttpMethod(t, req, "POST")
 		testHeader(t, req, "Authorization", fmt.Sprintf("Bearer %s", token))
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This function throws error with response 404.

Referring this API from docs: https://clerk.com/docs/reference/backend-api/tag/Sessions#operation/CreateSessionTokenFromTemplate

... seems to be typo in the url.

Validation - confirmed working by following ways:
- Used the "try it" in the above API docs link - worked !
- Created my own function for this using the same `clerk.Client.Req/Do` and updated URL - worked !