### PR TITLE
ORGS-67: Update user serializer to add CreateOrganizationsLimit field

### DIFF
--- a/user.go
+++ b/user.go
@@ -35,6 +35,7 @@ type User struct {
 	VerificationAttemptsRemaining *int64             `json:"verification_attempts_remaining"`
 	DeleteSelfEnabled             bool               `json:"delete_self_enabled"`
 	CreateOrganizationEnabled     bool               `json:"create_organization_enabled"`
+	CreateOrganizationsLimit      *int               `json:"create_organizations_limit,omitempty"`
 	LastActiveAt                  *int64             `json:"last_active_at"`
 	CreatedAt                     int64              `json:"created_at"`
 	UpdatedAt                     int64              `json:"updated_at"`

--- a/user/client.go
+++ b/user/client.go
@@ -98,6 +98,7 @@ type UpdateParams struct {
 	BackupCodes                      *[]string        `json:"backup_codes,omitempty"`
 	DeleteSelfEnabled                *bool            `json:"delete_self_enabled,omitempty"`
 	CreateOrganizationEnabled        *bool            `json:"create_organization_enabled,omitempty"`
+	CreateOrganizationsLimit         *int             `json:"create_organizations_limit,omitempty"`
 	// Specified in RFC3339 format
 	CreatedAt *string `json:"created_at,omitempty"`
 }


### PR DESCRIPTION
> WARNING: This only should be merged after [this change](https://github.com/clerk/clerk_go/pull/7124) is deployed to production!

This PR adds the `CreateOrganizationsLimit` field for the User serializer and user update params structs.