### PR TITLE
feat(users): add organization_id parameter support

### DIFF
--- a/user/client.go
+++ b/user/client.go
@@ -190,14 +190,18 @@ func (c *Client) Delete(ctx context.Context, id string) (*clerk.DeletedResource,
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	OrderBy           *string  `json:"order_by,omitempty"`
-	Query             *string  `json:"query,omitempty"`
-	EmailAddresses    []string `json:"email_address,omitempty"`
-	ExternalIDs       []string `json:"external_id,omitempty"`
-	PhoneNumbers      []string `json:"phone_number,omitempty"`
-	Web3Wallets       []string `json:"web3_wallet,omitempty"`
-	Usernames         []string `json:"username,omitempty"`
-	UserIDs           []string `json:"user_id,omitempty"`
+	OrderBy        *string  `json:"order_by,omitempty"`
+	Query          *string  `json:"query,omitempty"`
+	EmailAddresses []string `json:"email_address,omitempty"`
+	ExternalIDs    []string `json:"external_id,omitempty"`
+	PhoneNumbers   []string `json:"phone_number,omitempty"`
+	Web3Wallets    []string `json:"web3_wallet,omitempty"`
+	Usernames      []string `json:"username,omitempty"`
+	UserIDs        []string `json:"user_id,omitempty"`
+	// OrganizationIDs filters users that have memberships to the given organizations. For each organization ID, the
+	// + and - can be prepended to the ID, which denote whether the respective organization should be included or
+	// excluded from the result set. Accepts up to 100 organization IDs.
+	OrganizationIDs   []string `json:"organization_id,omitempty"`
 	LastActiveAtSince *int64   `json:"last_active_at_since,omitempty"`
 }
 
@@ -227,6 +231,9 @@ func (params *ListParams) ToQuery() url.Values {
 	}
 	for _, v := range params.UserIDs {
 		q.Add("user_id", v)
+	}
+	for _, v := range params.OrganizationIDs {
+		q.Add("organization_id", v)
 	}
 	if params.LastActiveAtSince != nil {
 		q.Add("last_active_at_since", strconv.FormatInt(*params.LastActiveAtSince, 10))

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -47,17 +47,19 @@ func TestUserClientList_Request(t *testing.T) {
 			T:      t,
 			Method: http.MethodGet,
 			Query: &url.Values{
-				"limit":         []string{"1"},
-				"offset":        []string{"2"},
-				"order_by":      []string{"-created_at"},
-				"email_address": []string{"foo@bar.com", "baz@bar.com"},
+				"limit":           []string{"1"},
+				"offset":          []string{"2"},
+				"order_by":        []string{"-created_at"},
+				"email_address":   []string{"foo@bar.com", "baz@bar.com"},
+				"organization_id": []string{"org_123", "org_456"},
 			},
 		},
 	}
 	client := NewClient(config)
 	params := &ListParams{
-		EmailAddresses: []string{"foo@bar.com", "baz@bar.com"},
-		OrderBy:        clerk.String("-created_at"),
+		EmailAddresses:  []string{"foo@bar.com", "baz@bar.com"},
+		OrderBy:         clerk.String("-created_at"),
+		OrganizationIDs: []string{"org_123", "org_456"},
 	}
 	params.Limit = clerk.Int64(1)
 	params.Offset = clerk.Int64(2)


### PR DESCRIPTION
# Why
The list all endpoint for users can accept organization IDs as a filter criterion. This is helpful to retrieve users with access to certain organizations.

# What
Add support for `OrganizationIDs string[]` exactly how it has been done for the JS SDK.

For comparison, this is how it is done within the JS SDK:

 - [parameter definition](https://github.com/clerk/javascript/blob/3c8fda28cfc99d6266397b75ebe1e6161192283c/packages/backend/src/api/endpoints/UserApi.ts#L37C5-L37C19]
 - [how the parameter is passed to the API call](https://github.com/clerk/javascript/blob/3c8fda28cfc99d6266397b75ebe1e6161192283c/packages/backend/src/api/endpoints/UserApi.ts#L116-L130)
 - [check how query parameters are transformed](https://github.com/clerk/javascript/blob/3c8fda28cfc99d6266397b75ebe1e6161192283c/packages/backend/src/api/request.ts#L69-L79)