### PR TITLE
readme fix: ResponseReader is interface, doesn't need ptr

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ func TestWithCustomBackend(t *testing.T) {
 
 type customBackend struct {}
 // Implement the Backend interface
-func (b *customBackend) Call(ctx context.Context, r *clerk.APIRequest, reader *clerk.ResponseReader) error {
+func (b *customBackend) Call(ctx context.Context, r *clerk.APIRequest, reader clerk.ResponseReader) error {
     // Construct a clerk.APIResponse and use the reader's Read method.
     reader.Read(&clerk.APIResponse{})
 }


### PR DESCRIPTION
Following this code example as-is results in an error because `reader` is a pointer to an interface instead of just an interface. This fixes it.