### PR TITLE
Fix issuer validation in tokens_issuer.go

### DIFF
--- a/clerk/tokens_issuer.go
+++ b/clerk/tokens_issuer.go
@@ -1,6 +1,9 @@
 package clerk
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 type issuer struct {
 	iss         string
@@ -33,6 +36,11 @@ func (iss *issuer) IsValid() bool {
 		return iss.iss == iss.proxyURL
 	}
 
-	return strings.HasPrefix(iss.iss, "https://clerk.") ||
-		strings.Contains(iss.iss, ".clerk.accounts")
+	parsedURL, err := url.Parse(iss.iss)
+	if err != nil {
+		return false
+	}
+
+	host := parsedURL.Hostname()
+	return host == "clerk.com" || strings.HasSuffix(host, ".clerk.com")
 }


### PR DESCRIPTION
Related to #309

Update the `IsValid` method in `clerk/tokens_issuer.go` to strictly check the issuer's domain segment.

* Parse the issuer URL and extract the hostname.
* Accept only issuers that match the exact domain `clerk.com` or subdomains of `clerk.com`.
* Return false if the URL parsing fails.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/clerk/clerk-sdk-go/issues/309?shareId=edcd9be3-db4f-44d9-b16f-d7f074f85ab4).