### PR TITLE
Add option to skip cookie verification in middleware

### DIFF
--- a/clerk/middleware_v2_test.go
+++ b/clerk/middleware_v2_test.go
@@ -51,3 +51,49 @@ func TestWithSessionV2_emptyAuthorizationHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestWithSessionV2_SkipCookieVerification(t *testing.T) {
+	c, mux, serverUrl, teardown := setup("test_dummy")
+	defer teardown()
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Should be signed in
+		_, ok := r.Context().Value(ActiveSessionClaims).(*SessionClaims)
+		if !ok {
+			t.Error("Expected session claims to be present in request context")
+		}
+	})
+
+	mux.Handle("/dummy", WithSessionV2(c, WithSkipCookieVerification())(dummyHandler))
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/dummy", serverUrl), nil)
+	req.Header.Set("Authorization", "Bearer dummy_token")
+
+	_, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWithSessionV2_NoSkipCookieVerification(t *testing.T) {
+	c, mux, serverUrl, teardown := setup("test_dummy")
+	defer teardown()
+
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Should be signed out
+		_, ok := r.Context().Value(ActiveSessionClaims).(*SessionClaims)
+		if ok {
+			t.Error("Expected session claims not to be present in request context")
+		}
+	})
+
+	mux.Handle("/dummy", WithSessionV2(c)(dummyHandler))
+
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/dummy", serverUrl), nil)
+	req.Header.Set("Authorization", "Bearer dummy_token")
+
+	_, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	injectActiveSession := clerk.WithSessionV2(client)
+	injectActiveSession := clerk.WithSessionV2(client, clerk.WithSkipCookieVerification())
 	mux.Handle("/session", injectActiveSession(http.HandlerFunc(returnActiveSession)))
 
 	err = http.ListenAndServe(":3000", mux)


### PR DESCRIPTION
Related to #129

Add an option to skip cookie verification in the middleware.

* Add a new `Options` struct to hold middleware options and a `WithSkipCookieVerification` function to set the `SkipCookieVerification` option in `clerk/middleware_v2.go`.
* Modify the `WithSessionV2` function in `clerk/middleware_v2.go` to check for the `WithSkipCookieVerification` option and skip cookie verification if set.
* Add tests in `clerk/middleware_v2_test.go` to verify the functionality of the `WithSkipCookieVerification` option, covering both scenarios: with and without the option.
* Update the example in `examples/middleware/main.go` to demonstrate the usage of the `WithSkipCookieVerification` option.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/clerk/clerk-sdk-go/issues/129?shareId=25d1b633-e3b1-4193-9634-86049293af6b).