### PR TITLE
feat: Support is_secondary for domain updates to indicate that the su…

### DIFF
--- a/domain/client.go
+++ b/domain/client.go
@@ -42,8 +42,9 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.Domai
 
 type UpdateParams struct {
 	clerk.APIParams
-	Name     *string `json:"name,omitempty"`
-	ProxyURL *string `json:"proxy_url,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	ProxyURL    *string `json:"proxy_url,omitempty"`
+	IsSecondary *bool   `json:"is_secondary,omitempty"`
 }
 
 // Update updates a domain's properties.


### PR DESCRIPTION
…bdomain is significant

If `is_secondary` is `true` and the application supports it, then the full domain name provided will be stored as the domain, including any subdomain(s).

i.e. we will not be storing the eTLD+1 as the domain in case a subdomain is provided.