### PR TITLE
feat: Support query, order_by and status for invitations List

### DIFF
--- a/invitation/client.go
+++ b/invitation/client.go
@@ -28,11 +28,24 @@ func NewClient(config *clerk.ClientConfig) *Client {
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
+	OrderBy *string `json:"order_by,omitempty"`
+	Query   *string `json:"query,omitempty"`
+	Status  *string `json:"status,omitempty"`
 }
 
 // ToQuery returns query string values from the params.
 func (params *ListParams) ToQuery() url.Values {
-	return params.ListParams.ToQuery()
+	q := params.ListParams.ToQuery()
+	if params.OrderBy != nil {
+		q.Set("order_by", *params.OrderBy)
+	}
+	if params.Query != nil {
+		q.Set("query", *params.Query)
+	}
+	if params.Status != nil {
+		q.Set("status", *params.Status)
+	}
+	return q
 }
 
 // List returns all invitations.

--- a/invitation/invitation_test.go
+++ b/invitation/invitation_test.go
@@ -39,6 +39,10 @@ func TestInvitationList(t *testing.T) {
 func TestInvitationListWithParams(t *testing.T) {
 	limit := int64(10)
 	offset := int64(20)
+	orderBy := "-created_at"
+	query := "example@email.com"
+	status := "pending"
+
 	clerk.SetBackend(clerk.NewBackend(&clerk.BackendConfig{
 		HTTPClient: &http.Client{
 			Transport: &clerktest.RoundTripper{
@@ -55,6 +59,9 @@ func TestInvitationListWithParams(t *testing.T) {
 				Query: &url.Values{
 					"limit":     []string{fmt.Sprintf("%d", limit)},
 					"offset":    []string{fmt.Sprintf("%d", offset)},
+					"order_by":  []string{orderBy},
+					"query":     []string{query},
+					"status":    []string{status},
 					"paginated": []string{"true"},
 				},
 			},
@@ -66,6 +73,9 @@ func TestInvitationListWithParams(t *testing.T) {
 			Limit:  &limit,
 			Offset: &offset,
 		},
+		OrderBy: &orderBy,
+		Query:   &query,
+		Status:  &status,
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(2), list.TotalCount)


### PR DESCRIPTION
This PR adds support for `query`, `order_by` & `status ` params in the invitations List