### PR TITLE
DASH-333: add Reserved for second factor field on PATCH phone_numbers

### DIFF
--- a/phonenumber/client.go
+++ b/phonenumber/client.go
@@ -54,8 +54,9 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.PhoneNumber, error)
 
 type UpdateParams struct {
 	clerk.APIParams
-	Verified *bool `json:"verified,omitempty"`
-	Primary  *bool `json:"primary,omitempty"`
+	Verified                *bool `json:"verified,omitempty"`
+	Primary                 *bool `json:"primary,omitempty"`
+	ReservedForSecondFactor *bool `json:"reserved_for_second_factor,omitempty"`
 }
 
 // Update updates the phone number specified by id.

--- a/phonenumber/client_test.go
+++ b/phonenumber/client_test.go
@@ -53,7 +53,8 @@ func TestPhoneNumberClientUpdate(t *testing.T) {
 	}
 	client := NewClient(config)
 	phoneNumber, err := client.Update(context.Background(), "idn_123", &UpdateParams{
-		Verified: clerk.Bool(true),
+		Verified:                clerk.Bool(true),
+		ReservedForSecondFactor: clerk.Bool(true),
 	})
 	require.NoError(t, err)
 	require.Equal(t, id, phoneNumber.ID)


### PR DESCRIPTION
This field was missing on the update phone numbers method, it's an [already existing](https://clerk.com/docs/reference/backend-api/tag/Phone-Numbers#operation/UpdatePhoneNumber!path=reserved_for_second_factor&t=request) field.