### PR TITLE
nicolas/dash 329 dapi delete ability to delete passkey

### DIFF
--- a/user/api.go
+++ b/user/api.go
@@ -90,6 +90,11 @@ func ListOrganizationMemberships(ctx context.Context, id string, params *ListOrg
 	return getClient().ListOrganizationMemberships(ctx, id, params)
 }
 
+// DeletePasskey deletes a passkey by it's identification ID.
+func DeletePasskey(ctx context.Context, userID, identificationID string) (*clerk.DeletedResource, error) {
+	return getClient().DeletePasskey(ctx, userID, identificationID)
+}
+
 func getClient() *Client {
 	return &Client{
 		Backend: clerk.GetBackend(),

--- a/user/api.go
+++ b/user/api.go
@@ -90,7 +90,7 @@ func ListOrganizationMemberships(ctx context.Context, id string, params *ListOrg
 	return getClient().ListOrganizationMemberships(ctx, id, params)
 }
 
-// DeletePasskey deletes a passkey by it's identification ID.
+// DeletePasskey deletes a passkey by its identification ID.
 func DeletePasskey(ctx context.Context, userID, identificationID string) (*clerk.DeletedResource, error) {
 	return getClient().DeletePasskey(ctx, userID, identificationID)
 }

--- a/user/client.go
+++ b/user/client.go
@@ -429,7 +429,7 @@ func (c *Client) ListOrganizationMemberships(ctx context.Context, id string, par
 	return list, err
 }
 
-// DeletePasskey deletes a passkey by it's identification ID.
+// DeletePasskey deletes a passkey by its identification ID.
 func (c *Client) DeletePasskey(ctx context.Context, userID, identificationID string) (*clerk.DeletedResource, error) {
 	path, err := clerk.JoinPath(path, userID, "/passkeys", identificationID)
 	if err != nil {

--- a/user/client.go
+++ b/user/client.go
@@ -428,3 +428,15 @@ func (c *Client) ListOrganizationMemberships(ctx context.Context, id string, par
 	err = c.Backend.Call(ctx, req, list)
 	return list, err
 }
+
+// DeletePasskey deletes a passkey by it's identification ID.
+func (c *Client) DeletePasskey(ctx context.Context, userID, identificationID string) (*clerk.DeletedResource, error) {
+	path, err := clerk.JoinPath(path, userID, "/passkeys", identificationID)
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodDelete, path)
+	resource := &clerk.DeletedResource{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -422,3 +422,22 @@ func TestUserClientListOrganizationMemberships(t *testing.T) {
 	require.Equal(t, organizationID, list.OrganizationMemberships[0].Organization.ID)
 	require.Equal(t, userID, list.OrganizationMemberships[0].PublicUserData.UserID)
 }
+
+func TestUserClientDeletePasskey(t *testing.T) {
+	t.Parallel()
+	userID := "user_123"
+	passkeyIdentificationID := "idn_345"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s"}`, passkeyIdentificationID)),
+			Method: http.MethodDelete,
+			Path:   "/v1/users/" + userID + "/passkeys/" + passkeyIdentificationID,
+		},
+	}
+	client := NewClient(config)
+	passkey, err := client.DeletePasskey(context.Background(), userID, passkeyIdentificationID)
+	require.NoError(t, err)
+	require.Equal(t, passkeyIdentificationID, passkey.ID)
+}


### PR DESCRIPTION
This PR implements a new method from a new BAPI endpoint to delete passkeys. It's all under the users' client.