### PR TITLE
fix(invitations): Support multiple statuses

### DIFF
--- a/invitation/client.go
+++ b/invitation/client.go
@@ -28,9 +28,9 @@ func NewClient(config *clerk.ClientConfig) *Client {
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	OrderBy *string `json:"order_by,omitempty"`
-	Query   *string `json:"query,omitempty"`
-	Status  *string `json:"status,omitempty"`
+	OrderBy  *string  `json:"order_by,omitempty"`
+	Query    *string  `json:"query,omitempty"`
+	Statuses []string `json:"status,omitempty"`
 }
 
 // ToQuery returns query string values from the params.
@@ -42,8 +42,8 @@ func (params *ListParams) ToQuery() url.Values {
 	if params.Query != nil {
 		q.Set("query", *params.Query)
 	}
-	if params.Status != nil {
-		q.Set("status", *params.Status)
+	for _, status := range params.Statuses {
+		q.Add("status", status)
 	}
 	return q
 }

--- a/invitation/invitation_test.go
+++ b/invitation/invitation_test.go
@@ -41,7 +41,8 @@ func TestInvitationListWithParams(t *testing.T) {
 	offset := int64(20)
 	orderBy := "-created_at"
 	query := "example@email.com"
-	status := "pending"
+	status1 := "pending"
+	status2 := "accepted"
 
 	clerk.SetBackend(clerk.NewBackend(&clerk.BackendConfig{
 		HTTPClient: &http.Client{
@@ -61,7 +62,7 @@ func TestInvitationListWithParams(t *testing.T) {
 					"offset":    []string{fmt.Sprintf("%d", offset)},
 					"order_by":  []string{orderBy},
 					"query":     []string{query},
-					"status":    []string{status},
+					"status":    []string{status1, status2},
 					"paginated": []string{"true"},
 				},
 			},
@@ -73,9 +74,9 @@ func TestInvitationListWithParams(t *testing.T) {
 			Limit:  &limit,
 			Offset: &offset,
 		},
-		OrderBy: &orderBy,
-		Query:   &query,
-		Status:  &status,
+		OrderBy:  &orderBy,
+		Query:    &query,
+		Statuses: []string{status1, status2},
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(2), list.TotalCount)


### PR DESCRIPTION
In this PR, we update the invitations to allow filtering by multiple statuses instead of just one, since we already support this in Backend API.