### PR TITLE
ORGS-138: Add `disable_additional_identifiers` field to SAML connection

### DIFF
--- a/saml_connection.go
+++ b/saml_connection.go
@@ -2,27 +2,28 @@ package clerk
 
 type SAMLConnection struct {
 	APIResource
-	ID                 string                         `json:"id"`
-	Object             string                         `json:"object"`
-	Name               string                         `json:"name"`
-	Domain             string                         `json:"domain"`
-	IdpEntityID        *string                        `json:"idp_entity_id"`
-	IdpSsoURL          *string                        `json:"idp_sso_url"`
-	IdpCertificate     *string                        `json:"idp_certificate"`
-	IdpMetadataURL     *string                        `json:"idp_metadata_url"`
-	IdpMetadata        *string                        `json:"idp_metadata"`
-	AcsURL             string                         `json:"acs_url"`
-	SPEntityID         string                         `json:"sp_entity_id"`
-	SPMetadataURL      string                         `json:"sp_metadata_url"`
-	AttributeMapping   SAMLConnectionAttributeMapping `json:"attribute_mapping"`
-	Active             bool                           `json:"active"`
-	Provider           string                         `json:"provider"`
-	UserCount          int64                          `json:"user_count"`
-	SyncUserAttributes bool                           `json:"sync_user_attributes"`
-	AllowSubdomains    bool                           `json:"allow_subdomains"`
-	AllowIdpInitiated  bool                           `json:"allow_idp_initiated"`
-	CreatedAt          int64                          `json:"created_at"`
-	UpdatedAt          int64                          `json:"updated_at"`
+	ID                               string                         `json:"id"`
+	Object                           string                         `json:"object"`
+	Name                             string                         `json:"name"`
+	Domain                           string                         `json:"domain"`
+	IdpEntityID                      *string                        `json:"idp_entity_id"`
+	IdpSsoURL                        *string                        `json:"idp_sso_url"`
+	IdpCertificate                   *string                        `json:"idp_certificate"`
+	IdpMetadataURL                   *string                        `json:"idp_metadata_url"`
+	IdpMetadata                      *string                        `json:"idp_metadata"`
+	AcsURL                           string                         `json:"acs_url"`
+	SPEntityID                       string                         `json:"sp_entity_id"`
+	SPMetadataURL                    string                         `json:"sp_metadata_url"`
+	AttributeMapping                 SAMLConnectionAttributeMapping `json:"attribute_mapping"`
+	Active                           bool                           `json:"active"`
+	Provider                         string                         `json:"provider"`
+	UserCount                        int64                          `json:"user_count"`
+	SyncUserAttributes               bool                           `json:"sync_user_attributes"`
+	AllowSubdomains                  bool                           `json:"allow_subdomains"`
+	AllowIdpInitiated                bool                           `json:"allow_idp_initiated"`
+	DisableAdditionalIdentifications bool                           `json:"disable_additional_identifications"`
+	CreatedAt                        int64                          `json:"created_at"`
+	UpdatedAt                        int64                          `json:"updated_at"`
 }
 
 type SAMLConnectionAttributeMapping struct {

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -67,18 +67,19 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.SAMLConnection, err
 
 type UpdateParams struct {
 	clerk.APIParams
-	Name               *string                 `json:"name,omitempty"`
-	Domain             *string                 `json:"domain,omitempty"`
-	IdpEntityID        *string                 `json:"idp_entity_id,omitempty"`
-	IdpSsoURL          *string                 `json:"idp_sso_url,omitempty"`
-	IdpCertificate     *string                 `json:"idp_certificate,omitempty"`
-	IdpMetadataURL     *string                 `json:"idp_metadata_url,omitempty"`
-	IdpMetadata        *string                 `json:"idp_metadata,omitempty"`
-	AttributeMapping   *AttributeMappingParams `json:"attribute_mapping,omitempty"`
-	Active             *bool                   `json:"active,omitempty"`
-	SyncUserAttributes *bool                   `json:"sync_user_attributes,omitempty"`
-	AllowSubdomains    *bool                   `json:"allow_subdomains,omitempty"`
-	AllowIdpInitiated  *bool                   `json:"allow_idp_initiated,omitempty"`
+	Name                             *string                 `json:"name,omitempty"`
+	Domain                           *string                 `json:"domain,omitempty"`
+	IdpEntityID                      *string                 `json:"idp_entity_id,omitempty"`
+	IdpSsoURL                        *string                 `json:"idp_sso_url,omitempty"`
+	IdpCertificate                   *string                 `json:"idp_certificate,omitempty"`
+	IdpMetadataURL                   *string                 `json:"idp_metadata_url,omitempty"`
+	IdpMetadata                      *string                 `json:"idp_metadata,omitempty"`
+	AttributeMapping                 *AttributeMappingParams `json:"attribute_mapping,omitempty"`
+	Active                           *bool                   `json:"active,omitempty"`
+	SyncUserAttributes               *bool                   `json:"sync_user_attributes,omitempty"`
+	AllowSubdomains                  *bool                   `json:"allow_subdomains,omitempty"`
+	AllowIdpInitiated                *bool                   `json:"allow_idp_initiated,omitempty"`
+	DisableAdditionalIdentifications *bool                   `json:"disable_additional_identifications,omitempty"`
 }
 
 // Update updates the SAML Connection specified by id.

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -73,11 +73,12 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	name := "the-name"
 	domain := "example.com"
 	provider := "saml_custom"
+	disableAdditionalIdentifications := true
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:   t,
-			Out: json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s"}`, id, name, domain, provider)), Method: http.MethodGet,
+			Out: json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s", "disable_additional_identifications": %t}`, id, name, domain, provider, disableAdditionalIdentifications)), Method: http.MethodGet,
 			Path: "/v1/saml_connections/" + id,
 		},
 	}
@@ -88,6 +89,7 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	require.Equal(t, name, samlConnection.Name)
 	require.Equal(t, domain, samlConnection.Domain)
 	require.Equal(t, provider, samlConnection.Provider)
+	require.Equal(t, disableAdditionalIdentifications, samlConnection.DisableAdditionalIdentifications)
 }
 
 func TestSAMLConnectionClientUpdate(t *testing.T) {
@@ -96,23 +98,26 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 	name := "the-name"
 	domain := "example.com"
 	provider := "saml_custom"
+	disableAdditionalIdentifications := true
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s"}`, name)),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s"}`, id, name, domain, provider)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s", "disable_additional_identifications": %t}`, name, disableAdditionalIdentifications)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","disable_additional_identifications": %t}`, id, name, domain, provider, disableAdditionalIdentifications)),
 			Method: http.MethodPatch,
 			Path:   "/v1/saml_connections/" + id,
 		},
 	}
 	client := NewClient(config)
 	samlConnection, err := client.Update(context.Background(), id, &UpdateParams{
-		Name: clerk.String(name),
+		Name:                             clerk.String(name),
+		DisableAdditionalIdentifications: clerk.Bool(disableAdditionalIdentifications),
 	})
 	require.NoError(t, err)
 	require.Equal(t, id, samlConnection.ID)
 	require.Equal(t, name, samlConnection.Name)
+	require.Equal(t, disableAdditionalIdentifications, samlConnection.DisableAdditionalIdentifications)
 }
 
 func TestSAMLConnectionClientUpdate_Error(t *testing.T) {


### PR DESCRIPTION
This PR adds a new field for the SAML connection struct called `disable_additional_identifiers`. It also updates the PATCH to accept this field 