### PR TITLE
feat: add role_name field for organization invitation and membership

### DIFF
--- a/organization_invitation.go
+++ b/organization_invitation.go
@@ -16,6 +16,7 @@ type OrganizationInvitation struct {
 	ID                     string                  `json:"id"`
 	EmailAddress           string                  `json:"email_address"`
 	Role                   string                  `json:"role"`
+	RoleName               string                  `json:"role_name"`
 	OrganizationID         string                  `json:"organization_id"`
 	PublicOrganizationData *PublicOrganizationData `json:"public_organization_data,omitempty"`
 	Status                 string                  `json:"status"`

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -11,6 +11,7 @@ type OrganizationMembership struct {
 	PublicMetadata  json.RawMessage                       `json:"public_metadata"`
 	PrivateMetadata json.RawMessage                       `json:"private_metadata"`
 	Role            string                                `json:"role"`
+	RoleName        string                                `json:"role_name"`
 	CreatedAt       int64                                 `json:"created_at"`
 	UpdatedAt       int64                                 `json:"updated_at"`
 	PublicUserData  *OrganizationMembershipPublicUserData `json:"public_user_data,omitempty"`

--- a/organizationinvitation/client_test.go
+++ b/organizationinvitation/client_test.go
@@ -131,7 +131,7 @@ func TestOrganizationInvitationClientGet(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"organization_invitation","email_address":"string","role":"string","organization_id":"%s","status":"string","public_metadata":{},"private_metadata":{},"created_at":0,"updated_at":0}`, id, organizationID)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"organization_invitation","email_address":"string","role":"string","role_name":"string","organization_id":"%s","status":"string","public_metadata":{},"private_metadata":{},"created_at":0,"updated_at":0}`, id, organizationID)),
 			Method: http.MethodGet,
 			Path:   "/v1/organizations/" + organizationID + "/invitations/" + id,
 		},
@@ -144,6 +144,8 @@ func TestOrganizationInvitationClientGet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, response.ID)
 	require.Equal(t, organizationID, response.OrganizationID)
+	require.Equal(t, "string", response.RoleName)
+	require.Equal(t, "string", response.Role)
 }
 
 func TestOrganizationInvitationClientGet_Error(t *testing.T) {

--- a/organizationmembership/client_test.go
+++ b/organizationmembership/client_test.go
@@ -176,7 +176,9 @@ func TestOrganizationMembershipClientList(t *testing.T) {
 "data": [{
 	"id":"%s",
 	"organization":{"id":"%s"},
-	"public_user_data":{"user_id":"%s"}
+	"public_user_data":{"user_id":"%s"},
+	"role": "string",
+	"role_name": "string"
 }],
 "total_count": 1
 }`,
@@ -204,4 +206,6 @@ func TestOrganizationMembershipClientList(t *testing.T) {
 	require.Equal(t, id, list.OrganizationMemberships[0].ID)
 	require.Equal(t, organizationID, list.OrganizationMemberships[0].Organization.ID)
 	require.Equal(t, userID, list.OrganizationMemberships[0].PublicUserData.UserID)
+	require.Equal(t, "string", list.OrganizationMemberships[0].RoleName)
+	require.Equal(t, "string", list.OrganizationMemberships[0].Role)
 }


### PR DESCRIPTION
This pull request updates the `organization_invitation` and `organization_membership` models to include the `role_name` field