### PR TITLE
feat: Support `include_has_members_with_elevated_permissions` for Backend API read/list organizations endpoints

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -4,21 +4,22 @@ import "encoding/json"
 
 type Organization struct {
 	APIResource
-	Object                  string          `json:"object"`
-	ID                      string          `json:"id"`
-	Name                    string          `json:"name"`
-	Slug                    string          `json:"slug"`
-	ImageURL                *string         `json:"image_url"`
-	HasImage                bool            `json:"has_image"`
-	MembersCount            *int64          `json:"members_count,omitempty"`
-	PendingInvitationsCount *int64          `json:"pending_invitations_count,omitempty"`
-	MaxAllowedMemberships   int64           `json:"max_allowed_memberships"`
-	AdminDeleteEnabled      bool            `json:"admin_delete_enabled"`
-	PublicMetadata          json.RawMessage `json:"public_metadata"`
-	PrivateMetadata         json.RawMessage `json:"private_metadata"`
-	CreatedBy               string          `json:"created_by"`
-	CreatedAt               int64           `json:"created_at"`
-	UpdatedAt               int64           `json:"updated_at"`
+	Object                           string          `json:"object"`
+	ID                               string          `json:"id"`
+	Name                             string          `json:"name"`
+	Slug                             string          `json:"slug"`
+	ImageURL                         *string         `json:"image_url"`
+	HasImage                         bool            `json:"has_image"`
+	MembersCount                     *int64          `json:"members_count,omitempty"`
+	HasMemberWithElevatedPermissions *bool           `json:"has_member_with_elevated_permissions,omitempty"`
+	PendingInvitationsCount          *int64          `json:"pending_invitations_count,omitempty"`
+	MaxAllowedMemberships            int64           `json:"max_allowed_memberships"`
+	AdminDeleteEnabled               bool            `json:"admin_delete_enabled"`
+	PublicMetadata                   json.RawMessage `json:"public_metadata"`
+	PrivateMetadata                  json.RawMessage `json:"private_metadata"`
+	CreatedBy                        string          `json:"created_by"`
+	CreatedAt                        int64           `json:"created_at"`
+	UpdatedAt                        int64           `json:"updated_at"`
 }
 
 type OrganizationList struct {

--- a/organization/api.go
+++ b/organization/api.go
@@ -15,8 +15,8 @@ func Create(ctx context.Context, params *CreateParams) (*clerk.Organization, err
 
 // Get retrieves details for an organization.
 // The organization can be fetched by either the ID or its slug.
-func Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
-	return getClient().Get(ctx, idOrSlug)
+func Get(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
+	return getClient().Get(ctx, idOrSlug, params)
 }
 
 // Update updates an organization.

--- a/organization/client.go
+++ b/organization/client.go
@@ -48,14 +48,32 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.Organ
 	return organization, err
 }
 
+type GetParams struct {
+	clerk.APIParams
+	IncludeMembersCount                     *bool `json:"include_members_count,omitempty"`
+	IncludeHasMemberWithElevatedPermissions *bool `json:"include_has_member_with_elevated_permissions,omitempty"`
+}
+
+func (params *GetParams) ToQuery() url.Values {
+	q := url.Values{}
+	if params.IncludeMembersCount != nil {
+		q.Set("include_members_count", strconv.FormatBool(*params.IncludeMembersCount))
+	}
+	if params.IncludeHasMemberWithElevatedPermissions != nil {
+		q.Set("include_has_member_with_elevated_permissions", strconv.FormatBool(*params.IncludeHasMemberWithElevatedPermissions))
+	}
+	return q
+}
+
 // Get retrieves details for an organization.
 // The organization can be fetched by either the ID or its slug.
-func (c *Client) Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
+func (c *Client) Get(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
 	path, err := clerk.JoinPath(path, idOrSlug)
 	if err != nil {
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodGet, path)
+	req.SetParams(params)
 	organization := &clerk.Organization{}
 	err = c.Backend.Call(ctx, req, organization)
 	return organization, err
@@ -185,10 +203,11 @@ func (c *Client) DeleteLogo(ctx context.Context, id string) (*clerk.Organization
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	IncludeMembersCount *bool    `json:"include_members_count,omitempty"`
-	OrderBy             *string  `json:"order_by,omitempty"`
-	Query               *string  `json:"query,omitempty"`
-	UserIDs             []string `json:"user_id,omitempty"`
+	IncludeMembersCount                     *bool    `json:"include_members_count,omitempty"`
+	IncludeHasMemberWithElevatedPermissions *bool    `json:"include_has_member_with_elevated_permissions,omitempty"`
+	OrderBy                                 *string  `json:"order_by,omitempty"`
+	Query                                   *string  `json:"query,omitempty"`
+	UserIDs                                 []string `json:"user_id,omitempty"`
 }
 
 // ToQuery returns query string values from the params.
@@ -196,6 +215,9 @@ func (params *ListParams) ToQuery() url.Values {
 	q := params.ListParams.ToQuery()
 	if params.IncludeMembersCount != nil {
 		q.Set("include_members_count", strconv.FormatBool(*params.IncludeMembersCount))
+	}
+	if params.IncludeHasMemberWithElevatedPermissions != nil {
+		q.Set("include_has_member_with_elevated_permissions", strconv.FormatBool(*params.IncludeHasMemberWithElevatedPermissions))
 	}
 	if params.OrderBy != nil {
 		q.Set("order_by", *params.OrderBy)

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -66,20 +66,40 @@ func TestOrganizationClientGet(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
 	name := "Acme Inc"
+	membersCount := int64(1)
+	hasMemberWithElevatedPermissions := true
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
-			T:      t,
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s"}`, id, name)),
+			T: t,
+			Out: json.RawMessage(fmt.Sprintf(
+				`{"id":"%s","name":"%s","members_count":%d,"has_member_with_elevated_permissions":%t}`,
+				id,
+				name,
+				membersCount,
+				hasMemberWithElevatedPermissions,
+			)),
 			Method: http.MethodGet,
 			Path:   "/v1/organizations/" + id,
+			Query: &url.Values{
+				"include_members_count":                        []string{"true"},
+				"include_has_member_with_elevated_permissions": []string{"true"},
+			},
 		},
 	}
+	params := &GetParams{
+		IncludeMembersCount:                     clerk.Bool(true),
+		IncludeHasMemberWithElevatedPermissions: clerk.Bool(true),
+	}
 	client := NewClient(config)
-	organization, err := client.Get(context.Background(), id)
+	organization, err := client.Get(context.Background(), id, params)
 	require.NoError(t, err)
 	require.Equal(t, id, organization.ID)
 	require.Equal(t, name, organization.Name)
+	require.Equal(t, membersCount, *organization.MembersCount)
+	require.NotNil(t, organization.HasMemberWithElevatedPermissions)
+	require.Equal(t, hasMemberWithElevatedPermissions, *organization.HasMemberWithElevatedPermissions)
+
 }
 
 func TestOrganizationClientUpdate(t *testing.T) {
@@ -156,25 +176,29 @@ func TestOrganizationClientList(t *testing.T) {
 		Transport: &clerktest.RoundTripper{
 			T: t,
 			Out: json.RawMessage(`{
-"data": [{"id":"org_123","name":"Acme Inc"}],
+"data": [{"id":"org_123","name":"Acme Inc","members_count":1,"has_member_with_elevated_permissions":true}],
 "total_count": 1
 }`),
 			Method: http.MethodGet,
 			Path:   "/v1/organizations",
 			Query: &url.Values{
-				"limit":    []string{"1"},
-				"offset":   []string{"2"},
-				"order_by": []string{"-created_at"},
-				"query":    []string{"Acme"},
-				"user_id":  []string{"user_123", "user_456"},
+				"limit":                 []string{"1"},
+				"offset":                []string{"2"},
+				"order_by":              []string{"-created_at"},
+				"query":                 []string{"Acme"},
+				"user_id":               []string{"user_123", "user_456"},
+				"include_members_count": []string{"true"},
+				"include_has_member_with_elevated_permissions": []string{"true"},
 			},
 		},
 	}
 	client := NewClient(config)
 	params := &ListParams{
-		OrderBy: clerk.String("-created_at"),
-		Query:   clerk.String("Acme"),
-		UserIDs: []string{"user_123", "user_456"},
+		OrderBy:                                 clerk.String("-created_at"),
+		Query:                                   clerk.String("Acme"),
+		UserIDs:                                 []string{"user_123", "user_456"},
+		IncludeMembersCount:                     clerk.Bool(true),
+		IncludeHasMemberWithElevatedPermissions: clerk.Bool(true),
 	}
 	params.Limit = clerk.Int64(1)
 	params.Offset = clerk.Int64(2)
@@ -184,6 +208,10 @@ func TestOrganizationClientList(t *testing.T) {
 	require.Equal(t, 1, len(list.Organizations))
 	require.Equal(t, "org_123", list.Organizations[0].ID)
 	require.Equal(t, "Acme Inc", list.Organizations[0].Name)
+	require.NotNil(t, list.Organizations[0].MembersCount)
+	require.Equal(t, int64(1), *list.Organizations[0].MembersCount)
+	require.NotNil(t, *list.Organizations[0].HasMemberWithElevatedPermissions)
+	require.Equal(t, true, *list.Organizations[0].HasMemberWithElevatedPermissions)
 }
 
 type testFile struct {


### PR DESCRIPTION
Support new `include_has_member_with_elevated_permissions` parameter