### PR TITLE
Revert "feat: Support `include_has_members_with_elevated_permissions` for Backend API read/list organizations endpoints"

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -4,22 +4,21 @@ import "encoding/json"
 
 type Organization struct {
 	APIResource
-	Object                           string          `json:"object"`
-	ID                               string          `json:"id"`
-	Name                             string          `json:"name"`
-	Slug                             string          `json:"slug"`
-	ImageURL                         *string         `json:"image_url"`
-	HasImage                         bool            `json:"has_image"`
-	MembersCount                     *int64          `json:"members_count,omitempty"`
-	HasMemberWithElevatedPermissions *bool           `json:"has_member_with_elevated_permissions,omitempty"`
-	PendingInvitationsCount          *int64          `json:"pending_invitations_count,omitempty"`
-	MaxAllowedMemberships            int64           `json:"max_allowed_memberships"`
-	AdminDeleteEnabled               bool            `json:"admin_delete_enabled"`
-	PublicMetadata                   json.RawMessage `json:"public_metadata"`
-	PrivateMetadata                  json.RawMessage `json:"private_metadata"`
-	CreatedBy                        string          `json:"created_by"`
-	CreatedAt                        int64           `json:"created_at"`
-	UpdatedAt                        int64           `json:"updated_at"`
+	Object                  string          `json:"object"`
+	ID                      string          `json:"id"`
+	Name                    string          `json:"name"`
+	Slug                    string          `json:"slug"`
+	ImageURL                *string         `json:"image_url"`
+	HasImage                bool            `json:"has_image"`
+	MembersCount            *int64          `json:"members_count,omitempty"`
+	PendingInvitationsCount *int64          `json:"pending_invitations_count,omitempty"`
+	MaxAllowedMemberships   int64           `json:"max_allowed_memberships"`
+	AdminDeleteEnabled      bool            `json:"admin_delete_enabled"`
+	PublicMetadata          json.RawMessage `json:"public_metadata"`
+	PrivateMetadata         json.RawMessage `json:"private_metadata"`
+	CreatedBy               string          `json:"created_by"`
+	CreatedAt               int64           `json:"created_at"`
+	UpdatedAt               int64           `json:"updated_at"`
 }
 
 type OrganizationList struct {

--- a/organization/api.go
+++ b/organization/api.go
@@ -15,8 +15,8 @@ func Create(ctx context.Context, params *CreateParams) (*clerk.Organization, err
 
 // Get retrieves details for an organization.
 // The organization can be fetched by either the ID or its slug.
-func Get(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
-	return getClient().Get(ctx, idOrSlug, params)
+func Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
+	return getClient().Get(ctx, idOrSlug)
 }
 
 // Update updates an organization.

--- a/organization/client.go
+++ b/organization/client.go
@@ -48,32 +48,14 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.Organ
 	return organization, err
 }
 
-type GetParams struct {
-	clerk.APIParams
-	IncludeMembersCount                     *bool `json:"include_members_count,omitempty"`
-	IncludeHasMemberWithElevatedPermissions *bool `json:"include_has_member_with_elevated_permissions,omitempty"`
-}
-
-func (params *GetParams) ToQuery() url.Values {
-	q := url.Values{}
-	if params.IncludeMembersCount != nil {
-		q.Set("include_members_count", strconv.FormatBool(*params.IncludeMembersCount))
-	}
-	if params.IncludeHasMemberWithElevatedPermissions != nil {
-		q.Set("include_has_member_with_elevated_permissions", strconv.FormatBool(*params.IncludeHasMemberWithElevatedPermissions))
-	}
-	return q
-}
-
 // Get retrieves details for an organization.
 // The organization can be fetched by either the ID or its slug.
-func (c *Client) Get(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
+func (c *Client) Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
 	path, err := clerk.JoinPath(path, idOrSlug)
 	if err != nil {
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodGet, path)
-	req.SetParams(params)
 	organization := &clerk.Organization{}
 	err = c.Backend.Call(ctx, req, organization)
 	return organization, err
@@ -203,11 +185,10 @@ func (c *Client) DeleteLogo(ctx context.Context, id string) (*clerk.Organization
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	IncludeMembersCount                     *bool    `json:"include_members_count,omitempty"`
-	IncludeHasMemberWithElevatedPermissions *bool    `json:"include_has_member_with_elevated_permissions,omitempty"`
-	OrderBy                                 *string  `json:"order_by,omitempty"`
-	Query                                   *string  `json:"query,omitempty"`
-	UserIDs                                 []string `json:"user_id,omitempty"`
+	IncludeMembersCount *bool    `json:"include_members_count,omitempty"`
+	OrderBy             *string  `json:"order_by,omitempty"`
+	Query               *string  `json:"query,omitempty"`
+	UserIDs             []string `json:"user_id,omitempty"`
 }
 
 // ToQuery returns query string values from the params.
@@ -215,9 +196,6 @@ func (params *ListParams) ToQuery() url.Values {
 	q := params.ListParams.ToQuery()
 	if params.IncludeMembersCount != nil {
 		q.Set("include_members_count", strconv.FormatBool(*params.IncludeMembersCount))
-	}
-	if params.IncludeHasMemberWithElevatedPermissions != nil {
-		q.Set("include_has_member_with_elevated_permissions", strconv.FormatBool(*params.IncludeHasMemberWithElevatedPermissions))
 	}
 	if params.OrderBy != nil {
 		q.Set("order_by", *params.OrderBy)


### PR DESCRIPTION
Reverts clerk/clerk-sdk-go#341