### PR TITLE
feat: Support identifier-type-specific query parameters for Users List

### DIFF
--- a/user/client.go
+++ b/user/client.go
@@ -209,14 +209,17 @@ func (c *Client) Delete(ctx context.Context, id string) (*clerk.DeletedResource,
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	OrderBy        *string  `json:"order_by,omitempty"`
-	Query          *string  `json:"query,omitempty"`
-	EmailAddresses []string `json:"email_address,omitempty"`
-	ExternalIDs    []string `json:"external_id,omitempty"`
-	PhoneNumbers   []string `json:"phone_number,omitempty"`
-	Web3Wallets    []string `json:"web3_wallet,omitempty"`
-	Usernames      []string `json:"username,omitempty"`
-	UserIDs        []string `json:"user_id,omitempty"`
+	OrderBy           *string  `json:"order_by,omitempty"`
+	Query             *string  `json:"query,omitempty"`
+	EmailAddressQuery *string  `json:"email_address_query,omitempty"`
+	PhoneNumberQuery  *string  `json:"phone_number_query,omitempty"`
+	UsernameQuery     *string  `json:"username_query,omitempty"`
+	EmailAddresses    []string `json:"email_address,omitempty"`
+	ExternalIDs       []string `json:"external_id,omitempty"`
+	PhoneNumbers      []string `json:"phone_number,omitempty"`
+	Web3Wallets       []string `json:"web3_wallet,omitempty"`
+	Usernames         []string `json:"username,omitempty"`
+	UserIDs           []string `json:"user_id,omitempty"`
 	// OrganizationIDs filters users that have memberships to the given organizations. For each organization ID, the
 	// + and - can be prepended to the ID, which denote whether the respective organization should be included or
 	// excluded from the result set. Accepts up to 100 organization IDs.
@@ -232,6 +235,15 @@ func (params *ListParams) ToQuery() url.Values {
 	}
 	if params.Query != nil {
 		q.Add("query", *params.Query)
+	}
+	if params.EmailAddressQuery != nil {
+		q.Add("email_address_query", *params.EmailAddressQuery)
+	}
+	if params.PhoneNumberQuery != nil {
+		q.Add("phone_number_query", *params.PhoneNumberQuery)
+	}
+	if params.UsernameQuery != nil {
+		q.Add("username_query", *params.UsernameQuery)
 	}
 	for _, v := range params.EmailAddresses {
 		q.Add("email_address", v)

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -47,19 +47,21 @@ func TestUserClientList_Request(t *testing.T) {
 			T:      t,
 			Method: http.MethodGet,
 			Query: &url.Values{
-				"limit":           []string{"1"},
-				"offset":          []string{"2"},
-				"order_by":        []string{"-created_at"},
-				"email_address":   []string{"foo@bar.com", "baz@bar.com"},
-				"organization_id": []string{"org_123", "org_456"},
+				"limit":               []string{"1"},
+				"offset":              []string{"2"},
+				"order_by":            []string{"-created_at"},
+				"email_address":       []string{"foo@bar.com", "baz@bar.com"},
+				"organization_id":     []string{"org_123", "org_456"},
+				"email_address_query": []string{"@bar.com"},
 			},
 		},
 	}
 	client := NewClient(config)
 	params := &ListParams{
-		EmailAddresses:  []string{"foo@bar.com", "baz@bar.com"},
-		OrderBy:         clerk.String("-created_at"),
-		OrganizationIDs: []string{"org_123", "org_456"},
+		EmailAddresses:    []string{"foo@bar.com", "baz@bar.com"},
+		OrderBy:           clerk.String("-created_at"),
+		OrganizationIDs:   []string{"org_123", "org_456"},
+		EmailAddressQuery: clerk.String("@bar.com"),
 	}
 	params.Limit = clerk.Int64(1)
 	params.Offset = clerk.Int64(2)


### PR DESCRIPTION
Introduces three query parameters to the Users List call:
- `email_address_query`
- `username_query`
- `phone_number_query`

These parameters allow you to add in filter for a specific type of identifier, via a case insensitive substring match (e.g. `email_address_query=gmail.com`).