### PR TITLE
Set CreateOrganizationsLimit as an int32

### DIFF
--- a/user.go
+++ b/user.go
@@ -35,7 +35,7 @@ type User struct {
 	VerificationAttemptsRemaining *int64             `json:"verification_attempts_remaining"`
 	DeleteSelfEnabled             bool               `json:"delete_self_enabled"`
 	CreateOrganizationEnabled     bool               `json:"create_organization_enabled"`
-	CreateOrganizationsLimit      *int               `json:"create_organizations_limit,omitempty"`
+	CreateOrganizationsLimit      *int32             `json:"create_organizations_limit,omitempty"`
 	LastActiveAt                  *int64             `json:"last_active_at"`
 	LegalAcceptedAt               *int64             `json:"legal_accepted_at"`
 	CreatedAt                     int64              `json:"created_at"`

--- a/user/client.go
+++ b/user/client.go
@@ -101,7 +101,7 @@ type UpdateParams struct {
 	BackupCodes                      *[]string        `json:"backup_codes,omitempty"`
 	DeleteSelfEnabled                *bool            `json:"delete_self_enabled,omitempty"`
 	CreateOrganizationEnabled        *bool            `json:"create_organization_enabled,omitempty"`
-	CreateOrganizationsLimit         *int             `json:"create_organizations_limit,omitempty"`
+	CreateOrganizationsLimit         *int32           `json:"create_organizations_limit,omitempty"`
 	// Specified in RFC3339 format
 	LegalAcceptedAt *string `json:"legal_accepted_at,omitempty"`
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`


### PR DESCRIPTION
This value is stored as an int32 in its underlying datastore, so we want this to be restricted to an int32 so an overflow can be caught in request validation.