### PR TITLE
Adds support for fetching orgs with `include_members_count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for the OAuth Applications API. Added the oauthapplication package for API operations and a clerk.OAuthApplication type.
 - Add support for multiple invitation templates with the `TemplateSlug` field in `invitation.Create`.
 - Add support for listing and creating waitlist entries with the `waitlistentry.List` and `waitlistentry.Create` methods.
+- Add support for fetching an organization with its members count, via a new `organizations.GetWithParams` method.
 
 ## 2.2.0
 

--- a/organization/client.go
+++ b/organization/client.go
@@ -48,14 +48,34 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.Organ
 	return organization, err
 }
 
+type GetParams struct {
+	clerk.APIParams
+	IncludeMembersCount *bool `json:"include_members_count,omitempty"`
+}
+
+func (params *GetParams) ToQuery() url.Values {
+	q := url.Values{}
+	if params.IncludeMembersCount != nil {
+		q.Set("include_members_count", strconv.FormatBool(*params.IncludeMembersCount))
+	}
+	return q
+}
+
 // Get retrieves details for an organization.
 // The organization can be fetched by either the ID or its slug.
 func (c *Client) Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
+	return c.GetWithParams(ctx, idOrSlug, nil)
+}
+
+// GetWithParams retrieves details for an organization.
+// The organization can be fetched by either the ID or its slug.
+func (c *Client) GetWithParams(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
 	path, err := clerk.JoinPath(path, idOrSlug)
 	if err != nil {
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodGet, path)
+	req.SetParams(params)
 	organization := &clerk.Organization{}
 	err = c.Backend.Call(ctx, req, organization)
 	return organization, err

--- a/organization/client.go
+++ b/organization/client.go
@@ -64,7 +64,7 @@ func (params *GetParams) ToQuery() url.Values {
 // Get retrieves details for an organization.
 // The organization can be fetched by either the ID or its slug.
 func (c *Client) Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
-	return c.GetWithParams(ctx, idOrSlug, nil)
+	return c.GetWithParams(ctx, idOrSlug, &GetParams{})
 }
 
 // GetWithParams retrieves details for an organization.

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -82,6 +82,31 @@ func TestOrganizationClientGet(t *testing.T) {
 	require.Equal(t, name, organization.Name)
 }
 
+func TestOrganizationClientGetWithParams(t *testing.T) {
+	t.Parallel()
+	id := "org_123"
+	name := "Acme Inc"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s"}`, id, name)),
+			Method: http.MethodGet,
+			Path:   "/v1/organizations/" + id,
+			Query: &url.Values{
+				"include_members_count": []string{"true"},
+			},
+		},
+	}
+	client := NewClient(config)
+	organization, err := client.GetWithParams(context.Background(), id, &GetParams{
+		IncludeMembersCount: clerk.Bool(true),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, organization.ID)
+	require.Equal(t, name, organization.Name)
+}
+
 func TestOrganizationClientUpdate(t *testing.T) {
 	t.Parallel()
 	id := "org_123"


### PR DESCRIPTION
Adds support for [include_members_count](https://clerk.com/docs/reference/backend-api/tag/Organizations#operation/GetOrganization) when fetching an organization.

I had to introduce a separate function`GetWithParams` as to not introduce a breaking change. This is a good candidate to flatten to a single method for our next major.