### PR TITLE
[v3] Simplify fetching organizations to use a single function

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,7 +19,28 @@ there is no guarantee.
 
 ## 2.x.x to 3.x.x
 
-TODO
+### Fetching Organizations
+
+We have simplified fetching specific organizations to be done via single function:
+
+```diff
+import (
++	"github.com/clerk/clerk-sdk-go/v2/organization"
+-	"github.com/clerk/clerk-sdk-go/v3/organization"
+)
+
+type Service {
+    orgsClient  *organization.Client
+}
+
+func (s *Service) fetchOrgExample(idOrSlug string, includeMembersCount bool) {
+-   s.orgsClient.Get(ctx, idOrSlug)
++   s.orgsClient.Get(ctx, idOrSlug, &GetParams{})
+
+-   s.orgsClient.GetWithParams(ctx, idOrSlug, &organization.GetParams{IncludeMembersCount: &includeMembersCount})
++   s.orgsClient.Get(ctx, idOrSlug, &organization.GetParams{IncludeMembersCount: &includeMembersCount})
+}
+```
 
 ## 1.x.x to 2.x.x
 

--- a/organization/api.go
+++ b/organization/api.go
@@ -13,16 +13,10 @@ func Create(ctx context.Context, params *CreateParams) (*clerk.Organization, err
 	return getClient().Create(ctx, params)
 }
 
-// Get retrieves details for an organization.
-// The organization can be fetched by either the ID or its slug.
-func Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
-	return getClient().Get(ctx, idOrSlug)
-}
-
 // GetWithParams retrieves details for an organization.
 // The organization can be fetched by either the ID or its slug.
-func GetWithParams(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
-	return getClient().GetWithParams(ctx, idOrSlug, params)
+func Get(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
+	return getClient().Get(ctx, idOrSlug, params)
 }
 
 // Update updates an organization.

--- a/organization/client.go
+++ b/organization/client.go
@@ -61,15 +61,9 @@ func (params *GetParams) ToQuery() url.Values {
 	return q
 }
 
-// Get retrieves details for an organization.
-// The organization can be fetched by either the ID or its slug.
-func (c *Client) Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
-	return c.GetWithParams(ctx, idOrSlug, &GetParams{})
-}
-
 // GetWithParams retrieves details for an organization.
 // The organization can be fetched by either the ID or its slug.
-func (c *Client) GetWithParams(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
+func (c *Client) Get(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
 	path, err := clerk.JoinPath(path, idOrSlug)
 	if err != nil {
 		return nil, err

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -76,13 +76,13 @@ func TestOrganizationClientGet(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	organization, err := client.Get(context.Background(), id)
+	organization, err := client.Get(context.Background(), id, &GetParams{})
 	require.NoError(t, err)
 	require.Equal(t, id, organization.ID)
 	require.Equal(t, name, organization.Name)
 }
 
-func TestOrganizationClientGetWithParams(t *testing.T) {
+func TestOrganizationClientGet_WithParams(t *testing.T) {
 	t.Parallel()
 	id := "org_123"
 	name := "Acme Inc"
@@ -99,7 +99,7 @@ func TestOrganizationClientGetWithParams(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	organization, err := client.GetWithParams(context.Background(), id, &GetParams{
+	organization, err := client.Get(context.Background(), id, &GetParams{
 		IncludeMembersCount: clerk.Bool(true),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is for `v3` and will have no impact on our current SDK version.

In #362 we introduced a new function `GetWithParams`, as to not introduce a breaking change to our `Get` function by adding another parameter. In our next major (`v3`), we will introduce a breaking change here to simplify usage.

This PR also just will serve as a bit of an example of how we should introduce breaking changes to the next major.