### PR TITLE
Add missing user.CreateParams properties

### DIFF
--- a/user/client.go
+++ b/user/client.go
@@ -32,23 +32,26 @@ func NewClient(config *clerk.ClientConfig) *Client {
 
 type CreateParams struct {
 	clerk.APIParams
-	EmailAddresses          *[]string        `json:"email_address,omitempty"`
-	PhoneNumbers            *[]string        `json:"phone_number,omitempty"`
-	Web3Wallets             *[]string        `json:"web3_wallet,omitempty"`
-	Username                *string          `json:"username,omitempty"`
-	Password                *string          `json:"password,omitempty"`
-	FirstName               *string          `json:"first_name,omitempty"`
-	LastName                *string          `json:"last_name,omitempty"`
-	ExternalID              *string          `json:"external_id,omitempty"`
-	UnsafeMetadata          *json.RawMessage `json:"unsafe_metadata,omitempty"`
-	PublicMetadata          *json.RawMessage `json:"public_metadata,omitempty"`
-	PrivateMetadata         *json.RawMessage `json:"private_metadata,omitempty"`
-	PasswordDigest          *string          `json:"password_digest,omitempty"`
-	PasswordHasher          *string          `json:"password_hasher,omitempty"`
-	SkipPasswordRequirement *bool            `json:"skip_password_requirement,omitempty"`
-	SkipPasswordChecks      *bool            `json:"skip_password_checks,omitempty"`
-	TOTPSecret              *string          `json:"totp_secret,omitempty"`
-	BackupCodes             *[]string        `json:"backup_codes,omitempty"`
+	EmailAddresses            *[]string        `json:"email_address,omitempty"`
+	PhoneNumbers              *[]string        `json:"phone_number,omitempty"`
+	Web3Wallets               *[]string        `json:"web3_wallet,omitempty"`
+	Username                  *string          `json:"username,omitempty"`
+	Password                  *string          `json:"password,omitempty"`
+	FirstName                 *string          `json:"first_name,omitempty"`
+	LastName                  *string          `json:"last_name,omitempty"`
+	ExternalID                *string          `json:"external_id,omitempty"`
+	UnsafeMetadata            *json.RawMessage `json:"unsafe_metadata,omitempty"`
+	PublicMetadata            *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata           *json.RawMessage `json:"private_metadata,omitempty"`
+	PasswordDigest            *string          `json:"password_digest,omitempty"`
+	PasswordHasher            *string          `json:"password_hasher,omitempty"`
+	SkipPasswordRequirement   *bool            `json:"skip_password_requirement,omitempty"`
+	SkipPasswordChecks        *bool            `json:"skip_password_checks,omitempty"`
+	TOTPSecret                *string          `json:"totp_secret,omitempty"`
+	BackupCodes               *[]string        `json:"backup_codes,omitempty"`
+	DeleteSelfEnabled         *bool            `json:"delete_self_enabled,omitempty"`
+	CreateOrganizationEnabled *bool            `json:"create_organization_enabled,omitempty"`
+	CreateOrganizationsLimit  *int             `json:"create_organizations_limit,omitempty"`
 	// Specified in RFC3339 format
 	LegalAcceptedAt *string `json:"legal_accepted_at,omitempty"`
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`

--- a/user/client.go
+++ b/user/client.go
@@ -51,7 +51,7 @@ type CreateParams struct {
 	BackupCodes               *[]string        `json:"backup_codes,omitempty"`
 	DeleteSelfEnabled         *bool            `json:"delete_self_enabled,omitempty"`
 	CreateOrganizationEnabled *bool            `json:"create_organization_enabled,omitempty"`
-	CreateOrganizationsLimit  *int64             `json:"create_organizations_limit,omitempty"`
+	CreateOrganizationsLimit  *int             `json:"create_organizations_limit,omitempty"`
 	// Specified in RFC3339 format
 	LegalAcceptedAt *string `json:"legal_accepted_at,omitempty"`
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`

--- a/user/client.go
+++ b/user/client.go
@@ -51,7 +51,7 @@ type CreateParams struct {
 	BackupCodes               *[]string        `json:"backup_codes,omitempty"`
 	DeleteSelfEnabled         *bool            `json:"delete_self_enabled,omitempty"`
 	CreateOrganizationEnabled *bool            `json:"create_organization_enabled,omitempty"`
-	CreateOrganizationsLimit  *int             `json:"create_organizations_limit,omitempty"`
+	CreateOrganizationsLimit  *int64             `json:"create_organizations_limit,omitempty"`
 	// Specified in RFC3339 format
 	LegalAcceptedAt *string `json:"legal_accepted_at,omitempty"`
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`


### PR DESCRIPTION
The `user.CreateParams` struct was missing three (optional) properties which are supported by the [`CreateUser`](https://clerk.com/docs/reference/backend-api/tag/Users#operation/CreateUser) operation:

- `DeleteSelfEnabled`: https://clerk.com/docs/reference/backend-api/tag/Users#operation/CreateUser!path=delete_self_enabled&t=request
- `CreateOrganizationEnabled`: https://clerk.com/docs/reference/backend-api/tag/Users#operation/CreateUser!path=create_organization_enabled&t=request
- `CreateOrganizationsLimit`: https://clerk.com/docs/reference/backend-api/tag/Users#operation/CreateUser!path=create_organizations_limit&t=request

The `user.UpdateParams` struct already contains these properties.