### PR TITLE
fix!: Align OAuth Application specs with API

### DIFF
--- a/oauth_application.go
+++ b/oauth_application.go
@@ -2,21 +2,22 @@ package clerk
 
 type OAuthApplication struct {
 	APIResource
-	Object        string  `json:"object"`
-	ID            string  `json:"id"`
-	InstanceID    string  `json:"instance_id"`
-	Name          string  `json:"name"`
-	ClientID      string  `json:"client_id"`
-	Public        bool    `json:"public"`
-	Scopes        string  `json:"scopes"`
-	CallbackURL   string  `json:"callback_url"`
-	DiscoveryURL  string  `json:"discovery_url"`
-	AuthorizeURL  string  `json:"authorize_url"`
-	TokenFetchURL string  `json:"token_fetch_url"`
-	UserInfoURL   string  `json:"user_info_url"`
-	CreatedAt     int64   `json:"created_at"`
-	UpdatedAt     int64   `json:"updated_at"`
-	ClientSecret  *string `json:"client_secret,omitempty"`
+	Object                string  `json:"object"`
+	ID                    string  `json:"id"`
+	InstanceID            string  `json:"instance_id"`
+	Name                  string  `json:"name"`
+	ClientID              string  `json:"client_id"`
+	ClientSecret          *string `json:"client_secret,omitempty"`
+	Public                bool    `json:"public"`
+	Scopes                string  `json:"scopes"`
+	CallbackURL           string  `json:"callback_url"`
+	DiscoveryURL          string  `json:"discovery_url"`
+	AuthorizeURL          string  `json:"authorize_url"`
+	TokenFetchURL         string  `json:"token_fetch_url"`
+	UserInfoURL           string  `json:"user_info_url"`
+	TokenIntrospectionURL string  `json:"token_introspection_url"`
+	CreatedAt             int64   `json:"created_at"`
+	UpdatedAt             int64   `json:"updated_at"`
 }
 
 type OAuthApplicationList struct {

--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -55,10 +55,10 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*clerk.OAuthAppl
 
 type CreateParams struct {
 	clerk.APIParams
-	Name        string `json:"name"`
-	CallbackURL string `json:"callback_url"`
-	Scopes      string `json:"scopes"`
-	Public      bool   `json:"public"`
+	Name        string  `json:"name"`
+	CallbackURL *string `json:"callback_url,omitempty"`
+	Scopes      *string `json:"scopes,omitempty"`
+	Public      *bool   `json:"public,omitempty"`
 }
 
 // Create creates a new OAuth application with the given parameters.

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -36,9 +36,9 @@ func TestOAuthApplicationClientCreate(t *testing.T) {
 
 	params := &CreateParams{
 		Name:        name,
-		CallbackURL: callbackURL,
-		Scopes:      scopes,
-		Public:      public,
+		CallbackURL: clerk.String(callbackURL),
+		Scopes:      clerk.String(scopes),
+		Public:      clerk.Bool(public),
 	}
 	oauthApp, err := client.Create(context.Background(), params)
 	require.NoError(t, err)


### PR DESCRIPTION
In this commit we are making changes to the OAuth Application resource API. We are aligning the types of the Create operation, to optional, as the only required right now is the 'name' property Also we are exposing a new 'token_introspection_url' property as part of the response. Those are considered breaking changes, that's why they only affect the new major version (v3)