### PR TITLE
chore: Make CreateTOTP noop and mark as deprecated

### DIFF
--- a/organization/api.go
+++ b/organization/api.go
@@ -19,6 +19,12 @@ func Get(ctx context.Context, idOrSlug string) (*clerk.Organization, error) {
 	return getClient().Get(ctx, idOrSlug)
 }
 
+// GetWithParams retrieves details for an organization.
+// The organization can be fetched by either the ID or its slug.
+func GetWithParams(ctx context.Context, idOrSlug string, params *GetParams) (*clerk.Organization, error) {
+	return getClient().GetWithParams(ctx, idOrSlug, params)
+}
+
 // Update updates an organization.
 func Update(ctx context.Context, id string, params *UpdateParams) (*clerk.Organization, error) {
 	return getClient().Update(ctx, id, params)

--- a/user/api.go
+++ b/user/api.go
@@ -105,7 +105,9 @@ func DeleteWeb3Wallet(ctx context.Context, userID, identificationID string) (*cl
 	return getClient().DeleteWeb3Wallet(ctx, userID, identificationID)
 }
 
-// CreateTOTP creates a TOTP (Time-based One-Time Password) for the user.
+// Deprecated: CreateTOTP creates a TOTP (Time-based One-Time Password) for the user.
+// The endpoint used for this method has been removed, we kept the method for backwards compatibility,
+// and now it's a noop action.
 func CreateTOTP(ctx context.Context, userID string) (*clerk.TOTP, error) {
 	return getClient().CreateTOTP(ctx, userID)
 }

--- a/user/client.go
+++ b/user/client.go
@@ -527,16 +527,14 @@ func (c *Client) DeleteWeb3Wallet(ctx context.Context, userID, identificationID 
 	return resource, err
 }
 
-// CreateTOTP creates a TOTP (Time-based One-Time Password) for the user.
+// Deprecated: CreateTOTP creates a TOTP (Time-based One-Time Password) for the user.
+// The endpoint used for this method has been removed, we kept the method for backwards compatibility,
+// and now it's a noop action.
 func (c *Client) CreateTOTP(ctx context.Context, userID string) (*clerk.TOTP, error) {
-	path, err := clerk.JoinPath(path, userID, "/totp")
-	if err != nil {
-		return nil, err
+	resource := &clerk.TOTP{
+		Object: "totp",
 	}
-	req := clerk.NewAPIRequest(http.MethodPost, path)
-	resource := &clerk.TOTP{}
-	err = c.Backend.Call(ctx, req, resource)
-	return resource, err
+	return resource, nil
 }
 
 // DeleteTOTP deletes all the TOTPs from a given user.

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -526,9 +526,9 @@ func TestUserClientCreateTOTP(t *testing.T) {
 	client := NewClient(config)
 	totp, err := client.CreateTOTP(context.Background(), userID)
 	require.NoError(t, err)
-	require.NotNil(t, totp.ID)
-	require.NotNil(t, totp.Secret)
-	require.NotNil(t, totp.URI)
+	require.Empty(t, totp.ID)
+	require.Empty(t, totp.Secret)
+	require.Empty(t, totp.URI)
 	require.Equal(t, totp.Object, "totp")
 }
 


### PR DESCRIPTION
The endpoint used for `CreateTOTP` will be removed so this PR makes `CreateTOTP` a noop to avoid code level breaking changes and also marks it as deprecated as it will be removed completely in `v3`

Resolves USER-1109