### PR TITLE
feat: Support the 'public' property on the OAuth application update operation

### DIFF
--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -75,6 +75,7 @@ type UpdateParams struct {
 	Name        *string `json:"name,omitempty"`
 	CallbackURL *string `json:"callback_url,omitempty"`
 	Scopes      *string `json:"scopes,omitempty"`
+	Public      *bool   `json:"public,omitempty"`
 }
 
 // Update updates an existing OAuth application.

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -108,13 +108,14 @@ func TestOAuthApplicationClientUpdate(t *testing.T) {
 	id := "app_123"
 	updatedName := "Updated Application"
 	callbackURL := "https://updated.callback.url"
+	public := true
 
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","callback_url":"%s"}`, updatedName, callbackURL)),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","callback_url":"%s"}`, id, updatedName, callbackURL)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","callback_url":"%s", "public":%t}`, updatedName, callbackURL, public)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","callback_url":"%s","public":%t}`, id, updatedName, callbackURL, public)),
 			Method: http.MethodPatch,
 			Path:   fmt.Sprintf("/v1/oauth_applications/%s", id),
 		},
@@ -124,6 +125,7 @@ func TestOAuthApplicationClientUpdate(t *testing.T) {
 	params := &UpdateParams{
 		Name:        clerk.String(updatedName),
 		CallbackURL: clerk.String(callbackURL),
+		Public:      clerk.Bool(public),
 	}
 	oauthApp, err := client.Update(context.Background(), id, params)
 	require.NoError(t, err)


### PR DESCRIPTION
Instead of only making this available during the create operation, we now also support it as part of the update operation as well