### PR TITLE
feat: Support the OAuth application 'redirect_uris' property

### DIFF
--- a/oauth_application.go
+++ b/oauth_application.go
@@ -2,22 +2,25 @@ package clerk
 
 type OAuthApplication struct {
 	APIResource
-	Object                string  `json:"object"`
-	ID                    string  `json:"id"`
-	InstanceID            string  `json:"instance_id"`
-	Name                  string  `json:"name"`
-	ClientID              string  `json:"client_id"`
-	ClientSecret          *string `json:"client_secret,omitempty"`
-	Public                bool    `json:"public"`
-	Scopes                string  `json:"scopes"`
-	CallbackURL           string  `json:"callback_url"`
-	DiscoveryURL          string  `json:"discovery_url"`
-	AuthorizeURL          string  `json:"authorize_url"`
-	TokenFetchURL         string  `json:"token_fetch_url"`
-	UserInfoURL           string  `json:"user_info_url"`
-	TokenIntrospectionURL string  `json:"token_introspection_url"`
-	CreatedAt             int64   `json:"created_at"`
-	UpdatedAt             int64   `json:"updated_at"`
+	Object                string   `json:"object"`
+	ID                    string   `json:"id"`
+	InstanceID            string   `json:"instance_id"`
+	Name                  string   `json:"name"`
+	ClientID              string   `json:"client_id"`
+	ClientSecret          *string  `json:"client_secret,omitempty"`
+	Public                bool     `json:"public"`
+	Scopes                string   `json:"scopes"`
+	RedirectURIs          []string `json:"redirect_uris"`
+	DiscoveryURL          string   `json:"discovery_url"`
+	AuthorizeURL          string   `json:"authorize_url"`
+	TokenFetchURL         string   `json:"token_fetch_url"`
+	UserInfoURL           string   `json:"user_info_url"`
+	TokenIntrospectionURL string   `json:"token_introspection_url"`
+	CreatedAt             int64    `json:"created_at"`
+	UpdatedAt             int64    `json:"updated_at"`
+
+	// Deprecated: Use RedirectURIs instead
+	CallbackURL string `json:"callback_url"`
 }
 
 type OAuthApplicationList struct {

--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -55,10 +55,13 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*clerk.OAuthAppl
 
 type CreateParams struct {
 	clerk.APIParams
-	Name        string  `json:"name"`
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirect_uris,omitempty"`
+	Scopes       *string  `json:"scopes,omitempty"`
+	Public       *bool    `json:"public,omitempty"`
+
+	// Deprecated: Use RedirectURIs instead
 	CallbackURL *string `json:"callback_url,omitempty"`
-	Scopes      *string `json:"scopes,omitempty"`
-	Public      *bool   `json:"public,omitempty"`
 }
 
 // Create creates a new OAuth application with the given parameters.
@@ -72,10 +75,13 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.OAuth
 
 type UpdateParams struct {
 	clerk.APIParams
-	Name        *string `json:"name,omitempty"`
+	Name         *string  `json:"name,omitempty"`
+	RedirectURIs []string `json:"redirect_uris,omitempty"`
+	Scopes       *string  `json:"scopes,omitempty"`
+	Public       *bool    `json:"public,omitempty"`
+
+	// Deprecated: Use RedirectURIs instead
 	CallbackURL *string `json:"callback_url,omitempty"`
-	Scopes      *string `json:"scopes,omitempty"`
-	Public      *bool   `json:"public,omitempty"`
 }
 
 // Update updates an existing OAuth application.


### PR DESCRIPTION
We enhance the OAuth application response with the new property 'redirect_uris' that will replace the existing 'callback_url', which is now marked as deprecated. Also we support passing the new property during the create and update operations