### PR TITLE
feat: Add `DisableInvitations` on organization instance settings

### DIFF
--- a/instance_settings.go
+++ b/instance_settings.go
@@ -22,4 +22,5 @@ type OrganizationSettings struct {
 	DomainsEnabled         bool     `json:"domains_enabled"`
 	DomainsEnrollmentModes []string `json:"domains_enrollment_modes"`
 	DomainsDefaultRole     string   `json:"domains_default_role"`
+	DisableInvitations     bool     `json:"disable_invitations"`
 }

--- a/instancesettings/client.go
+++ b/instancesettings/client.go
@@ -108,6 +108,7 @@ type UpdateOrganizationSettingsParams struct {
 	DomainsEnabled         *bool     `json:"domains_enabled,omitempty"`
 	DomainsEnrollmentModes *[]string `json:"domains_enrollment_modes,omitempty"`
 	DomainsDefaultRoleID   *string   `json:"domains_default_role_id,omitempty"`
+	DisableInvitations     bool      `json:"disable_invitations"`
 }
 
 // UpdateOrganizationSettings updates the organization settings of the instance.


### PR DESCRIPTION
## What changed?

We're introducing a new property on organization settings to disable invitations via fapi if the application is in restricted or waitlist mode, and this introduces it in the SDK!

## Where are the tests?

It doesn't look like we have property-level test coverage for org settings yet, and the test coverage of this is solid in our internal use of this client, so i'm not worried about it.


