### PR TITLE
feat: Add support for session reverification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for multiple invitation templates with the `TemplateSlug` field in `invitation.Create`.
 - Add support for listing and creating waitlist entries with the `waitlistentry.List` and `waitlistentry.Create` methods.
 - Add support for fetching an organization with its members count, via a new `organizations.GetWithParams` method.
+- Add support for session reverification with `SessionClaims.NeedsReverification()`, `SessionReverificationPolicy`, predefined policies like `SessionReverificationStrict`, and middleware via `http.NeedsSessionReverification()`.
 
 ## 2.2.0
 

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -362,3 +362,22 @@ func getCache() *jwkCache {
 	})
 	return cache
 }
+
+func NeedsSessionReverification(policy clerk.SessionReverificationPolicy) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims, ok := clerk.SessionClaimsFromContext(r.Context())
+			if !ok || claims == nil {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+
+			if claims.NeedsReverification(policy) {
+				WriteNeedsReverificationResponse(w, policy)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -365,7 +366,7 @@ func TestNeedsSessionReverification(t *testing.T) {
 				})
 			}
 
-			// This is the user's server, guarded by Clerk's middleware.
+			// This is the user's server, using the NeedsSessionReverification middleware.
 			ts := httptest.NewServer(includeSessionClaims(NeedsSessionReverification(tc.policy)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, err := w.Write([]byte("{}"))
 				require.NoError(t, err)
@@ -382,6 +383,16 @@ func TestNeedsSessionReverification(t *testing.T) {
 
 			// Verify the response status
 			require.Equal(t, tc.expectedStatus, resp.StatusCode)
+
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+
+			// Verify the error response has the expected structure and reason
+			var errResp ClerkErrorResponse
+			err = json.NewDecoder(resp.Body).Decode(&errResp)
+			require.NoError(t, err)
+			require.Equal(t, "reverification-error", errResp.ClerkError.Reason)
 		})
 	}
 }

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -347,9 +347,9 @@ func TestNeedsSessionReverification(t *testing.T) {
 			expectedStatus: http.StatusForbidden,
 		},
 		{
-			name:           "using predefined policy - very strict",
+			name:           "using predefined policy",
 			factorAges:     [2]int64{15, 15},
-			policy:         clerk.SessionReverificationVeryStrict,
+			policy:         clerk.SessionReverificationStrictMFA,
 			expectedStatus: http.StatusForbidden,
 		},
 	} {

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -283,3 +283,105 @@ func TestAuthorizationJWTExtractor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusForbidden, res.StatusCode)
 }
+
+func TestNeedsSessionReverification(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		factorAges     [2]int64
+		policy         clerk.SessionReverificationPolicy
+		expectedStatus int
+	}{
+		{
+			name:       "first factor - valid",
+			factorAges: [2]int64{5, -1},
+			policy: clerk.SessionReverificationPolicy{
+				AfterMinutes: 10,
+				Level:        clerk.SessionReverificationLevelFirstFactor,
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:       "first factor - needs reverification",
+			factorAges: [2]int64{15, -1},
+			policy: clerk.SessionReverificationPolicy{
+				AfterMinutes: 10,
+				Level:        clerk.SessionReverificationLevelFirstFactor,
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:       "second factor - valid",
+			factorAges: [2]int64{20, 5},
+			policy: clerk.SessionReverificationPolicy{
+				AfterMinutes: 10,
+				Level:        clerk.SessionReverificationLevelSecondFactor,
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:       "second factor - needs reverification",
+			factorAges: [2]int64{20, 15},
+			policy: clerk.SessionReverificationPolicy{
+				AfterMinutes: 10,
+				Level:        clerk.SessionReverificationLevelSecondFactor,
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:       "multi factor - valid",
+			factorAges: [2]int64{5, -1},
+			policy: clerk.SessionReverificationPolicy{
+				AfterMinutes: 10,
+				Level:        clerk.SessionReverificationLevelSecondFactor,
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:       "multi factor - needs reverification",
+			factorAges: [2]int64{5, 15},
+			policy: clerk.SessionReverificationPolicy{
+				AfterMinutes: 10,
+				Level:        clerk.SessionReverificationLevelMultiFactor,
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			name:           "using predefined policy - very strict",
+			factorAges:     [2]int64{15, 15},
+			policy:         clerk.SessionReverificationVeryStrict,
+			expectedStatus: http.StatusForbidden,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			includeSessionClaims := func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					claims := &clerk.SessionClaims{
+						Claims: clerk.Claims{
+							FactorVerificationAge: tc.factorAges,
+						},
+					}
+					ctx := clerk.ContextWithSessionClaims(r.Context(), claims)
+					next.ServeHTTP(w, r.WithContext(ctx))
+				})
+			}
+
+			// This is the user's server, guarded by Clerk's middleware.
+			ts := httptest.NewServer(includeSessionClaims(NeedsSessionReverification(tc.policy)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte("{}"))
+				require.NoError(t, err)
+			}))))
+			defer ts.Close()
+
+			req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+			require.NoError(t, err)
+
+			// Send the request
+			resp, err := ts.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			// Verify the response status
+			require.Equal(t, tc.expectedStatus, resp.StatusCode)
+		})
+	}
+}

--- a/http/response.go
+++ b/http/response.go
@@ -1,0 +1,37 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/clerk/clerk-sdk-go/v2"
+)
+
+type ErrorPayload struct {
+	Type     string         `json:"type"`
+	Reason   string         `json:"reason"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+type ClerkErrorResponse struct {
+	ClerkError ErrorPayload `json:"clerk_error"`
+}
+
+func NewSessionReverificationErrorPayload(missingConfig clerk.SessionReverificationPolicy) ClerkErrorResponse {
+	return ClerkErrorResponse{
+		ClerkError: ErrorPayload{
+			Type:   "forbidden",
+			Reason: "reverification-error",
+			Metadata: map[string]any{
+				"reverification": missingConfig,
+			},
+		},
+	}
+}
+
+func WriteNeedsReverificationResponse(w http.ResponseWriter, missingConfig clerk.SessionReverificationPolicy) {
+	payload := NewSessionReverificationErrorPayload(missingConfig)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/jwt.go
+++ b/jwt.go
@@ -69,6 +69,34 @@ func (s *SessionClaims) HasRole(role string) bool {
 	return s.ActiveOrganizationRole == role
 }
 
+// NeedsReverification checks if a session needs to be reverified based on the
+// provided policy.
+func (s *SessionClaims) NeedsReverification(policy SessionReverificationPolicy) bool {
+	firstFactorAgeMinutes, secondFactorAgeMinutes := s.FactorVerificationAge[0], s.FactorVerificationAge[1]
+
+	firstFactorNeedsReverification := policy.AfterMinutes < firstFactorAgeMinutes
+	isSecondFactorEnabled := secondFactorAgeMinutes != -1
+	secondFactorNeedsReverification := isSecondFactorEnabled &&
+		policy.AfterMinutes < secondFactorAgeMinutes
+
+	switch policy.Level {
+	case SessionReverificationLevelFirstFactor:
+		return firstFactorNeedsReverification
+	case SessionReverificationLevelSecondFactor:
+		if !isSecondFactorEnabled {
+			return firstFactorNeedsReverification
+		}
+		return secondFactorNeedsReverification
+	case SessionReverificationLevelMultiFactor:
+		if !isSecondFactorEnabled {
+			return firstFactorNeedsReverification
+		}
+		return firstFactorNeedsReverification || secondFactorNeedsReverification
+	default:
+		return true
+	}
+}
+
 // RegisteredClaims holds public claim values (as specified in RFC 7519).
 type RegisteredClaims struct {
 	Issuer    string   `json:"iss,omitempty"`
@@ -123,6 +151,7 @@ type Claims struct {
 	ActiveOrganizationRole        string          `json:"org_role"`
 	ActiveOrganizationPermissions []string        `json:"org_permissions"`
 	Actor                         json.RawMessage `json:"act,omitempty"`
+	FactorVerificationAge         [2]int64        `json:"fva"`
 }
 
 // UnverifiedToken holds the result of a JWT decoding without any

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -146,6 +146,7 @@ func TestVerify_PublicClaims(t *testing.T) {
 		"org_role":        "org:admin",
 		"org_permissions": []string{"org:create"},
 		"org_slug":        "acmeinc",
+		"fva":             [2]int64{10, -1},
 		"sid":             "sess_123",
 		"sub":             "user_123",
 		"iss":             "https://clerk.com",
@@ -171,6 +172,8 @@ func TestVerify_PublicClaims(t *testing.T) {
 	require.Equal(t, 1, len(claims.ActiveOrganizationPermissions))
 	require.Equal(t, "org:create", claims.ActiveOrganizationPermissions[0])
 	require.NotNil(t, claims.NotBefore)
+	require.Equal(t, int64(10), claims.FactorVerificationAge[0])
+	require.Equal(t, int64(-1), claims.FactorVerificationAge[1])
 }
 
 // TestVerify_TimeValues tests that Verify validates that the token's

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -58,3 +58,127 @@ func TestSessionClaimsHasPermission(t *testing.T) {
 		require.Equal(t, claims.HasPermission(tc.permission), tc.want)
 	}
 }
+
+func TestNeedsReverification(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		factorAges     [2]int64
+		policyLevel    SessionReverificationLevel
+		policyMinutes  int64
+		expectedResult bool
+	}{
+		// FirstFactor
+		{
+			name:           "first factor - both valid",
+			factorAges:     [2]int64{5, -1},
+			policyLevel:    SessionReverificationLevelFirstFactor,
+			policyMinutes:  10,
+			expectedResult: false,
+		},
+		{
+			name:           "first factor - exactly at the threshold",
+			factorAges:     [2]int64{10, -1},
+			policyLevel:    SessionReverificationLevelFirstFactor,
+			policyMinutes:  10,
+			expectedResult: false,
+		},
+		{
+			name:           "first factor needs reverification",
+			factorAges:     [2]int64{15, -1},
+			policyLevel:    SessionReverificationLevelFirstFactor,
+			policyMinutes:  10,
+			expectedResult: true,
+		},
+
+		// SecondFactor
+		{
+			name:           "second factor both valid",
+			factorAges:     [2]int64{5, 5},
+			policyLevel:    SessionReverificationLevelSecondFactor,
+			policyMinutes:  10,
+			expectedResult: false,
+		},
+		{
+			name:           "second factor needs reverification",
+			factorAges:     [2]int64{5, 15},
+			policyLevel:    SessionReverificationLevelSecondFactor,
+			policyMinutes:  10,
+			expectedResult: true,
+		},
+		{
+			name:           "second factor valid, but first not",
+			factorAges:     [2]int64{15, 0},
+			policyLevel:    SessionReverificationLevelSecondFactor,
+			policyMinutes:  10,
+			expectedResult: false,
+		},
+		{
+			name:           "second factor not enabled",
+			factorAges:     [2]int64{15, -1},
+			policyLevel:    SessionReverificationLevelSecondFactor,
+			policyMinutes:  10,
+			expectedResult: true,
+		},
+
+		// MultiFactor
+		{
+			name:           "multi factor - both valid",
+			factorAges:     [2]int64{5, 5},
+			policyLevel:    SessionReverificationLevelMultiFactor,
+			policyMinutes:  10,
+			expectedResult: false,
+		},
+		{
+			name:           "multi factor - first needs reverification, second valid",
+			factorAges:     [2]int64{15, 5},
+			policyLevel:    SessionReverificationLevelMultiFactor,
+			policyMinutes:  10,
+			expectedResult: true,
+		},
+		{
+			name:           "multi factor - first valid, second needs reverification",
+			factorAges:     [2]int64{5, 15},
+			policyLevel:    SessionReverificationLevelMultiFactor,
+			policyMinutes:  10,
+			expectedResult: true,
+		},
+		{
+			name:           "multi factor - both need reverification",
+			factorAges:     [2]int64{15, 15},
+			policyLevel:    SessionReverificationLevelMultiFactor,
+			policyMinutes:  10,
+			expectedResult: true,
+		},
+		{
+			name:           "multi factor - second not enabled",
+			factorAges:     [2]int64{5, -1},
+			policyLevel:    SessionReverificationLevelMultiFactor,
+			policyMinutes:  10,
+			expectedResult: false,
+		},
+
+		// Edge cases
+		{
+			name:           "invalid policy level",
+			factorAges:     [2]int64{5, 5},
+			policyLevel:    SessionReverificationLevel("InvalidLevel"),
+			policyMinutes:  10,
+			expectedResult: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionClaims := &SessionClaims{
+				Claims: Claims{
+					FactorVerificationAge: tc.factorAges,
+				},
+			}
+			policy := SessionReverificationPolicy{
+				Level:        tc.policyLevel,
+				AfterMinutes: tc.policyMinutes,
+			}
+
+			result := sessionClaims.NeedsReverification(policy)
+			require.Equal(t, tc.expectedResult, result)
+		})
+	}
+}

--- a/session_reverification.go
+++ b/session_reverification.go
@@ -1,0 +1,47 @@
+package clerk
+
+type SessionReverificationLevel string
+
+const (
+	// SessionReverificationLevelFirstFactor uses first factor methods
+	// e.g. email/phone code, password
+	SessionReverificationLevelFirstFactor SessionReverificationLevel = "first_factor"
+
+	// SessionReverificationLevelSecondFactor uses second factor methods, if available
+	// e.g. authenticator app, backup code
+	SessionReverificationLevelSecondFactor SessionReverificationLevel = "second_factor"
+
+	// SessionReverificationLevelMultiFactor requires both first and second factor
+	// methods, if available
+	SessionReverificationLevelMultiFactor SessionReverificationLevel = "multi_factor"
+)
+
+type SessionReverificationPolicy struct {
+	// AfterMinutes is the session age threshold before reverification
+	AfterMinutes int64
+
+	// Level specifies which verification factors are required
+	Level SessionReverificationLevel
+}
+
+var (
+	SessionReverificationVeryStrict = SessionReverificationPolicy{
+		AfterMinutes: 10,
+		Level:        SessionReverificationLevelMultiFactor,
+	}
+
+	SessionReverificationStrict = SessionReverificationPolicy{
+		AfterMinutes: 10,
+		Level:        SessionReverificationLevelSecondFactor,
+	}
+
+	SessionReverificationModerate = SessionReverificationPolicy{
+		AfterMinutes: 60,
+		Level:        SessionReverificationLevelSecondFactor,
+	}
+
+	SessionReverificationLax = SessionReverificationPolicy{
+		AfterMinutes: 1_440,
+		Level:        SessionReverificationLevelSecondFactor,
+	}
+)

--- a/session_reverification.go
+++ b/session_reverification.go
@@ -25,7 +25,7 @@ type SessionReverificationPolicy struct {
 }
 
 var (
-	SessionReverificationVeryStrict = SessionReverificationPolicy{
+	SessionReverificationStrictMFA = SessionReverificationPolicy{
 		AfterMinutes: 10,
 		Level:        SessionReverificationLevelMultiFactor,
 	}


### PR DESCRIPTION
This PR adds Go helpers and middleware for session reverification. This allows to do checks based on the factor ages and triggering reverification when needed.