### PR TITLE
feat(client/UpdateOrganizationSettings): introduce new field `force_organization_selection`

### DIFF
--- a/instancesettings/client.go
+++ b/instancesettings/client.go
@@ -108,6 +108,9 @@ type UpdateOrganizationSettingsParams struct {
 	DomainsEnabled         *bool     `json:"domains_enabled,omitempty"`
 	DomainsEnrollmentModes *[]string `json:"domains_enrollment_modes,omitempty"`
 	DomainsDefaultRoleID   *string   `json:"domains_default_role_id,omitempty"`
+	// This feature is currently in beta and is not yet available for all instances.
+	// do not use this feature in production.
+	ForceOrganizationSelection *bool `json:"force_organization_selection,omitempty"`
 }
 
 // UpdateOrganizationSettings updates the organization settings of the instance.

--- a/instancesettings/client_test.go
+++ b/instancesettings/client_test.go
@@ -107,7 +107,7 @@ func TestInstanceClientUpdateOrganizationSettings(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(`{"enabled":true}`),
+			In:     json.RawMessage(`{"enabled":true,"force_organization_selection": true}`),
 			Out:    json.RawMessage(`{"enabled":true,"max_allowed_memberships":3}`),
 			Method: http.MethodPatch,
 			Path:   "/v1/instance/organization_settings",
@@ -115,7 +115,8 @@ func TestInstanceClientUpdateOrganizationSettings(t *testing.T) {
 	}
 	client := NewClient(config)
 	orgSettings, err := client.UpdateOrganizationSettings(context.Background(), &UpdateOrganizationSettingsParams{
-		Enabled: clerk.Bool(true),
+		Enabled:                    clerk.Bool(true),
+		ForceOrganizationSelection: clerk.Bool(true),
 	})
 	require.NoError(t, err)
 	require.True(t, orgSettings.Enabled)


### PR DESCRIPTION
Introduces a new field `force_organization_selection` on the update organization settings method for `/v1/instance/organization_settings`.

> [!WARNING]
> This feature is not yet available, do not use in production.

### What's next?
Backport to `v2`
