### PR TITLE
feat: Adds support for `order_by` param to Oauth Applications

### DIFF
--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -38,10 +38,17 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.OAuthApplication, e
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
+	OrderBy *string `json:"order_by,omitempty"`
 }
 
 func (params *ListParams) ToQuery() url.Values {
-	return params.ListParams.ToQuery()
+	q := params.ListParams.ToQuery()
+
+	if params.OrderBy != nil {
+		q.Set("order_by", *params.OrderBy)
+	}
+
+	return q
 }
 
 // List retrieves all OAuth applications.

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -196,8 +196,9 @@ func TestOAuthApplicationClientList(t *testing.T) {
 			Method: http.MethodGet,
 			Path:   "/v1/oauth_applications",
 			Query: &url.Values{
-				"limit":  []string{"10"},
-				"offset": []string{"0"},
+				"limit":    []string{"10"},
+				"offset":   []string{"0"},
+				"order_by": []string{"-name"},
 			},
 		},
 	}
@@ -205,6 +206,7 @@ func TestOAuthApplicationClientList(t *testing.T) {
 	params := &ListParams{}
 	params.Limit = clerk.Int64(10)
 	params.Offset = clerk.Int64(0)
+	params.OrderBy = clerk.String("-name")
 	appList, err := client.List(context.Background(), params)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), appList.TotalCount)


### PR DESCRIPTION
This adds support for an `order_by` param when listing OAuth Applications for when the backend API supports sorting them.