### PR TITLE
feat: Adds support for `name_query` param to Oauth Applications 

### DIFF
--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -38,7 +38,8 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.OAuthApplication, e
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	OrderBy *string `json:"order_by,omitempty"`
+	OrderBy   *string `json:"order_by,omitempty"`
+	NameQuery *string `json:"name_query,omitempty"`
 }
 
 func (params *ListParams) ToQuery() url.Values {
@@ -46,6 +47,10 @@ func (params *ListParams) ToQuery() url.Values {
 
 	if params.OrderBy != nil {
 		q.Set("order_by", *params.OrderBy)
+	}
+
+	if params.NameQuery != nil {
+		q.Set("name_query", *params.NameQuery)
 	}
 
 	return q

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -200,9 +200,10 @@ func TestOAuthApplicationClientList(t *testing.T) {
 			Method: http.MethodGet,
 			Path:   "/v1/oauth_applications",
 			Query: &url.Values{
-				"limit":    []string{"10"},
-				"offset":   []string{"0"},
-				"order_by": []string{"-name"},
+				"limit":      []string{"10"},
+				"offset":     []string{"0"},
+				"order_by":   []string{"-name"},
+				"name_query": []string{"app_123"},
 			},
 		},
 	}
@@ -211,6 +212,7 @@ func TestOAuthApplicationClientList(t *testing.T) {
 	params.Limit = clerk.Int64(10)
 	params.Offset = clerk.Int64(0)
 	params.OrderBy = clerk.String("-name")
+	params.NameQuery = clerk.String("app_123")
 	appList, err := client.List(context.Background(), params)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), appList.TotalCount)


### PR DESCRIPTION
This adds support for an `name_query` param when listing OAuth Applications for when the backend API supports filtering by a search query on an OAuth applications name.