### PR TITLE
ORGS-695: Include new domains field and deprecate domain

### DIFF
--- a/saml_connection.go
+++ b/saml_connection.go
@@ -2,10 +2,12 @@ package clerk
 
 type SAMLConnection struct {
 	APIResource
-	ID                               string                         `json:"id"`
-	Object                           string                         `json:"object"`
-	Name                             string                         `json:"name"`
+	ID     string `json:"id"`
+	Object string `json:"object"`
+	Name   string `json:"name"`
+	// Deprecated: Use `domains` instead.
 	Domain                           string                         `json:"domain"`
+	Domains                          []string                       `json:"domains"`
 	IdpEntityID                      *string                        `json:"idp_entity_id"`
 	OrganizationID                   *string                        `json:"organization_id"`
 	IdpSsoURL                        *string                        `json:"idp_sso_url"`

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -33,9 +33,11 @@ type AttributeMappingParams struct {
 
 type CreateParams struct {
 	clerk.APIParams
-	Name             *string                 `json:"name,omitempty"`
-	OrganizationID   *string                 `json:"organization_id,omitempty"`
+	Name           *string `json:"name,omitempty"`
+	OrganizationID *string `json:"organization_id,omitempty"`
+	// Deprecated: Use `domains` instead.
 	Domain           *string                 `json:"domain,omitempty"`
+	Domains          *[]string               `json:"domains,omitempty"`
 	Provider         *string                 `json:"provider,omitempty"`
 	IdpEntityID      *string                 `json:"idp_entity_id,omitempty"`
 	IdpSsoURL        *string                 `json:"idp_sso_url,omitempty"`
@@ -68,13 +70,27 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.SAMLConnection, err
 
 type UpdateParams struct {
 	clerk.APIParams
-	Name        *string `json:"name,omitempty"`
-	Domain      *string `json:"domain,omitempty"`
-	IdpEntityID *string `json:"idp_entity_id,omitempty"`
+	Name *string `json:"name,omitempty"`
+	// Deprecated: Use `domains` instead.
+	Domain *string `json:"domain,omitempty"`
+	// Domains represents the complete, desired set of domains.
+	//   - If nil or an empty slice is provided, no changes will be made.
+	//   - Otherwise, the provided slice is treated as the full target list:
+	//     • Any existing domains not in this list will be removed.
+	//     • Any domains in this list not already present will be added.
+	//
+	// For example, if the current domains are ["b", "c"] and you set:
+	//     Domains: []string{"a", "c", "d"}
+	// then:
+	//     - "a" and "d" will be added
+	//     - "b" will be removed
+	//     - "c" will remain unchanged
+	Domains     *[]string `json:"domains,omitempty"`
+	IdpEntityID *string   `json:"idp_entity_id,omitempty"`
 	// OrganizationID is a nullable optional field.
-	// - If nil or unset, no action will be taken.
-	// - If an empty value (""), the organization_id will be unset.
-	// - If a valid ID is provided, the organization_id will be updated.
+	//   - If nil or unset, no action will be taken.
+	//   - If an empty value (""), the organization_id will be unset.
+	//   - If a valid ID is provided, the organization_id will be updated.
 	OrganizationID                   *string                 `json:"organization_id,omitempty"`
 	IdpSsoURL                        *string                 `json:"idp_sso_url,omitempty"`
 	IdpCertificate                   *string                 `json:"idp_certificate,omitempty"`

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -38,6 +38,7 @@ func TestSAMLConnectionClientCreate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, samlConnection.ID)
 	require.Equal(t, name, samlConnection.Name)
+	// nolint:staticcheck // we want to test the .Domain behavior when it's deprecated
 	require.Equal(t, domain, samlConnection.Domain)
 	require.Equal(t, provider, samlConnection.Provider)
 }
@@ -99,6 +100,7 @@ func TestSAMLConnectionClientCreate_WithDomains(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, samlConnection.ID)
 	require.Equal(t, name, samlConnection.Name)
+	// nolint:staticcheck // we want to test the .Domain behavior when it's deprecated
 	require.Equal(t, domainA, samlConnection.Domain)
 	require.Equal(t, []string{domainA, domainB}, samlConnection.Domains)
 	require.Equal(t, provider, samlConnection.Provider)
@@ -149,6 +151,7 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, samlConnection.ID)
 	require.Equal(t, name, samlConnection.Name)
+	// nolint:staticcheck // we want to test the .Domain behavior when it's deprecated
 	require.Equal(t, domain, samlConnection.Domain)
 	require.Equal(t, provider, samlConnection.Provider)
 	require.Equal(t, disableAdditionalIdentifications, samlConnection.DisableAdditionalIdentifications)
@@ -263,6 +266,7 @@ func TestSAMLConnectionClientUpdate_WithDomains(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, samlConnection.ID)
 	require.Equal(t, name, samlConnection.Name)
+	// nolint:staticcheck // we want to test the .Domain behavior when it's deprecated
 	require.Equal(t, domainA, samlConnection.Domain)
 	require.Equal(t, []string{domainA, domainB}, samlConnection.Domains)
 	require.Equal(t, provider, samlConnection.Provider)
@@ -298,9 +302,9 @@ func TestSAMLConnectionClientList(t *testing.T) {
 		Transport: &clerktest.RoundTripper{
 			T: t,
 			Out: json.RawMessage(fmt.Sprintf(`{
-	"data": [{"id":"%s","name":"%s","domain":"%s","provider":"%s"}],
+	"data": [{"id":"%s","name":"%s","domain":"%s","domains": ["%s"],"provider":"%s"}],
 	"total_count": 1
-}`, id, name, domain, provider)),
+}`, id, name, domain, domain, provider)),
 			Method: http.MethodGet,
 			Path:   "/v1/saml_connections",
 			Query: &url.Values{
@@ -324,6 +328,8 @@ func TestSAMLConnectionClientList(t *testing.T) {
 	require.Equal(t, 1, len(list.SAMLConnections))
 	require.Equal(t, id, list.SAMLConnections[0].ID)
 	require.Equal(t, name, list.SAMLConnections[0].Name)
+	// nolint:staticcheck // we want to test the .Domain behavior when it's deprecated
 	require.Equal(t, domain, list.SAMLConnections[0].Domain)
+	require.Equal(t, domain, list.SAMLConnections[0].Domains[0])
 	require.Equal(t, provider, list.SAMLConnections[0].Provider)
 }

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -42,6 +42,68 @@ func TestSAMLConnectionClientCreate(t *testing.T) {
 	require.Equal(t, provider, samlConnection.Provider)
 }
 
+// TestSAMLConnectionClientCreate_WithBothDomainAndDomains tests that the client can not create a SAML connection
+// When providing both domain and domains. An error is returned.
+func TestSAMLConnectionClientCreate_WithBothDomainAndDomains(t *testing.T) {
+	t.Parallel()
+	name := "the-name"
+	domain := "example.com"
+	provider := "saml_custom"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","domain":"%s", "domains": ["%s"], "provider":"%s"}`, name, domain, domain, provider)),
+			Out:    json.RawMessage(`{ "clerk_trace_id": "trace-id", "errors": [{"code": "form_conditional_param_disallowed", "short_message": "is not allowed", "long_message": "domain isn't allowed when domains is present.", "meta": {"param_name": "domain"}}]}`),
+			Method: http.MethodPost,
+			Path:   "/v1/saml_connections",
+			Status: http.StatusUnprocessableEntity,
+		},
+	}
+	client := NewClient(config)
+	samlConnection, err := client.Create(context.Background(), &CreateParams{
+		Name:     clerk.String(name),
+		Domain:   clerk.String(domain),
+		Domains:  &[]string{domain},
+		Provider: clerk.String(provider),
+	})
+	require.Error(t, err)
+	require.Empty(t, samlConnection.ID)
+}
+
+// TestSAMLConnectionClientCreate_WithDomains tests that the client can create a SAML connection
+// When providing only domains.
+func TestSAMLConnectionClientCreate_WithDomains(t *testing.T) {
+	t.Parallel()
+	id := "samlc__123"
+	name := "the-name"
+	domainA := "example.com"
+	domainB := "example.org"
+	provider := "saml_custom"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","domains": ["%s", "%s"], "provider":"%s"}`, name, domainA, domainB, provider)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain": "%s", "domains": ["%s", "%s"],"provider":"%s"}`, id, name, domainA, domainA, domainB, provider)),
+			Method: http.MethodPost,
+			Path:   "/v1/saml_connections",
+		},
+	}
+	client := NewClient(config)
+	samlConnection, err := client.Create(context.Background(), &CreateParams{
+		Name:     clerk.String(name),
+		Domains:  &[]string{domainA, domainB},
+		Provider: clerk.String(provider),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, samlConnection.ID)
+	require.Equal(t, name, samlConnection.Name)
+	require.Equal(t, domainA, samlConnection.Domain)
+	require.Equal(t, []string{domainA, domainB}, samlConnection.Domains)
+	require.Equal(t, provider, samlConnection.Provider)
+}
+
 func TestSAMLConnectionClientCreate_Error(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}
@@ -144,6 +206,66 @@ func TestSAMLConnectionClientUpdate_Error(t *testing.T) {
 	require.Equal(t, "update-trace-id", apiErr.TraceID)
 	require.Equal(t, 1, len(apiErr.Errors))
 	require.Equal(t, "update-error-code", apiErr.Errors[0].Code)
+}
+
+// TestSAMLConnectionClientUpdate_WithBothDomainAndDomains tests that the client can not update a SAML connection
+// When providing both domain and domains. An error is returned.
+func TestSAMLConnectionClientUpdate_WithBothDomainAndDomains(t *testing.T) {
+	t.Parallel()
+	id := "samlc__123"
+	name := "the-name"
+	domain := "example.com"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","domain":"%s", "domains": ["%s"]}`, name, domain, domain)),
+			Out:    json.RawMessage(`{ "clerk_trace_id": "trace-id", "errors": [{"code": "form_conditional_param_disallowed", "short_message": "is not allowed", "long_message": "domain isn't allowed when domains is present.", "meta": {"param_name": "domain"}}]}`),
+			Method: http.MethodPatch,
+			Path:   "/v1/saml_connections/" + id,
+			Status: http.StatusUnprocessableEntity,
+		},
+	}
+	client := NewClient(config)
+	samlConnection, err := client.Update(context.Background(), id, &UpdateParams{
+		Name:    clerk.String(name),
+		Domain:  clerk.String(domain),
+		Domains: &[]string{domain},
+	})
+	require.Error(t, err)
+	require.Empty(t, samlConnection.ID)
+}
+
+// TestSAMLConnectionClientUpdate_WithDomains tests that the client can update a SAML connection
+// When providing only domains.
+func TestSAMLConnectionClientUpdate_WithDomains(t *testing.T) {
+	t.Parallel()
+	id := "samlc__123"
+	name := "the-name"
+	domainA := "example.com"
+	domainB := "example.org"
+	provider := "saml_custom"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","domains": ["%s", "%s"]}`, name, domainA, domainB)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain": "%s", "domains": ["%s", "%s"],"provider":"%s"}`, id, name, domainA, domainA, domainB, provider)),
+			Method: http.MethodPatch,
+			Path:   "/v1/saml_connections/" + id,
+		},
+	}
+	client := NewClient(config)
+	samlConnection, err := client.Update(context.Background(), id, &UpdateParams{
+		Name:    clerk.String(name),
+		Domains: &[]string{domainA, domainB},
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, samlConnection.ID)
+	require.Equal(t, name, samlConnection.Name)
+	require.Equal(t, domainA, samlConnection.Domain)
+	require.Equal(t, []string{domainA, domainB}, samlConnection.Domains)
+	require.Equal(t, provider, samlConnection.Provider)
 }
 
 func TestSAMLConnectionClientDelete(t *testing.T) {


### PR DESCRIPTION
This commit deprecates the `domain` field in favor of the new `domains` field. SAML connections now supports multiple domains per connection and the `domains` field should be used to interact with this new feature. On the next API version the `domain` field will be removed.

> [!WARNING]
>
> This PR should not be merged until the backend changes are in place.