### PR TITLE
feat: Add ListWithoutCount function for users

### DIFF
--- a/user/client.go
+++ b/user/client.go
@@ -312,10 +312,7 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*clerk.UserList,
 	// The response is then synthesized from the individual responses.
 
 	// GET /v1/users
-	req := clerk.NewAPIRequest(http.MethodGet, path)
-	req.SetParams(params)
-	data := &userList{}
-	err := c.Backend.Call(ctx, req, data)
+	users, err := c.ListWithoutCount(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +323,6 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*clerk.UserList,
 		return nil, err
 	}
 
-	users := []*clerk.User(*data)
 	return &clerk.UserList{
 		Users:      users,
 		TotalCount: totalCount.TotalCount,

--- a/user/client.go
+++ b/user/client.go
@@ -333,6 +333,19 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*clerk.UserList,
 	}, nil
 }
 
+// ListWithoutCount returns a list of users without fetching the total count.
+// This is more efficient than List when you don't need the total count.
+func (c *Client) ListWithoutCount(ctx context.Context, params *ListParams) ([]*clerk.User, error) {
+	req := clerk.NewAPIRequest(http.MethodGet, path)
+	req.SetParams(params)
+	data := &userList{}
+	err := c.Backend.Call(ctx, req, data)
+	if err != nil {
+		return nil, err
+	}
+	return []*clerk.User(*data), nil
+}
+
 // Count returns the total count of users satisfying the parameters.
 func (c *Client) Count(ctx context.Context, params *ListParams) (*TotalCount, error) {
 	path, err := clerk.JoinPath(path, "/count")

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -107,6 +107,37 @@ func TestUserClientList_Response(t *testing.T) {
 	require.Equal(t, "user_123", list.Users[0].ID)
 }
 
+func TestUserClientListWithoutCount(t *testing.T) {
+	t.Parallel()
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(`[{"object":"user","id":"user_123","username":"user1"},{"object":"user","id":"user_456","username":"user2"}]`),
+			Method: http.MethodGet,
+			Path:   "/v1/users",
+			Query: &url.Values{
+				"limit":         []string{"2"},
+				"order_by":      []string{"-created_at"},
+				"email_address": []string{"foo@bar.com"},
+			},
+		},
+	}
+	client := NewClient(config)
+	params := &ListParams{
+		EmailAddresses: []string{"foo@bar.com"},
+		OrderBy:        clerk.String("-created_at"),
+	}
+	params.Limit = clerk.Int64(2)
+	users, err := client.ListWithoutCount(context.Background(), params)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(users))
+	require.Equal(t, "user_123", users[0].ID)
+	require.Equal(t, "user_456", users[1].ID)
+	require.Equal(t, "user1", *users[0].Username)
+	require.Equal(t, "user2", *users[1].Username)
+}
+
 func TestUserClientCount(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}


### PR DESCRIPTION
## Description

This PR adds a new `ListWithoutCount` function to the user client that retrieves users without fetching the total count. This is more efficient when the total count is not needed, as it avoids the extra API call to `/users/count`.

## Changes

- Added `ListWithoutCount` function that returns `[]*clerk.User`
- Added comprehensive test coverage for the new function
- Refactored `List` function to use `ListWithoutCount` internally to avoid code duplication

## Benefits

- More efficient when total count is not needed (single API call instead of two)
- Reduces code duplication by having `List` use `ListWithoutCount` internally
- Maintains backward compatibility with existing `List` function

## Testing

All existing tests pass, and new tests have been added for the `ListWithoutCount` function.