### PR TITLE
Remove scoped machine from update parameter v2

### DIFF
--- a/machine/client.go
+++ b/machine/client.go
@@ -54,9 +54,8 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.MachineWithScopedMa
 
 type UpdateParams struct {
 	clerk.APIParams
-	Name            *string  `json:"name,omitempty"`
-	ScopedMachines  []string `json:"scoped_machines,omitempty"`
-	DefaultTokenTTL *int64   `json:"default_token_ttl,omitempty"`
+	Name            *string `json:"name,omitempty"`
+	DefaultTokenTTL *int64  `json:"default_token_ttl,omitempty"`
 }
 
 // Update updates a machine.


### PR DESCRIPTION
This is a mistake, this is not a paramter in `PATCH /v1/machines/{machineID}`