### PR TITLE
Switch `secret` -> `token` in m2m (v3)

### DIFF
--- a/m2m_token.go
+++ b/m2m_token.go
@@ -20,11 +20,11 @@ type M2MToken struct {
 	UpdatedAt        int64           `json:"updated_at"`
 }
 
-// M2MTokenWithSecret represents a machine-to-machine token response that includes the secret field.
+// M2MTokenWithToken represents a machine-to-machine token response that includes the token field.
 // This is only used for the Create endpoint.
-type M2MTokenWithSecret struct {
+type M2MTokenWithToken struct {
 	M2MToken
-	Secret string `json:"secret"`
+	Token string `json:"token"`
 }
 
 // M2MTokenList represents a list of machine-to-machine tokens.

--- a/m2m_token/api.go
+++ b/m2m_token/api.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Create creates a new M2M token.
-func Create(ctx context.Context, params *CreateParams) (*clerk.M2MTokenWithSecret, error) {
+func Create(ctx context.Context, params *CreateParams) (*clerk.M2MTokenWithToken, error) {
 	return getClient().Create(ctx, params)
 }
 

--- a/m2m_token/api_test.go
+++ b/m2m_token/api_test.go
@@ -22,7 +22,7 @@ func TestPackageCreate(t *testing.T) {
 		"subject":           "mch_2xhFjEI5X2qWRvtV13BzSj8H6Dk",
 		"claims":            map[string]interface{}{"foo": "bar"},
 		"scopes":            []string{"mch_2xhFjEI5X2qWRvtV13BzSj8H6Dk"},
-		"secret":            "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"token":             "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
 		"revoked":           false,
 		"revocation_reason": nil,
 		"expired":           false,
@@ -60,7 +60,7 @@ func TestPackageCreate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "mt_test123", token.ID)
 	assert.Equal(t, "mch_2xhFjEI5X2qWRvtV13BzSj8H6Dk", token.Subject)
-	assert.Equal(t, "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", token.Secret)
+	assert.Equal(t, "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", token.Token)
 }
 
 func TestPackageList(t *testing.T) {
@@ -190,7 +190,7 @@ func TestPackageVerify(t *testing.T) {
 		HTTPClient: &http.Client{
 			Transport: &clerktest.RoundTripper{
 				T:      t,
-				In:     json.RawMessage(`{"secret":"mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}`),
+				In:     json.RawMessage(`{"token":"mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}`),
 				Out:    json.RawMessage(responseJSON),
 				Method: http.MethodPost,
 				Path:   "/v1/m2m_tokens/verify",
@@ -202,7 +202,7 @@ func TestPackageVerify(t *testing.T) {
 	clerk.SetBackend(clerk.NewBackend(backend))
 
 	params := &VerifyParams{
-		Secret: "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		Token: "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
 	}
 
 	token, err := Verify(context.Background(), params)

--- a/m2m_token/client.go
+++ b/m2m_token/client.go
@@ -33,10 +33,10 @@ type CreateParams struct {
 }
 
 // Create creates a new M2M token.
-func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.M2MTokenWithSecret, error) {
+func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.M2MTokenWithToken, error) {
 	req := clerk.NewAPIRequest(http.MethodPost, path)
 	req.SetParams(params)
-	resource := &clerk.M2MTokenWithSecret{}
+	resource := &clerk.M2MTokenWithToken{}
 	err := c.Backend.Call(ctx, req, resource)
 	return resource, err
 }
@@ -99,7 +99,7 @@ func (c *Client) Revoke(ctx context.Context, tokenID string, params *RevokeParam
 
 type VerifyParams struct {
 	clerk.APIParams
-	Secret string `json:"secret"`
+	Token string `json:"token"`
 }
 
 // Verify verifies an M2M token.

--- a/m2m_token/client_test.go
+++ b/m2m_token/client_test.go
@@ -22,7 +22,7 @@ func TestCreate(t *testing.T) {
 		"subject":           "mch_2xhFjEI5X2qWRvtV13BzSj8H6Dk",
 		"claims":            map[string]interface{}{"foo": "bar"},
 		"scopes":            []string{"mch_2xhFjEI5X2qWRvtV13BzSj8H6Dk"},
-		"secret":            "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"token":             "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
 		"revoked":           false,
 		"revocation_reason": nil,
 		"expired":           false,
@@ -56,7 +56,7 @@ func TestCreate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "mt_test123", token.ID)
 	assert.Equal(t, "mch_2xhFjEI5X2qWRvtV13BzSj8H6Dk", token.Subject)
-	assert.Equal(t, "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", token.Secret)
+	assert.Equal(t, "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", token.Token)
 }
 
 func TestList(t *testing.T) {
@@ -177,7 +177,7 @@ func TestVerify(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(`{"secret":"mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}`),
+			In:     json.RawMessage(`{"token":"mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}`),
 			Out:    json.RawMessage(responseJSON),
 			Method: http.MethodPost,
 			Path:   "/v1/m2m_tokens/verify",
@@ -186,7 +186,7 @@ func TestVerify(t *testing.T) {
 
 	client := NewClient(config)
 	params := &VerifyParams{
-		Secret: "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		Token: "mt_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
 	}
 
 	token, err := client.Verify(context.Background(), params)


### PR DESCRIPTION
This is a breaking change, but this feature is in private beta, and nobody in the beta is using the go sdk functionality yet.