### PR TITLE
feat(organizations): add new filter on GET /organizations

### DIFF
--- a/organization/client.go
+++ b/organization/client.go
@@ -205,6 +205,10 @@ type ListParams struct {
 	Query                                       *string  `json:"query,omitempty"`
 	UserIDs                                     []string `json:"user_id,omitempty"`
 	FilterBy                                    []string `json:"filter_by,omitempty"`
+	CreatedAtBefore                             *int64   `json:"created_at_before,omitempty"`
+	CreatedAtAfter                              *int64   `json:"created_at_after,omitempty"`
+	Slug                                        *string  `json:"slug,omitempty"`
+	Name                                        *string  `json:"name,omitempty"`
 }
 
 // ToQuery returns query string values from the params.
@@ -230,6 +234,18 @@ func (params *ListParams) ToQuery() url.Values {
 	}
 	if params.FilterBy != nil {
 		q["filter_by"] = params.FilterBy
+	}
+	if params.CreatedAtBefore != nil {
+		q.Set("created_at_before", strconv.FormatInt(*params.CreatedAtBefore, 10))
+	}
+	if params.CreatedAtAfter != nil {
+		q.Set("created_at_after", strconv.FormatInt(*params.CreatedAtAfter, 10))
+	}
+	if params.Slug != nil {
+		q.Set("slug", *params.Slug)
+	}
+	if params.Name != nil {
+		q.Set("name", *params.Name)
 	}
 	return q
 }

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -195,6 +195,10 @@ func TestOrganizationClientList(t *testing.T) {
 				"filter_by":             []string{"missing_member_with_elevated_permissions"},
 				"include_members_count": []string{"true"},
 				"include_missing_member_with_elevated_permissions": []string{"true"},
+				"created_at_before": []string{"1730333164378"},
+				"created_at_after":  []string{"1730333164378"},
+				"slug":              []string{"acme"},
+				"name":              []string{"Acme Inc"},
 			},
 		},
 	}
@@ -206,6 +210,10 @@ func TestOrganizationClientList(t *testing.T) {
 		FilterBy:            []string{"missing_member_with_elevated_permissions"},
 		IncludeMembersCount: clerk.Bool(true),
 		IncludeMissingMemberWithElevatedPermissions: clerk.Bool(true),
+		CreatedAtBefore: clerk.Int64(1730333164378),
+		CreatedAtAfter:  clerk.Int64(1730333164378),
+		Slug:            clerk.String("acme"),
+		Name:            clerk.String("Acme Inc"),
 	}
 	params.Limit = clerk.Int64(1)
 	params.Offset = clerk.Int64(2)


### PR DESCRIPTION
This commit adds a set of new filters on the `GET /organizations` endpoint, it includes the following filters:

- `created_at_before`
- `created_at_after`
- `slug`
- `name`