### PR TITLE
chore(samlconnection): add `force_authn` handling (v3)

### DIFF
--- a/saml_connection.go
+++ b/saml_connection.go
@@ -25,6 +25,7 @@ type SAMLConnection struct {
 	AllowSubdomains                  bool                           `json:"allow_subdomains"`
 	AllowIdpInitiated                bool                           `json:"allow_idp_initiated"`
 	DisableAdditionalIdentifications bool                           `json:"disable_additional_identifications"`
+	ForceAuthn                       bool                           `json:"force_authn"`
 	CreatedAt                        int64                          `json:"created_at"`
 	UpdatedAt                        int64                          `json:"updated_at"`
 }

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -45,6 +45,7 @@ type CreateParams struct {
 	IdpMetadataURL   *string                 `json:"idp_metadata_url,omitempty"`
 	IdpMetadata      *string                 `json:"idp_metadata,omitempty"`
 	AttributeMapping *AttributeMappingParams `json:"attribute_mapping,omitempty"`
+	ForceAuthn       *bool                   `json:"force_authn,omitempty"`
 }
 
 // Create creates a new SAML Connection.
@@ -102,6 +103,7 @@ type UpdateParams struct {
 	AllowSubdomains                  *bool                   `json:"allow_subdomains,omitempty"`
 	AllowIdpInitiated                *bool                   `json:"allow_idp_initiated,omitempty"`
 	DisableAdditionalIdentifications *bool                   `json:"disable_additional_identifications,omitempty"`
+	ForceAuthn                       *bool                   `json:"force_authn,omitempty"`
 }
 
 // Update updates the SAML Connection specified by id.

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -19,21 +19,23 @@ func TestSAMLConnectionClientCreate(t *testing.T) {
 	name := "the-name"
 	domain := "example.com"
 	provider := "saml_custom"
+	forceAuthn := true
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","domain":"%s","provider":"%s"}`, name, domain, provider)),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s"}`, id, name, domain, provider)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","domain":"%s","provider":"%s","force_authn":%t}`, name, domain, provider, forceAuthn)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","force_authn":%t}`, id, name, domain, provider, forceAuthn)),
 			Method: http.MethodPost,
 			Path:   "/v1/saml_connections",
 		},
 	}
 	client := NewClient(config)
 	samlConnection, err := client.Create(context.Background(), &CreateParams{
-		Name:     clerk.String(name),
-		Domain:   clerk.String(domain),
-		Provider: clerk.String(provider),
+		Name:       clerk.String(name),
+		Domain:     clerk.String(domain),
+		Provider:   clerk.String(provider),
+		ForceAuthn: clerk.Bool(forceAuthn),
 	})
 	require.NoError(t, err)
 	require.Equal(t, id, samlConnection.ID)
@@ -41,6 +43,7 @@ func TestSAMLConnectionClientCreate(t *testing.T) {
 	// nolint:staticcheck // we want to test the .Domain behavior when it's deprecated
 	require.Equal(t, domain, samlConnection.Domain)
 	require.Equal(t, provider, samlConnection.Provider)
+	require.Equal(t, forceAuthn, samlConnection.ForceAuthn)
 }
 
 // TestSAMLConnectionClientCreate_WithBothDomainAndDomains tests that the client can not create a SAML connection
@@ -138,12 +141,14 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	domain := "example.com"
 	provider := "saml_custom"
 	disableAdditionalIdentifications := true
+	forceAuthn := false
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
-			T:   t,
-			Out: json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s", "disable_additional_identifications": %t}`, id, name, domain, provider, disableAdditionalIdentifications)), Method: http.MethodGet,
-			Path: "/v1/saml_connections/" + id,
+			T:      t,
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s", "disable_additional_identifications": %t, "force_authn": %t}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
+			Method: http.MethodGet,
+			Path:   "/v1/saml_connections/" + id,
 		},
 	}
 	client := NewClient(config)
@@ -155,6 +160,7 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	require.Equal(t, domain, samlConnection.Domain)
 	require.Equal(t, provider, samlConnection.Provider)
 	require.Equal(t, disableAdditionalIdentifications, samlConnection.DisableAdditionalIdentifications)
+	require.Equal(t, forceAuthn, samlConnection.ForceAuthn)
 }
 
 func TestSAMLConnectionClientUpdate(t *testing.T) {
@@ -164,12 +170,13 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 	domain := "example.com"
 	provider := "saml_custom"
 	disableAdditionalIdentifications := true
+	forceAuthn := true
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s", "disable_additional_identifications": %t, "organization_id": ""}`, name, disableAdditionalIdentifications)),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","disable_additional_identifications": %t}`, id, name, domain, provider, disableAdditionalIdentifications)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s", "disable_additional_identifications": %t, "organization_id": "", "force_authn": %t}`, name, disableAdditionalIdentifications, forceAuthn)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","disable_additional_identifications": %t,"force_authn": %t}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
 			Method: http.MethodPatch,
 			Path:   "/v1/saml_connections/" + id,
 		},
@@ -179,11 +186,13 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 		Name:                             clerk.String(name),
 		DisableAdditionalIdentifications: clerk.Bool(disableAdditionalIdentifications),
 		OrganizationID:                   clerk.String(""),
+		ForceAuthn:                       clerk.Bool(forceAuthn),
 	})
 	require.NoError(t, err)
 	require.Equal(t, id, samlConnection.ID)
 	require.Equal(t, name, samlConnection.Name)
 	require.Equal(t, disableAdditionalIdentifications, samlConnection.DisableAdditionalIdentifications)
+	require.Equal(t, forceAuthn, samlConnection.ForceAuthn)
 }
 
 func TestSAMLConnectionClientUpdate_Error(t *testing.T) {


### PR DESCRIPTION
This is the v3 equivalent of #446.

Steps:
- base on `v3`
- `gco -b kevin/orgs-906-update-bapi-v1saml_connections-update-operation-to-set-v3`
- `gcp 002b9f0` (commit from #446)
- PR