### PR TITLE
chore: Updated org invite struct to have the URL field

### DIFF
--- a/organization_invitation.go
+++ b/organization_invitation.go
@@ -20,6 +20,7 @@ type OrganizationInvitation struct {
 	OrganizationID         string                  `json:"organization_id"`
 	PublicOrganizationData *PublicOrganizationData `json:"public_organization_data,omitempty"`
 	Status                 string                  `json:"status"`
+	URL                    string                  `json:"url,omitempty"`
 	PublicMetadata         json.RawMessage         `json:"public_metadata"`
 	PrivateMetadata        json.RawMessage         `json:"private_metadata"`
 	ExpiresAt              *int64                  `json:"expires_at,omitempty"`


### PR DESCRIPTION
Adds URL field to the org invite struct to match our backend api response structure. 