### PR TITLE
feat(client/UpdateOrganizationSettings): introduce new field `slug_disabled`

### DIFF
--- a/instance_settings.go
+++ b/instance_settings.go
@@ -21,6 +21,7 @@ type OrganizationSettings struct {
 	CreatorRole            string   `json:"creator_role"`
 	AdminDeleteEnabled     bool     `json:"admin_delete_enabled"`
 	DomainsEnabled         bool     `json:"domains_enabled"`
+	SlugDisabled           bool     `json:"slug_disabled"`
 	DomainsEnrollmentModes []string `json:"domains_enrollment_modes"`
 	DomainsDefaultRole     string   `json:"domains_default_role"`
 }

--- a/instancesettings/client.go
+++ b/instancesettings/client.go
@@ -107,6 +107,7 @@ type UpdateOrganizationSettingsParams struct {
 	CreatorRoleID          *string   `json:"creator_role_id,omitempty"`
 	AdminDeleteEnabled     *bool     `json:"admin_delete_enabled,omitempty"`
 	DomainsEnabled         *bool     `json:"domains_enabled,omitempty"`
+	SlugDisabled           *bool     `json:"slug_disabled,omitempty"`
 	DomainsEnrollmentModes *[]string `json:"domains_enrollment_modes,omitempty"`
 	DomainsDefaultRoleID   *string   `json:"domains_default_role_id,omitempty"`
 	// This feature is currently in beta and is not yet available for all instances.

--- a/instancesettings/client_test.go
+++ b/instancesettings/client_test.go
@@ -107,7 +107,7 @@ func TestInstanceClientUpdateOrganizationSettings(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(`{"enabled":true,"force_organization_selection": true}`),
+			In:     json.RawMessage(`{"enabled":true,"force_organization_selection": true,"slug_disabled": true}`),
 			Out:    json.RawMessage(`{"enabled":true,"max_allowed_memberships":3}`),
 			Method: http.MethodPatch,
 			Path:   "/v1/instance/organization_settings",
@@ -117,6 +117,7 @@ func TestInstanceClientUpdateOrganizationSettings(t *testing.T) {
 	orgSettings, err := client.UpdateOrganizationSettings(context.Background(), &UpdateOrganizationSettingsParams{
 		Enabled:                    clerk.Bool(true),
 		ForceOrganizationSelection: clerk.Bool(true),
+		SlugDisabled:               clerk.Bool(true),
 	})
 	require.NoError(t, err)
 	require.True(t, orgSettings.Enabled)


### PR DESCRIPTION
Resolves ORGS-887

Introduces a new field `slug_disabled` on the update organization settings method for `/v1/instance/organization_settings`
