### PR TITLE
feat: add SessionCreatedEvent type with User object

### DIFF
--- a/webhookevents/session_created_event.go
+++ b/webhookevents/session_created_event.go
@@ -1,0 +1,8 @@
+package webhookevents
+
+import "github.com/clerk/clerk-sdk-go/v3"
+
+type SessionCreatedEvent struct {
+	clerk.Session
+	User clerk.User `json:"user"`
+}


### PR DESCRIPTION
## Overview

This pull request introduces a new event struct to the `webhookevents` package for handling session creation events. The new struct embeds the `clerk.Session` and includes a `clerk.User` field for easier access to user information in session-related webhooks.

End goal is to ensure congruency between our webhook event structures by using the Go SDK for source of truth of these structs when publishing the webhook. 

### New `webhookevents` package struct:

* Added `SessionCreatedEvent` struct to `webhookevents/session_created_event.go`, embedding `clerk.Session` and including a `clerk.User` field.