### PR TITLE
feat: add initial role set key param and role set list query/order params

### DIFF
--- a/instance_settings.go
+++ b/instance_settings.go
@@ -24,4 +24,6 @@ type OrganizationSettings struct {
 	SlugDisabled           bool     `json:"slug_disabled"`
 	DomainsEnrollmentModes []string `json:"domains_enrollment_modes"`
 	DomainsDefaultRole     string   `json:"domains_default_role"`
+	// TODO(nicolas): Remove omitempty when it's GA
+	InitialRoleSetKey *string `json:"initial_role_set_key,omitempty"`
 }

--- a/instancesettings/client.go
+++ b/instancesettings/client.go
@@ -112,7 +112,8 @@ type UpdateOrganizationSettingsParams struct {
 	DomainsDefaultRoleID   *string   `json:"domains_default_role_id,omitempty"`
 	// This feature is currently in beta and is not yet available for all instances.
 	// do not use this feature in production.
-	ForceOrganizationSelection *bool `json:"force_organization_selection,omitempty"`
+	ForceOrganizationSelection *bool   `json:"force_organization_selection,omitempty"`
+	InitialRoleSetKey          *string `json:"initial_role_set_key,omitempty"`
 }
 
 // UpdateOrganizationSettings updates the organization settings of the instance.

--- a/instancesettings/client_test.go
+++ b/instancesettings/client_test.go
@@ -124,6 +124,31 @@ func TestInstanceClientUpdateOrganizationSettings(t *testing.T) {
 	require.Equal(t, int64(3), orgSettings.MaxAllowedMemberships)
 }
 
+func TestInstanceClientUpdateOrganizationSettingsWithInitialRoleSetKey(t *testing.T) {
+	t.Parallel()
+	initialRoleSetKey := "admin-roles"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"enabled":true,"initial_role_set_key":"admin-roles"}`),
+			Out:    json.RawMessage(`{"enabled":true,"max_allowed_memberships":5,"initial_role_set_key":"admin-roles"}`),
+			Method: http.MethodPatch,
+			Path:   "/v1/instance/organization_settings",
+		},
+	}
+	client := NewClient(config)
+	orgSettings, err := client.UpdateOrganizationSettings(context.Background(), &UpdateOrganizationSettingsParams{
+		Enabled:           clerk.Bool(true),
+		InitialRoleSetKey: clerk.String(initialRoleSetKey),
+	})
+	require.NoError(t, err)
+	require.True(t, orgSettings.Enabled)
+	require.Equal(t, int64(5), orgSettings.MaxAllowedMemberships)
+	require.NotNil(t, orgSettings.InitialRoleSetKey)
+	require.Equal(t, initialRoleSetKey, *orgSettings.InitialRoleSetKey)
+}
+
 func TestInstanceClientUpdateOrganizationSettings_Error(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}

--- a/roleset/client.go
+++ b/roleset/client.go
@@ -95,11 +95,21 @@ func (c *Client) Delete(ctx context.Context, roleSetKeyOrID string) (*clerk.Dele
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
+
+	Query   *string `json:"query,omitempty"`
+	OrderBy *string `json:"order_by,omitempty"`
 }
 
 // ToQuery returns query string values from the params.
 func (params *ListParams) ToQuery() url.Values {
-	return params.ListParams.ToQuery()
+	q := params.ListParams.ToQuery()
+	if params.Query != nil {
+		q.Set("query", *params.Query)
+	}
+	if params.OrderBy != nil {
+		q.Set("order_by", *params.OrderBy)
+	}
+	return q
 }
 
 // List returns a list of role sets.

--- a/roleset/client_test.go
+++ b/roleset/client_test.go
@@ -186,3 +186,98 @@ func TestRoleSetClient_RemoveRoles(t *testing.T) {
 	assert.Equal(t, roleSetID, roleSet.ID)
 	assert.Len(t, roleSet.Roles, 0)
 }
+
+func TestListParams_ToQuery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with all parameters", func(t *testing.T) {
+		params := &ListParams{
+			ListParams: clerk.ListParams{
+				Limit:  clerk.Int64(10),
+				Offset: clerk.Int64(20),
+			},
+			Query:   clerk.String("admin"),
+			OrderBy: clerk.String("created_at"),
+		}
+
+		query := params.ToQuery()
+		assert.Equal(t, "10", query.Get("limit"))
+		assert.Equal(t, "20", query.Get("offset"))
+		assert.Equal(t, "admin", query.Get("query"))
+		assert.Equal(t, "created_at", query.Get("order_by"))
+	})
+
+	t.Run("with only base list parameters", func(t *testing.T) {
+		params := &ListParams{
+			ListParams: clerk.ListParams{
+				Limit: clerk.Int64(5),
+			},
+		}
+
+		query := params.ToQuery()
+		assert.Equal(t, "5", query.Get("limit"))
+		assert.Empty(t, query.Get("query"))
+		assert.Empty(t, query.Get("order_by"))
+	})
+
+	t.Run("with only new parameters", func(t *testing.T) {
+		params := &ListParams{
+			Query:   clerk.String("test query"),
+			OrderBy: clerk.String("name"),
+		}
+
+		query := params.ToQuery()
+		assert.Equal(t, "test query", query.Get("query"))
+		assert.Equal(t, "name", query.Get("order_by"))
+		assert.Empty(t, query.Get("limit"))
+		assert.Empty(t, query.Get("offset"))
+	})
+
+	t.Run("with nil parameters", func(t *testing.T) {
+		params := &ListParams{}
+
+		query := params.ToQuery()
+		assert.Empty(t, query.Get("query"))
+		assert.Empty(t, query.Get("order_by"))
+		assert.Empty(t, query.Get("limit"))
+		assert.Empty(t, query.Get("offset"))
+	})
+}
+
+func TestRoleSetClient_ListWithQueryParams(t *testing.T) {
+	t.Parallel()
+	roleSet1ID := "role_set_2b6E7b8FdHPjQKsrrakHLUPOzKe"
+
+	expectedQuery := url.Values{}
+	expectedQuery.Set("query", "admin")
+	expectedQuery.Set("order_by", "created_at")
+	expectedQuery.Set("limit", "10")
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T: t,
+			Out: json.RawMessage(fmt.Sprintf(`{
+				"data": [
+					{"object":"role_set","id":"%s","name":"Admin Role Set","key":"admin-roles","description":"Admin roles","type": "initial","roles":[],"created_at":1234567890,"updated_at":1234567890}
+				],
+				"total_count": 1
+			}`, roleSet1ID)),
+			Method: http.MethodGet,
+			Path:   "/v1/role_sets",
+			Query:  &expectedQuery,
+		},
+	}
+	client := NewClient(config)
+	list, err := client.List(context.Background(), &ListParams{
+		ListParams: clerk.ListParams{
+			Limit: clerk.Int64(10),
+		},
+		Query:   clerk.String("admin"),
+		OrderBy: clerk.String("created_at"),
+	})
+	require.NoError(t, err)
+	assert.Len(t, list.RoleSets, 1)
+	assert.Equal(t, int64(1), list.TotalCount)
+	assert.Equal(t, roleSet1ID, list.RoleSets[0].ID)
+}


### PR DESCRIPTION
Add InitialRoleSetKey parameter to OrganizationSettings struct and UpdateOrganizationSettingsParams. Add Query and OrderBy parameters to role set ListParams.
