### PR TITLE
feat: add missing User struct fields

### DIFF
--- a/email_address.go
+++ b/email_address.go
@@ -24,6 +24,7 @@ type Verification struct {
 	ExpireAt                        *int64          `json:"expire_at"`
 	VerifiedAtClient                string          `json:"verified_at_client,omitempty"`
 	Nonce                           *string         `json:"nonce,omitempty"`
+	Message                         *string         `json:"message,omitempty"`
 	ExternalVerificationRedirectURL *string         `json:"external_verification_redirect_url,omitempty"`
 	Error                           json.RawMessage `json:"error,omitempty"`
 }

--- a/email_address.go
+++ b/email_address.go
@@ -4,17 +4,22 @@ import "encoding/json"
 
 type EmailAddress struct {
 	APIResource
-	ID           string                  `json:"id"`
-	Object       string                  `json:"object"`
-	EmailAddress string                  `json:"email_address"`
-	Reserved     bool                    `json:"reserved"`
-	Verification *Verification           `json:"verification"`
-	LinkedTo     []*LinkedIdentification `json:"linked_to"`
+	ID                   string                  `json:"id"`
+	Object               string                  `json:"object"`
+	EmailAddress         string                  `json:"email_address"`
+	Reserved             bool                    `json:"reserved"`
+	Verification         *Verification           `json:"verification"`
+	LinkedTo             []*LinkedIdentification `json:"linked_to"`
+	MatchesSsoConnection bool                    `json:"matches_sso_connection"`
+	CreatedAt            int64                   `json:"created_at"`
+	UpdatedAt            int64                   `json:"updated_at"`
 }
 
 type Verification struct {
+	Object                          string          `json:"object"`
 	Status                          string          `json:"status"`
 	Strategy                        string          `json:"strategy"`
+	Channel                         *string         `json:"channel,omitempty"`
 	Attempts                        *int64          `json:"attempts"`
 	ExpireAt                        *int64          `json:"expire_at"`
 	VerifiedAtClient                string          `json:"verified_at_client,omitempty"`

--- a/email_address.go
+++ b/email_address.go
@@ -10,7 +10,7 @@ type EmailAddress struct {
 	Reserved             bool                    `json:"reserved"`
 	Verification         *Verification           `json:"verification"`
 	LinkedTo             []*LinkedIdentification `json:"linked_to"`
-	MatchesSsoConnection bool                    `json:"matches_sso_connection"`
+	MatchesSSOConnection bool                    `json:"matches_sso_connection"`
 	CreatedAt            int64                   `json:"created_at"`
 	UpdatedAt            int64                   `json:"updated_at"`
 }

--- a/enterprise_account.go
+++ b/enterprise_account.go
@@ -1,0 +1,44 @@
+package clerk
+
+import "encoding/json"
+
+type EnterpriseAccount struct {
+	ID                     string                       `json:"id"`
+	Object                 string                       `json:"object"`
+	Protocol               string                       `json:"protocol"`
+	Provider               string                       `json:"provider"`
+	Active                 bool                         `json:"active"`
+	EmailAddress           string                       `json:"email_address"`
+	FirstName              *string                      `json:"first_name"`
+	LastName               *string                      `json:"last_name"`
+	ProviderUserID         *string                      `json:"provider_user_id"`
+	LastAuthenticatedAt    *int64                       `json:"last_authenticated_at"`
+	PublicMetadata         json.RawMessage              `json:"public_metadata" logger:"omit"`
+	Verification           *Verification                `json:"verification"`
+	EnterpriseConnection   *enterpriseAccountConnection `json:"enterprise_connection"`
+	EnterpriseConnectionID string                       `json:"enterprise_connection_id"`
+}
+
+type enterpriseAccountConnection struct {
+	// ID belongs to the underlying connection, either SAML Connection or the OAuth config
+	ID                     string `json:"id"`
+	EnterpriseConnectionID string `json:"enterprise_connection_id"`
+	Protocol               string `json:"protocol"`
+	Provider               string `json:"provider"`
+
+	// Name is the name of this enterprise connection that we will display directly to end-users
+	Name          string  `json:"name"`
+	LogoPublicURL *string `json:"logo_public_url"`
+	// Deprecated: Use Domains instead
+	Domain                           string   `json:"domain,omitempty"`
+	Domains                          []string `json:"domains,omitempty"`
+	Active                           bool     `json:"active"`
+	SyncUserAttributes               bool     `json:"sync_user_attributes"`
+	DisableAdditionalIdentifications bool     `json:"disable_additional_identifications"`
+	CreatedAt                        int64    `json:"created_at"`
+	UpdatedAt                        int64    `json:"updated_at"`
+
+	// SAML Connection specific fields
+	AllowSubdomains   bool `json:"allow_subdomains"`
+	AllowIdpInitiated bool `json:"allow_idp_initiated"`
+}

--- a/enterprise_account.go
+++ b/enterprise_account.go
@@ -27,10 +27,8 @@ type enterpriseAccountConnection struct {
 	Provider               string `json:"provider"`
 
 	// Name is the name of this enterprise connection that we will display directly to end-users
-	Name          string  `json:"name"`
-	LogoPublicURL *string `json:"logo_public_url"`
-	// Deprecated: Use Domains instead
-	Domain                           string   `json:"domain,omitempty"`
+	Name                             string   `json:"name"`
+	LogoPublicURL                    *string  `json:"logo_public_url"`
 	Domains                          []string `json:"domains,omitempty"`
 	Active                           bool     `json:"active"`
 	SyncUserAttributes               bool     `json:"sync_user_attributes"`

--- a/enterprise_account.go
+++ b/enterprise_account.go
@@ -15,11 +15,11 @@ type EnterpriseAccount struct {
 	LastAuthenticatedAt    *int64                       `json:"last_authenticated_at"`
 	PublicMetadata         json.RawMessage              `json:"public_metadata" logger:"omit"`
 	Verification           *Verification                `json:"verification"`
-	EnterpriseConnection   *enterpriseAccountConnection `json:"enterprise_connection"`
+	EnterpriseConnection   *EnterpriseAccountConnection `json:"enterprise_connection"`
 	EnterpriseConnectionID string                       `json:"enterprise_connection_id"`
 }
 
-type enterpriseAccountConnection struct {
+type EnterpriseAccountConnection struct {
 	// ID belongs to the underlying connection, either SAML Connection or the OAuth config
 	ID                     string `json:"id"`
 	EnterpriseConnectionID string `json:"enterprise_connection_id"`

--- a/enterprise_account.go
+++ b/enterprise_account.go
@@ -38,5 +38,5 @@ type enterpriseAccountConnection struct {
 
 	// SAML Connection specific fields
 	AllowSubdomains   bool `json:"allow_subdomains"`
-	AllowIdpInitiated bool `json:"allow_idp_initiated"`
+	AllowIDPInitiated bool `json:"allow_idp_initiated"`
 }

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -30,4 +30,5 @@ type OrganizationMembershipPublicUserData struct {
 	ImageURL   *string `json:"image_url"`
 	HasImage   bool    `json:"has_image"`
 	Identifier string  `json:"identifier"`
+	Username   *string `json:"username"`
 }

--- a/phone_number.go
+++ b/phone_number.go
@@ -11,4 +11,6 @@ type PhoneNumber struct {
 	Verification            *Verification           `json:"verification"`
 	LinkedTo                []*LinkedIdentification `json:"linked_to"`
 	BackupCodes             []string                `json:"backup_codes"`
+	CreatedAt               int64                   `json:"created_at"`
+	UpdatedAt               int64                   `json:"updated_at"`
 }

--- a/user.go
+++ b/user.go
@@ -60,6 +60,7 @@ type ExternalAccount struct {
 	AvatarURL        string          `json:"avatar_url"`
 	ImageURL         *string         `json:"image_url,omitempty"`
 	Username         *string         `json:"username"`
+	PhoneNumber      *string         `json:"phone_number"`
 	PublicMetadata   json.RawMessage `json:"public_metadata"`
 	Label            *string         `json:"label"`
 	CreatedAt        int64           `json:"created_at"`
@@ -87,7 +88,7 @@ type SAMLAccount struct {
 	ProviderUserID         *string                `json:"provider_user_id"`
 	LastAuthenticatedAt    *int64                 `json:"last_authenticated_at"`
 	PublicMetadata         json.RawMessage        `json:"public_metadata"`
-	SAMLConnection         *samlAccountConnection `json:"saml_connection"`
+	SAMLConnection         *SAMLAccountConnection `json:"saml_connection"`
 	EnterpriseConnectionID string                 `json:"enterprise_connection_id"`
 	Verification           *Verification          `json:"verification"`
 }
@@ -98,7 +99,7 @@ type UserList struct {
 	TotalCount int64   `json:"total_count"`
 }
 
-type samlAccountConnection struct {
+type SAMLAccountConnection struct {
 	ID                               string   `json:"id"`
 	Name                             string   `json:"name"`
 	Domains                          []string `json:"domains"`

--- a/user.go
+++ b/user.go
@@ -4,43 +4,47 @@ import "encoding/json"
 
 type User struct {
 	APIResource
-	Object                        string             `json:"object"`
-	ID                            string             `json:"id"`
-	Username                      *string            `json:"username"`
-	FirstName                     *string            `json:"first_name"`
-	LastName                      *string            `json:"last_name"`
-	ImageURL                      *string            `json:"image_url,omitempty"`
-	HasImage                      bool               `json:"has_image"`
-	PrimaryEmailAddressID         *string            `json:"primary_email_address_id"`
-	PrimaryPhoneNumberID          *string            `json:"primary_phone_number_id"`
-	PrimaryWeb3WalletID           *string            `json:"primary_web3_wallet_id"`
-	PasswordEnabled               bool               `json:"password_enabled"`
-	TwoFactorEnabled              bool               `json:"two_factor_enabled"`
-	TOTPEnabled                   bool               `json:"totp_enabled"`
-	BackupCodeEnabled             bool               `json:"backup_code_enabled"`
-	EmailAddresses                []*EmailAddress    `json:"email_addresses"`
-	PhoneNumbers                  []*PhoneNumber     `json:"phone_numbers"`
-	Web3Wallets                   []*Web3Wallet      `json:"web3_wallets"`
-	Passkeys                      []*Passkey         `json:"passkeys"`
-	ExternalAccounts              []*ExternalAccount `json:"external_accounts"`
-	SAMLAccounts                  []*SAMLAccount     `json:"saml_accounts"`
-	PasswordLastUpdatedAt         *int64             `json:"password_last_updated_at,omitempty"`
-	PublicMetadata                json.RawMessage    `json:"public_metadata"`
-	PrivateMetadata               json.RawMessage    `json:"private_metadata,omitempty"`
-	UnsafeMetadata                json.RawMessage    `json:"unsafe_metadata,omitempty"`
-	ExternalID                    *string            `json:"external_id"`
-	LastSignInAt                  *int64             `json:"last_sign_in_at"`
-	Banned                        bool               `json:"banned"`
-	Locked                        bool               `json:"locked"`
-	LockoutExpiresInSeconds       *int64             `json:"lockout_expires_in_seconds"`
-	VerificationAttemptsRemaining *int64             `json:"verification_attempts_remaining"`
-	DeleteSelfEnabled             bool               `json:"delete_self_enabled"`
-	CreateOrganizationEnabled     bool               `json:"create_organization_enabled"`
-	CreateOrganizationsLimit      *int               `json:"create_organizations_limit,omitempty"`
-	LastActiveAt                  *int64             `json:"last_active_at"`
-	LegalAcceptedAt               *int64             `json:"legal_accepted_at"`
-	CreatedAt                     int64              `json:"created_at"`
-	UpdatedAt                     int64              `json:"updated_at"`
+	Object                        string                    `json:"object"`
+	ID                            string                    `json:"id"`
+	Username                      *string                   `json:"username"`
+	FirstName                     *string                   `json:"first_name"`
+	LastName                      *string                   `json:"last_name"`
+	ImageURL                      *string                   `json:"image_url,omitempty"`
+	HasImage                      bool                      `json:"has_image"`
+	PrimaryEmailAddressID         *string                   `json:"primary_email_address_id"`
+	PrimaryPhoneNumberID          *string                   `json:"primary_phone_number_id"`
+	PrimaryWeb3WalletID           *string                   `json:"primary_web3_wallet_id"`
+	PasswordEnabled               bool                      `json:"password_enabled"`
+	TwoFactorEnabled              bool                      `json:"two_factor_enabled"`
+	TOTPEnabled                   bool                      `json:"totp_enabled"`
+	BackupCodeEnabled             bool                      `json:"backup_code_enabled"`
+	EmailAddresses                []*EmailAddress           `json:"email_addresses"`
+	PhoneNumbers                  []*PhoneNumber            `json:"phone_numbers"`
+	Web3Wallets                   []*Web3Wallet             `json:"web3_wallets"`
+	Passkeys                      []*Passkey                `json:"passkeys"`
+	OrganizationMemberships       []*OrganizationMembership `json:"organization_memberships,omitempty"`
+	ExternalAccounts              []*ExternalAccount        `json:"external_accounts"`
+	SAMLAccounts                  []*SAMLAccount            `json:"saml_accounts"`
+	EnterpriseAccounts            []*EnterpriseAccount      `json:"enterprise_accounts"`
+	PasswordLastUpdatedAt         *int64                    `json:"password_last_updated_at,omitempty"`
+	PublicMetadata                json.RawMessage           `json:"public_metadata"`
+	PrivateMetadata               json.RawMessage           `json:"private_metadata,omitempty"`
+	UnsafeMetadata                json.RawMessage           `json:"unsafe_metadata,omitempty"`
+	ExternalID                    *string                   `json:"external_id"`
+	LastSignInAt                  *int64                    `json:"last_sign_in_at"`
+	Banned                        bool                      `json:"banned"`
+	Locked                        bool                      `json:"locked"`
+	LockoutExpiresInSeconds       *int64                    `json:"lockout_expires_in_seconds"`
+	VerificationAttemptsRemaining *int64                    `json:"verification_attempts_remaining"`
+	CreatedAt                     int64                     `json:"created_at"`
+	UpdatedAt                     int64                     `json:"updated_at"`
+	DeleteSelfEnabled             bool                      `json:"delete_self_enabled"`
+	CreateOrganizationEnabled     bool                      `json:"create_organization_enabled"`
+	CreateOrganizationsLimit      *int                      `json:"create_organizations_limit,omitempty"`
+	LastActiveAt                  *int64                    `json:"last_active_at"`
+	MFAEnabledAt                  *int64                    `json:"mfa_enabled_at"`
+	MFADisabledAt                 *int64                    `json:"mfa_disabled_at"`
+	LegalAcceptedAt               *int64                    `json:"legal_accepted_at"`
 }
 
 type ExternalAccount struct {
@@ -58,6 +62,8 @@ type ExternalAccount struct {
 	Username         *string         `json:"username"`
 	PublicMetadata   json.RawMessage `json:"public_metadata"`
 	Label            *string         `json:"label"`
+	CreatedAt        int64           `json:"created_at"`
+	UpdatedAt        int64           `json:"updated_at"`
 	Verification     *Verification   `json:"verification"`
 }
 
@@ -66,23 +72,44 @@ type Web3Wallet struct {
 	ID           string        `json:"id"`
 	Web3Wallet   string        `json:"web3_wallet"`
 	Verification *Verification `json:"verification"`
+	CreatedAt    int64         `json:"created_at"`
+	UpdatedAt    int64         `json:"updated_at"`
 }
 
 type SAMLAccount struct {
-	Object         string          `json:"object"`
-	ID             string          `json:"id"`
-	Provider       string          `json:"provider"`
-	Active         bool            `json:"active"`
-	EmailAddress   string          `json:"email_address"`
-	FirstName      *string         `json:"first_name"`
-	LastName       *string         `json:"last_name"`
-	ProviderUserID *string         `json:"provider_user_id"`
-	PublicMetadata json.RawMessage `json:"public_metadata"`
-	Verification   *Verification   `json:"verification"`
+	Object                 string                 `json:"object"`
+	ID                     string                 `json:"id"`
+	Provider               string                 `json:"provider"`
+	Active                 bool                   `json:"active"`
+	EmailAddress           string                 `json:"email_address"`
+	FirstName              *string                `json:"first_name"`
+	LastName               *string                `json:"last_name"`
+	ProviderUserID         *string                `json:"provider_user_id"`
+	LastAuthenticatedAt    *int64                 `json:"last_authenticated_at"`
+	PublicMetadata         json.RawMessage        `json:"public_metadata"`
+	SamlConnection         *samlAccountConnection `json:"saml_connection"`
+	EnterpriseConnectionID string                 `json:"enterprise_connection_id"`
+	Verification           *Verification          `json:"verification"`
 }
 
 type UserList struct {
 	APIResource
 	Users      []*User `json:"data"`
 	TotalCount int64   `json:"total_count"`
+}
+
+type samlAccountConnection struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// Deprecated: Use Domains instead
+	Domain                           string   `json:"domain"`
+	Domains                          []string `json:"domains"`
+	Active                           bool     `json:"active"`
+	Provider                         string   `json:"provider"`
+	SyncUserAttributes               bool     `json:"sync_user_attributes"`
+	AllowSubdomains                  bool     `json:"allow_subdomains"`
+	AllowIdpInitiated                bool     `json:"allow_idp_initiated"`
+	DisableAdditionalIdentifications bool     `json:"disable_additional_identifications"`
+	CreatedAt                        int64    `json:"created_at"`
+	UpdatedAt                        int64    `json:"updated_at"`
 }

--- a/user.go
+++ b/user.go
@@ -99,10 +99,8 @@ type UserList struct {
 }
 
 type samlAccountConnection struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	// Deprecated: Use Domains instead
-	Domain                           string   `json:"domain"`
+	ID                               string   `json:"id"`
+	Name                             string   `json:"name"`
 	Domains                          []string `json:"domains"`
 	Active                           bool     `json:"active"`
 	Provider                         string   `json:"provider"`

--- a/user.go
+++ b/user.go
@@ -87,7 +87,7 @@ type SAMLAccount struct {
 	ProviderUserID         *string                `json:"provider_user_id"`
 	LastAuthenticatedAt    *int64                 `json:"last_authenticated_at"`
 	PublicMetadata         json.RawMessage        `json:"public_metadata"`
-	SamlConnection         *samlAccountConnection `json:"saml_connection"`
+	SAMLConnection         *samlAccountConnection `json:"saml_connection"`
 	EnterpriseConnectionID string                 `json:"enterprise_connection_id"`
 	Verification           *Verification          `json:"verification"`
 }
@@ -106,7 +106,7 @@ type samlAccountConnection struct {
 	Provider                         string   `json:"provider"`
 	SyncUserAttributes               bool     `json:"sync_user_attributes"`
 	AllowSubdomains                  bool     `json:"allow_subdomains"`
-	AllowIdpInitiated                bool     `json:"allow_idp_initiated"`
+	AllowIDPInitiated                bool     `json:"allow_idp_initiated"`
 	DisableAdditionalIdentifications bool     `json:"disable_additional_identifications"`
 	CreatedAt                        int64    `json:"created_at"`
 	UpdatedAt                        int64    `json:"updated_at"`


### PR DESCRIPTION
## Changes

- Add `EnterpriseAccount` type with SAML/OAuth enterprise connection support
- Enhance `User` struct with new fields:
  - `CreatedAt`, `UpdatedAt`, `MFAEnabledAt`, `MFADisabledAt`, `LegalAcceptedAt`
  - `EnterpriseAccounts` for enterprise SSO support
- Update `EmailAddress` with `MatchesSsoConnection` field
- Add shared `Verification` and `LinkedIdentification` types