### PR TITLE
feat: Add locale field from BAPI

### DIFF
--- a/user.go
+++ b/user.go
@@ -39,6 +39,7 @@ type User struct {
 	CreateOrganizationsLimit      *int               `json:"create_organizations_limit,omitempty"`
 	LastActiveAt                  *int64             `json:"last_active_at"`
 	LegalAcceptedAt               *int64             `json:"legal_accepted_at"`
+	Locale                        *string            `json:"locale"`
 	CreatedAt                     int64              `json:"created_at"`
 	UpdatedAt                     int64              `json:"updated_at"`
 }

--- a/user/client.go
+++ b/user/client.go
@@ -57,6 +57,8 @@ type CreateParams struct {
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`
 	// Specified in RFC3339 format
 	CreatedAt *string `json:"created_at,omitempty"`
+	// Specified in BCP-47 format
+	Locale *string `json:"locale,omitempty"`
 }
 
 // Create creates a new user.
@@ -110,6 +112,8 @@ type UpdateParams struct {
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`
 	// Specified in RFC3339 format
 	CreatedAt *string `json:"created_at,omitempty"`
+	// Specified in BCP-47 format
+	Locale *string `json:"locale,omitempty"`
 }
 
 // Update updates a user.

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -39,6 +39,32 @@ func TestUserClientCreate(t *testing.T) {
 	require.Equal(t, username, *user.Username)
 }
 
+func TestUserClientCreate_WithLocale(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	username := "username"
+	locale := "en-US"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"username":"%s","locale":"%s"}`, username, locale)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","username":"%s","locale":"%s"}`, id, username, locale)),
+			Method: http.MethodPost,
+			Path:   "/v1/users",
+		},
+	}
+	client := NewClient(config)
+	user, err := client.Create(context.Background(), &CreateParams{
+		Username: clerk.String(username),
+		Locale:   clerk.String(locale),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, user.ID)
+	require.Equal(t, username, *user.Username)
+	require.Equal(t, locale, *user.Locale)
+}
+
 func TestUserClientList_Request(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}
@@ -197,6 +223,29 @@ func TestUserClientUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, user.ID)
 	require.Equal(t, username, *user.Username)
+}
+
+func TestUserClientUpdate_WithLocale(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	locale := "fr-FR"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"locale":"%s"}`, locale)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","locale":"%s"}`, id, locale)),
+			Method: http.MethodPatch,
+			Path:   "/v1/users/" + id,
+		},
+	}
+	client := NewClient(config)
+	user, err := client.Update(context.Background(), id, &UpdateParams{
+		Locale: clerk.String(locale),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, user.ID)
+	require.Equal(t, locale, *user.Locale)
 }
 
 type testFile struct {


### PR DESCRIPTION
Context: https://github.com/clerk/clerk_go/pull/13957

We currently support `locale` field for the user model. The feature of sending localized emails is under development behind a feature flag.

https://linear.app/clerk/issue/USER-3627/update-go-sdk-to-support-locale