### PR TITLE
feat: Adds inviter_id to org invitation struct

### DIFF
--- a/organization_invitation.go
+++ b/organization_invitation.go
@@ -18,6 +18,7 @@ type OrganizationInvitation struct {
 	Role                   string                  `json:"role"`
 	RoleName               string                  `json:"role_name"`
 	OrganizationID         string                  `json:"organization_id"`
+	InviterID              string                  `json:"inviter_id"`
 	PublicOrganizationData *PublicOrganizationData `json:"public_organization_data,omitempty"`
 	Status                 string                  `json:"status"`
 	PublicMetadata         json.RawMessage         `json:"public_metadata"`

--- a/organizationinvitation/client_test.go
+++ b/organizationinvitation/client_test.go
@@ -70,6 +70,7 @@ func TestOrganizationInvitationClientList(t *testing.T) {
 	t.Parallel()
 	organizationID := "org_123"
 	id := "orginv_123"
+	inviterID := "inviter_123"
 	statuses := []string{"pending", "accepted"}
 	emailAddress := "string"
 	orderBy := "-created_at"
@@ -78,7 +79,7 @@ func TestOrganizationInvitationClientList(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			Out:    json.RawMessage(fmt.Sprintf(`{"data":[{"id":"%s","object":"organization_invitation","email_address":"string","role":"string","organization_id":"%s","status":"string","public_metadata":{},"private_metadata":{},"expires_at":1,"created_at":0,"updated_at":0}],"total_count":1}`, id, organizationID)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"data":[{"id":"%s","object":"organization_invitation","email_address":"string","role":"string","organization_id":"%s","inviter_id":"%s","status":"string","public_metadata":{},"private_metadata":{},"expires_at":1,"created_at":0,"updated_at":0}],"total_count":1}`, id, organizationID, inviterID)),
 			Method: http.MethodGet,
 			Path:   "/v1/organizations/" + organizationID + "/invitations",
 			Query: &url.Values{
@@ -103,6 +104,7 @@ func TestOrganizationInvitationClientList(t *testing.T) {
 	require.Len(t, response.OrganizationInvitations, 1)
 	require.Equal(t, id, response.OrganizationInvitations[0].ID)
 	require.Equal(t, organizationID, response.OrganizationInvitations[0].OrganizationID)
+	require.Equal(t, inviterID, response.OrganizationInvitations[0].InviterID)
 	require.Equal(t, int64(1), *response.OrganizationInvitations[0].ExpiresAt)
 	require.Equal(t, int64(1), response.TotalCount)
 }
@@ -135,12 +137,13 @@ func TestOrganizationInvitationClientList_Error(t *testing.T) {
 func TestOrganizationInvitationClientGet(t *testing.T) {
 	t.Parallel()
 	organizationID := "org_123"
+	inviterID := "inviter_123"
 	id := "orginv_123"
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"organization_invitation","email_address":"string","role":"string","role_name":"string","organization_id":"%s","status":"string","public_metadata":{},"private_metadata":{},"expires_at": 1,"created_at":0,"updated_at":0}`, id, organizationID)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"organization_invitation","email_address":"string","role":"string","role_name":"string","organization_id":"%s","inviter_id":"%s","status":"string","public_metadata":{},"private_metadata":{},"expires_at": 1,"created_at":0,"updated_at":0}`, id, organizationID, inviterID)),
 			Method: http.MethodGet,
 			Path:   "/v1/organizations/" + organizationID + "/invitations/" + id,
 		},
@@ -153,6 +156,7 @@ func TestOrganizationInvitationClientGet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, response.ID)
 	require.Equal(t, organizationID, response.OrganizationID)
+	require.Equal(t, inviterID, response.InviterID)
 	require.Equal(t, "string", response.RoleName)
 	require.Equal(t, "string", response.Role)
 	require.Equal(t, int64(1), *response.ExpiresAt)


### PR DESCRIPTION
bapi is being updated to store and report org invitation inviter ID. This PR updates the `OrganizationInvitation` struct to capture that data.

ORGS-736