### PR TITLE
ORGS-953: Add max_role_sets_allowed field on organization settings

### DIFF
--- a/instance_settings.go
+++ b/instance_settings.go
@@ -18,6 +18,7 @@ type OrganizationSettings struct {
 	MaxAllowedMemberships  int64    `json:"max_allowed_memberships"`
 	MaxAllowedRoles        int64    `json:"max_allowed_roles"`
 	MaxAllowedPermissions  int64    `json:"max_allowed_permissions"`
+	MaxRoleSetsAllowed     int64    `json:"max_role_sets_allowed"`
 	CreatorRole            string   `json:"creator_role"`
 	AdminDeleteEnabled     bool     `json:"admin_delete_enabled"`
 	DomainsEnabled         bool     `json:"domains_enabled"`

--- a/instancesettings/client_test.go
+++ b/instancesettings/client_test.go
@@ -132,7 +132,7 @@ func TestInstanceClientUpdateOrganizationSettingsWithInitialRoleSetKey(t *testin
 		Transport: &clerktest.RoundTripper{
 			T:      t,
 			In:     json.RawMessage(`{"enabled":true,"initial_role_set_key":"admin-roles"}`),
-			Out:    json.RawMessage(`{"enabled":true,"max_allowed_memberships":5,"initial_role_set_key":"admin-roles"}`),
+			Out:    json.RawMessage(`{"enabled":true,"max_allowed_memberships":5,"initial_role_set_key":"admin-roles", "max_role_sets_allowed": 30}`),
 			Method: http.MethodPatch,
 			Path:   "/v1/instance/organization_settings",
 		},


### PR DESCRIPTION
Adds new field MaxRoleSetsAllowed on OrganizationSettings struct