### PR TITLE
Add delete and get methods to apikey client

### DIFF
--- a/apikey/api.go
+++ b/apikey/api.go
@@ -13,6 +13,11 @@ func Create(ctx context.Context, params *CreateParams) (*clerk.APIKeyWithSecret,
 	return getClient().Create(ctx, params)
 }
 
+// Get returns an API key
+func Get(ctx context.Context, apiKeyID string) (*clerk.APIKey, error) {
+	return getClient().Get(ctx, apiKeyID)
+}
+
 // List returns a list of API keys.
 func List(ctx context.Context, params *ListParams) (*clerk.APIKeyList, error) {
 	return getClient().List(ctx, params)
@@ -26,6 +31,11 @@ func GetSecret(ctx context.Context, apiKeyID string) (*APIKeySecret, error) {
 // Update updates an API key.
 func Update(ctx context.Context, apiKeyID string, params *UpdateParams) (*clerk.APIKey, error) {
 	return getClient().Update(ctx, apiKeyID, params)
+}
+
+// Delete deletes an API key
+func Delete(ctx context.Context, apiKeyID string) (*clerk.DeletedResource, error) {
+	return getClient().Delete(ctx, apiKeyID)
 }
 
 // Revoke revokes an API key.

--- a/apikey/api_test.go
+++ b/apikey/api_test.go
@@ -68,6 +68,52 @@ func TestPackageCreate(t *testing.T) {
 	assert.Equal(t, "ak_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", apiKey.Secret)
 }
 
+func TestPackageGet(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"object":            "api_key",
+		"id":                "ak_test123",
+		"type":              "api_key",
+		"subject":           "user_123",
+		"name":              "test_key",
+		"description":       "Test API key",
+		"claims":            map[string]interface{}{},
+		"scopes":            []string{},
+		"revoked":           false,
+		"revocation_reason": nil,
+		"expired":           false,
+		"expiration":        nil,
+		"created_by":        "user_123",
+		"last_used_at":      nil,
+		"created_at":        1640995200,
+		"updated_at":        1640995200,
+	}
+
+	responseJSON, _ := json.Marshal(response)
+
+	backend := &clerk.BackendConfig{
+		HTTPClient: &http.Client{
+			Transport: &clerktest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(responseJSON),
+				Method: http.MethodGet,
+				Path:   "/v1/api_keys/ak_test123",
+			},
+		},
+	}
+
+	clerk.SetBackend(clerk.NewBackend(backend))
+
+	apiKey, err := Get(context.Background(), "ak_test123")
+	require.NoError(t, err)
+	assert.Equal(t, "ak_test123", apiKey.ID)
+	assert.Equal(t, "test_key", apiKey.Name)
+	assert.Equal(t, "user_123", apiKey.Subject)
+	assert.Equal(t, "Test API key", *apiKey.Description)
+	assert.False(t, apiKey.Revoked)
+}
+
 func TestPackageList(t *testing.T) {
 	t.Parallel()
 
@@ -198,6 +244,37 @@ func TestPackageUpdate(t *testing.T) {
 	apiKey, err := Update(context.Background(), "ak_test123", params)
 	require.NoError(t, err)
 	assert.Equal(t, "Updated description", *apiKey.Description)
+}
+
+func TestPackageDelete(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"object":  "api_key",
+		"id":      "ak_test123",
+		"deleted": true,
+	}
+
+	responseJSON, _ := json.Marshal(response)
+
+	backend := &clerk.BackendConfig{
+		HTTPClient: &http.Client{
+			Transport: &clerktest.RoundTripper{
+				T:      t,
+				Out:    json.RawMessage(responseJSON),
+				Method: http.MethodDelete,
+				Path:   "/v1/api_keys/ak_test123",
+			},
+		},
+	}
+
+	clerk.SetBackend(clerk.NewBackend(backend))
+
+	deletedResource, err := Delete(context.Background(), "ak_test123")
+	require.NoError(t, err)
+	assert.Equal(t, "ak_test123", deletedResource.ID)
+	assert.True(t, deletedResource.Deleted)
+	assert.Equal(t, "api_key", deletedResource.Object)
 }
 
 func TestPackageUpdateWithSecondsUntilExpiration(t *testing.T) {

--- a/apikey/client.go
+++ b/apikey/client.go
@@ -47,6 +47,18 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.APIKe
 	return resource, err
 }
 
+// Get returns an API key
+func (c *Client) Get(ctx context.Context, apiKeyID string) (*clerk.APIKey, error) {
+	path, err := clerk.JoinPath(path, apiKeyID)
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodGet, path)
+	resource := &clerk.APIKey{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}
+
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
@@ -120,6 +132,18 @@ func (c *Client) Update(ctx context.Context, apiKeyID string, params *UpdatePara
 	req := clerk.NewAPIRequest(http.MethodPatch, path)
 	req.SetParams(params)
 	resource := &clerk.APIKey{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}
+
+// Delete deletes an API key
+func (c *Client) Delete(ctx context.Context, apiKeyID string) (*clerk.DeletedResource, error) {
+	path, err := clerk.JoinPath(path, apiKeyID)
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodDelete, path)
+	resource := &clerk.DeletedResource{}
 	err = c.Backend.Call(ctx, req, resource)
 	return resource, err
 }

--- a/apikey/client_test.go
+++ b/apikey/client_test.go
@@ -120,6 +120,50 @@ func TestList(t *testing.T) {
 	assert.Equal(t, "ak_test123", apiKeys.APIKeys[0].ID)
 }
 
+func TestGet(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"object":            "api_key",
+		"id":                "ak_test123",
+		"type":              "api_key",
+		"subject":           "user_123",
+		"name":              "test_key",
+		"description":       "Test API key",
+		"claims":            map[string]interface{}{},
+		"scopes":            []string{},
+		"revoked":           false,
+		"revocation_reason": nil,
+		"expired":           false,
+		"expiration":        nil,
+		"created_by":        "user_123",
+		"last_used_at":      nil,
+		"created_at":        1640995200,
+		"updated_at":        1640995200,
+	}
+
+	responseJSON, _ := json.Marshal(response)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(responseJSON),
+			Method: http.MethodGet,
+			Path:   "/v1/api_keys/ak_test123",
+		},
+	}
+
+	client := NewClient(config)
+	apiKey, err := client.Get(context.Background(), "ak_test123")
+	require.NoError(t, err)
+	assert.Equal(t, "ak_test123", apiKey.ID)
+	assert.Equal(t, "test_key", apiKey.Name)
+	assert.Equal(t, "user_123", apiKey.Subject)
+	assert.Equal(t, "Test API key", *apiKey.Description)
+	assert.False(t, apiKey.Revoked)
+}
+
 func TestGetSecret(t *testing.T) {
 	t.Parallel()
 
@@ -281,6 +325,35 @@ func TestUpdateSecondsUntilExpirationOnly(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ak_test123", apiKey.ID)
 	assert.Equal(t, int64(1716883200), *apiKey.Expiration)
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"object":  "api_key",
+		"id":      "ak_test123",
+		"deleted": true,
+	}
+
+	responseJSON, _ := json.Marshal(response)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(responseJSON),
+			Method: http.MethodDelete,
+			Path:   "/v1/api_keys/ak_test123",
+		},
+	}
+
+	client := NewClient(config)
+	deletedResource, err := client.Delete(context.Background(), "ak_test123")
+	require.NoError(t, err)
+	assert.Equal(t, "ak_test123", deletedResource.ID)
+	assert.True(t, deletedResource.Deleted)
+	assert.Equal(t, "api_key", deletedResource.Object)
 }
 
 func TestRevoke(t *testing.T) {


### PR DESCRIPTION
Adds methods for Get and Delete to the api_key client. The bapi edge endpoints were introduced in the following PRs -
https://github.com/clerk/cloudflare-workers/pull/1414
https://github.com/clerk/cloudflare-workers/pull/1411