### PR TITLE
feat: Add `PasswordCompromised` endpoint

### DIFF
--- a/user.go
+++ b/user.go
@@ -47,6 +47,7 @@ type User struct {
 	MFADisabledAt                 *int64                    `json:"mfa_disabled_at"`
 	LegalAcceptedAt               *int64                    `json:"legal_accepted_at"`
 	Locale                        *string                   `json:"locale"`
+	RequiresPasswordReset         bool                      `json:"requires_password_reset"`
 }
 
 type ExternalAccount struct {

--- a/user.go
+++ b/user.go
@@ -47,7 +47,7 @@ type User struct {
 	MFADisabledAt                 *int64                    `json:"mfa_disabled_at"`
 	LegalAcceptedAt               *int64                    `json:"legal_accepted_at"`
 	Locale                        *string                   `json:"locale"`
-	RequiresPasswordReset         bool                      `json:"requires_password_reset"`
+	RequiresPasswordReset         *bool                     `json:"requires_password_reset,omitempty"`
 }
 
 type ExternalAccount struct {

--- a/user/api.go
+++ b/user/api.go
@@ -126,9 +126,9 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 	return getClient().DeleteExternalAccount(ctx, params)
 }
 
-// PasswordUntrusted marks the user's password as untrusted.
-func PasswordUntrusted(ctx context.Context, params *PasswordUntrustedParams) (*clerk.User, error) {
-	return getClient().PasswordUntrusted(ctx, params)
+// PasswordCompromised marks the user's password as compromised.
+func PasswordCompromised(ctx context.Context, params *PasswordCompromisedParams) (*clerk.User, error) {
+	return getClient().PasswordCompromised(ctx, params)
 }
 
 func getClient() *Client {

--- a/user/api.go
+++ b/user/api.go
@@ -127,8 +127,8 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 }
 
 // PasswordCompromised marks the user's password as compromised.
-func PasswordCompromised(ctx context.Context, params *PasswordCompromisedParams) (*clerk.User, error) {
-	return getClient().PasswordCompromised(ctx, params)
+func PasswordCompromised(ctx context.Context, userID string) (*clerk.User, error) {
+	return getClient().PasswordCompromised(ctx, userID)
 }
 
 func getClient() *Client {

--- a/user/api.go
+++ b/user/api.go
@@ -126,7 +126,7 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 	return getClient().DeleteExternalAccount(ctx, params)
 }
 
-// DeleteExternalAccount deletes an external account by its ID.
+// PasswordUntrusted marks the user's password as untrusted.
 func PasswordUntrusted(ctx context.Context, params *PasswordUntrustedParams) (*clerk.User, error) {
 	return getClient().PasswordUntrusted(ctx, params)
 }

--- a/user/api.go
+++ b/user/api.go
@@ -126,8 +126,8 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 	return getClient().DeleteExternalAccount(ctx, params)
 }
 
-// PasswordUntrusted marks the user's password as untrusted.
-func PasswordUntrusted(ctx context.Context, params *DeleteExternalAccountParams) (*clerk.DeletedResource, error) {
+// DeleteExternalAccount deletes an external account by its ID.
+func PasswordUntrusted(ctx context.Context, params *PasswordUntrustedParams) (*clerk.User, error) {
 	return getClient().PasswordUntrusted(ctx, params)
 }
 

--- a/user/api.go
+++ b/user/api.go
@@ -126,6 +126,11 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 	return getClient().DeleteExternalAccount(ctx, params)
 }
 
+// PasswordUntrusted marks the user's password as untrusted.
+func PasswordUntrusted(ctx context.Context, params *DeleteExternalAccountParams) (*clerk.DeletedResource, error) {
+	return getClient().PasswordUntrusted(ctx, params)
+}
+
 func getClient() *Client {
 	return &Client{
 		Backend: clerk.GetBackend(),

--- a/user/client.go
+++ b/user/client.go
@@ -589,14 +589,14 @@ func (c *Client) DeleteExternalAccount(ctx context.Context, params *DeleteExtern
 	return resource, err
 }
 
-type PasswordUntrustedParams struct {
+type PasswordCompromisedParams struct {
 	clerk.APIParams
 	UserID string `json:"user_id"`
 }
 
-// PasswordUntrusted marks the user's password as untrusted.
-func (c *Client) PasswordUntrusted(ctx context.Context, params *PasswordUntrustedParams) (*clerk.User, error) {
-	path, err := clerk.JoinPath(path, params.UserID, "/password_untrusted")
+// PasswordCompromised marks the user's password as compromised.
+func (c *Client) PasswordCompromised(ctx context.Context, params *PasswordCompromisedParams) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, params.UserID, "/password_compromised")
 	if err != nil {
 		return nil, err
 	}

--- a/user/client.go
+++ b/user/client.go
@@ -594,7 +594,7 @@ type PasswordUntrustedParams struct {
 	UserID string `json:"user_id"`
 }
 
-// DeleteExternalAccount deletes an external account by its ID.
+// PasswordUntrusted marks the user's password as untrusted.
 func (c *Client) PasswordUntrusted(ctx context.Context, params *PasswordUntrustedParams) (*clerk.User, error) {
 	path, err := clerk.JoinPath(path, params.UserID, "/password_untrusted")
 	if err != nil {

--- a/user/client.go
+++ b/user/client.go
@@ -589,14 +589,9 @@ func (c *Client) DeleteExternalAccount(ctx context.Context, params *DeleteExtern
 	return resource, err
 }
 
-type PasswordCompromisedParams struct {
-	clerk.APIParams
-	UserID string `json:"user_id"`
-}
-
 // PasswordCompromised marks the user's password as compromised.
-func (c *Client) PasswordCompromised(ctx context.Context, params *PasswordCompromisedParams) (*clerk.User, error) {
-	path, err := clerk.JoinPath(path, params.UserID, "/password_compromised")
+func (c *Client) PasswordCompromised(ctx context.Context, userID string) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, userID, "/password_compromised")
 	if err != nil {
 		return nil, err
 	}

--- a/user/client.go
+++ b/user/client.go
@@ -600,7 +600,7 @@ func (c *Client) PasswordUntrusted(ctx context.Context, params *PasswordUntruste
 	if err != nil {
 		return nil, err
 	}
-	req := clerk.NewAPIRequest(http.MethodDelete, path)
+	req := clerk.NewAPIRequest(http.MethodPost, path)
 	resource := &clerk.User{}
 	err = c.Backend.Call(ctx, req, resource)
 	return resource, err

--- a/user/client.go
+++ b/user/client.go
@@ -588,3 +588,20 @@ func (c *Client) DeleteExternalAccount(ctx context.Context, params *DeleteExtern
 	err = c.Backend.Call(ctx, req, resource)
 	return resource, err
 }
+
+type PasswordUntrustedParams struct {
+	clerk.APIParams
+	UserID string `json:"user_id"`
+}
+
+// DeleteExternalAccount deletes an external account by its ID.
+func (c *Client) PasswordUntrusted(ctx context.Context, params *PasswordUntrustedParams) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, params.UserID, "/password_untrusted")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodDelete, path)
+	resource := &clerk.User{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -651,3 +651,24 @@ func TestUserClientDeleteExternalAccount(t *testing.T) {
 	require.Equal(t, externalAccountID, externalAccount.ID)
 	require.Equal(t, "external_account", externalAccount.Object)
 }
+
+func TestUserClientPasswordUntrusted(t *testing.T) {
+	t.Parallel()
+	userID := "user_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Method: http.MethodPost,
+			Out:    json.RawMessage(fmt.Sprintf(`{"user_id":"%s"}`, userID)),
+			Path:   fmt.Sprintf("/v1/users/%s/password_untrusted", userID),
+		},
+	}
+	client := NewClient(config)
+	user, err := client.PasswordUntrusted(context.Background(), &PasswordUntrustedParams{
+		UserID: userID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, userID, user.ID)
+	require.True(t, user.RequiresPasswordReset)
+}

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -661,14 +661,14 @@ func TestUserClientPasswordUntrusted(t *testing.T) {
 			T:      t,
 			Method: http.MethodPost,
 			Out:    json.RawMessage(fmt.Sprintf(`{"user_id":"%s"}`, userID)),
-			Path:   fmt.Sprintf("/v1/users/%s/password_untrusted", userID),
+			Path:   fmt.Sprintf("/v1/users/%s/password_compromised", userID),
 		},
 	}
 	client := NewClient(config)
-	user, err := client.PasswordUntrusted(context.Background(), &PasswordUntrustedParams{
+	user, err := client.PasswordCompromised(context.Background(), &PasswordCompromisedParams{
 		UserID: userID,
 	})
 	require.NoError(t, err)
 	require.Equal(t, userID, user.ID)
-	require.True(t, user.RequiresPasswordReset)
+	require.True(t, *user.RequiresPasswordReset)
 }

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -652,7 +652,7 @@ func TestUserClientDeleteExternalAccount(t *testing.T) {
 	require.Equal(t, "external_account", externalAccount.Object)
 }
 
-func TestUserClientPasswordUntrusted(t *testing.T) {
+func TestUserClientPasswordCompromised(t *testing.T) {
 	t.Parallel()
 	userID := "user_123"
 	config := &clerk.ClientConfig{}
@@ -660,14 +660,12 @@ func TestUserClientPasswordUntrusted(t *testing.T) {
 		Transport: &clerktest.RoundTripper{
 			T:      t,
 			Method: http.MethodPost,
-			Out:    json.RawMessage(fmt.Sprintf(`{"user_id":"%s"}`, userID)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"object":"user","id":"%s","requires_password_reset":true}`, userID)),
 			Path:   fmt.Sprintf("/v1/users/%s/password_compromised", userID),
 		},
 	}
 	client := NewClient(config)
-	user, err := client.PasswordCompromised(context.Background(), &PasswordCompromisedParams{
-		UserID: userID,
-	})
+	user, err := client.PasswordCompromised(context.Background(), userID)
 	require.NoError(t, err)
 	require.Equal(t, userID, user.ID)
 	require.True(t, *user.RequiresPasswordReset)


### PR DESCRIPTION
Adds `/password_compromised` endpoint  and adds `requires_password_reset` to `User.list` and `User.get` responses