### PR TITLE
refactor: drop support to bulk role set role removal

### DIFF
--- a/roleset/api.go
+++ b/roleset/api.go
@@ -39,8 +39,8 @@ func AddRoles(ctx context.Context, roleSetKeyOrID string, params *AddRolesParams
 }
 
 // RemoveRoles removes roles from a role set.
-func RemoveRoles(ctx context.Context, roleSetKeyOrID string, params *RemoveRolesParams) (*clerk.RoleSet, error) {
-	return getClient().RemoveRoles(ctx, roleSetKeyOrID, params)
+func RemoveRoles(ctx context.Context, roleSetKeyOrID string, params *RemoveRoleParams) (*clerk.RoleSet, error) {
+	return getClient().RemoveRole(ctx, roleSetKeyOrID, params)
 }
 
 func getClient() *Client {

--- a/roleset/client.go
+++ b/roleset/client.go
@@ -142,13 +142,13 @@ func (c *Client) AddRoles(ctx context.Context, roleSetKeyOrID string, params *Ad
 	return roleSet, err
 }
 
-type RemoveRolesParams struct {
+type RemoveRoleParams struct {
 	clerk.APIParams
-	RoleKeys []string `json:"role_keys,omitempty"`
+	RoleKey string `json:"role_key,omitempty"`
 }
 
 // RemoveRoles removes roles from a role set.
-func (c *Client) RemoveRoles(ctx context.Context, roleSetKeyOrID string, params *RemoveRolesParams) (*clerk.RoleSet, error) {
+func (c *Client) RemoveRole(ctx context.Context, roleSetKeyOrID string, params *RemoveRoleParams) (*clerk.RoleSet, error) {
 	path, err := clerk.JoinPath(path, roleSetKeyOrID, "/roles")
 	if err != nil {
 		return nil, err

--- a/roleset/client_test.go
+++ b/roleset/client_test.go
@@ -172,21 +172,21 @@ func TestRoleSetClient_AddRoles(t *testing.T) {
 func TestRoleSetClient_RemoveRoles(t *testing.T) {
 	roleSetKey := "admin-roles"
 	roleSetID := "role_set_2b6E7b8FdHPjQKsrrakHLUPOzKe"
-	roleKeys := []string{"role:admin"}
+	roleKey := "role:admin"
 
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(`{"role_keys":["role:admin"]}`),
+			In:     json.RawMessage(`{"role_key":"role:admin"}`),
 			Out:    json.RawMessage(fmt.Sprintf(`{"object":"role_set","id":"%s","name":"Admin Role Set","type":"initial","key":"%s","description":"Admin roles","roles":[],"default_role":{"object":"role_set_item","id":"role_123","name":"Member","key":"org:member","description":"Default member role","created_at":1234567890,"updated_at":1234567890},"created_at":1234567890,"updated_at":1234567891}`, roleSetID, roleSetKey)),
 			Method: http.MethodDelete,
 			Path:   "/v1/role_sets/" + url.PathEscape(roleSetKey) + "/roles",
 		},
 	}
 	client := NewClient(config)
-	roleSet, err := client.RemoveRoles(context.Background(), roleSetKey, &RemoveRolesParams{
-		RoleKeys: roleKeys,
+	roleSet, err := client.RemoveRole(context.Background(), roleSetKey, &RemoveRoleParams{
+		RoleKey: roleKey,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, roleSetID, roleSet.ID)


### PR DESCRIPTION
### Context
Removing a role set from a role might trigger a reassignment, in order to avoid many role set migrations, we'll for now keep role removal a single operation

### Disclaimer 
Role sets are not out in production, so we can just update the field and not worry about deprecating it first!