### PR TITLE
fix: Change PasswordCompromised to accept `revoke_all_sessions` param

### DIFF
--- a/user/api.go
+++ b/user/api.go
@@ -127,8 +127,8 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 }
 
 // PasswordCompromised marks the user's password as compromised.
-func PasswordCompromised(ctx context.Context, userID string) (*clerk.User, error) {
-	return getClient().PasswordCompromised(ctx, userID)
+func PasswordCompromised(ctx context.Context, params *PasswordCompromisedParams) (*clerk.User, error) {
+	return getClient().PasswordCompromised(ctx, params)
 }
 
 func getClient() *Client {

--- a/user/client.go
+++ b/user/client.go
@@ -602,8 +602,8 @@ func (c *Client) PasswordCompromised(ctx context.Context, params *PasswordCompro
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodPost, path)
-	resource := &clerk.User{}
 	req.SetParams(params)
+	resource := &clerk.User{}
 	err = c.Backend.Call(ctx, req, resource)
 	return resource, err
 }

--- a/user/client.go
+++ b/user/client.go
@@ -589,14 +589,21 @@ func (c *Client) DeleteExternalAccount(ctx context.Context, params *DeleteExtern
 	return resource, err
 }
 
+type PasswordCompromisedParams struct {
+	clerk.APIParams
+	UserID            string `json:"-"`
+	RevokeAllSessions *bool  `json:"revoke_all_sessions,omitempty"`
+}
+
 // PasswordCompromised marks the user's password as compromised.
-func (c *Client) PasswordCompromised(ctx context.Context, userID string) (*clerk.User, error) {
-	path, err := clerk.JoinPath(path, userID, "/password_compromised")
+func (c *Client) PasswordCompromised(ctx context.Context, params *PasswordCompromisedParams) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, params.UserID, "/password_compromised")
 	if err != nil {
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodPost, path)
 	resource := &clerk.User{}
+	req.SetParams(params)
 	err = c.Backend.Call(ctx, req, resource)
 	return resource, err
 }

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -665,7 +665,10 @@ func TestUserClientPasswordCompromised(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	user, err := client.PasswordCompromised(context.Background(), userID)
+	user, err := client.PasswordCompromised(context.Background(), &PasswordCompromisedParams{
+		UserID:            userID,
+		RevokeAllSessions: clerk.Bool(true),
+	})
 	require.NoError(t, err)
 	require.Equal(t, userID, user.ID)
 	require.True(t, *user.RequiresPasswordReset)


### PR DESCRIPTION
Change the `user.PasswordCompromised` to accept params so that we can use `revoke_all_sessions` param