### PR TITLE
ORGS-1080: Add reassignment mappings support for role set operations

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -29,3 +29,7 @@ type OrganizationList struct {
 	Organizations []*Organization `json:"data"`
 	TotalCount    int64           `json:"total_count"`
 }
+
+// ReassignmentMappings is a map of role keys to the new role key.
+// NOTE: This is a preview struct and is not available yet for all customers.
+type ReassignmentMappings map[string]string

--- a/organization/client.go
+++ b/organization/client.go
@@ -80,15 +80,16 @@ func (c *Client) Get(ctx context.Context, idOrSlug string, params *GetParams) (*
 
 type UpdateParams struct {
 	clerk.APIParams
-	Name                  *string `json:"name,omitempty"`
-	Slug                  *string `json:"slug,omitempty"`
-	MaxAllowedMemberships *int64  `json:"max_allowed_memberships,omitempty"`
-	// RoleSetKey is a preview field and is not available yet for all customers.
+	Name                  *string          `json:"name,omitempty"`
+	Slug                  *string          `json:"slug,omitempty"`
+	MaxAllowedMemberships *int64           `json:"max_allowed_memberships,omitempty"`
+	PublicMetadata        *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata       *json.RawMessage `json:"private_metadata,omitempty"`
+	AdminDeleteEnabled    *bool            `json:"admin_delete_enabled,omitempty"`
+	// RoleSetKey and ReassignmentMappings are preview fields and are not available yet for all customers.
 	// The use of this field will cause an error to be returned.
-	RoleSetKey         *string          `json:"role_set_key,omitempty"`
-	PublicMetadata     *json.RawMessage `json:"public_metadata,omitempty"`
-	PrivateMetadata    *json.RawMessage `json:"private_metadata,omitempty"`
-	AdminDeleteEnabled *bool            `json:"admin_delete_enabled,omitempty"`
+	RoleSetKey           *string                     `json:"role_set_key,omitempty"`
+	ReassignmentMappings *clerk.ReassignmentMappings `json:"reassignment_mappings,omitempty"`
 }
 
 // Update updates an organization.

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -141,7 +141,7 @@ func TestOrganizationClientUpdate(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s"}`, name)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","reassignment_mappings":{"org:member":"org:admin"},"role_set_key":"admin-roles"}`, name)),
 			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s"}`, id, name)),
 			Method: http.MethodPatch,
 			Path:   "/v1/organizations/" + id,
@@ -150,6 +150,10 @@ func TestOrganizationClientUpdate(t *testing.T) {
 	client := NewClient(config)
 	organization, err := client.Update(context.Background(), id, &UpdateParams{
 		Name: clerk.String(name),
+		ReassignmentMappings: &clerk.ReassignmentMappings{
+			"org:member": "org:admin",
+		},
+		RoleSetKey: clerk.String("admin-roles"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, id, organization.ID)

--- a/roleset/api.go
+++ b/roleset/api.go
@@ -24,8 +24,8 @@ func Update(ctx context.Context, roleSetKeyOrID string, params *UpdateParams) (*
 }
 
 // Delete removes a role set.
-func Delete(ctx context.Context, roleSetKeyOrID string) (*clerk.DeletedResource, error) {
-	return getClient().Delete(ctx, roleSetKeyOrID)
+func Delete(ctx context.Context, roleSetKeyOrID string, params *DeleteParams) (*clerk.DeletedResource, error) {
+	return getClient().Delete(ctx, roleSetKeyOrID, params)
 }
 
 // List returns a list of role sets.
@@ -39,7 +39,7 @@ func AddRoles(ctx context.Context, roleSetKeyOrID string, params *AddRolesParams
 }
 
 // RemoveRoles removes roles from a role set.
-func RemoveRoles(ctx context.Context, roleSetKeyOrID string, params *RemoveRoleParams) (*clerk.RoleSet, error) {
+func RemoveRole(ctx context.Context, roleSetKeyOrID string, params *RemoveRoleParams) (*clerk.RoleSet, error) {
 	return getClient().RemoveRole(ctx, roleSetKeyOrID, params)
 }
 

--- a/roleset/client.go
+++ b/roleset/client.go
@@ -82,13 +82,20 @@ func (c *Client) Update(ctx context.Context, roleSetKeyOrID string, params *Upda
 	return roleSet, err
 }
 
+type DeleteParams struct {
+	clerk.APIParams
+	ReassignmentMappings *clerk.ReassignmentMappings `json:"reassignment_mappings,omitempty"`
+	DestRoleSetKey       *string                     `json:"dest_role_set_key,omitempty"`
+}
+
 // Delete removes a role set.
-func (c *Client) Delete(ctx context.Context, roleSetKeyOrID string) (*clerk.DeletedResource, error) {
-	path, err := clerk.JoinPath(path, roleSetKeyOrID)
+func (c *Client) Delete(ctx context.Context, roleSetKeyOrID string, params *DeleteParams) (*clerk.DeletedResource, error) {
+	path, err := clerk.JoinPath(path, roleSetKeyOrID, "/replace")
 	if err != nil {
 		return nil, err
 	}
-	req := clerk.NewAPIRequest(http.MethodDelete, path)
+	req := clerk.NewAPIRequest(http.MethodPost, path)
+	req.SetParams(params)
 	deletedResource := &clerk.DeletedResource{}
 	err = c.Backend.Call(ctx, req, deletedResource)
 	return deletedResource, err

--- a/roleset/client_test.go
+++ b/roleset/client_test.go
@@ -103,13 +103,18 @@ func TestRoleSetClient_Delete(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			Out:    json.RawMessage(fmt.Sprintf(`{"object":"role_set","id":"%s","deleted":true}`, roleSetID)),
-			Method: http.MethodDelete,
-			Path:   "/v1/role_sets/" + url.PathEscape(roleSetKey),
+			Out:    json.RawMessage(fmt.Sprintf(`{"object":"role_set","id":"%s","deleted":true,"reassignment_mappings":{"org:member":"org:admin"},"dest_role_set_key":"admin-roles"}`, roleSetID)),
+			Method: http.MethodPost,
+			Path:   "/v1/role_sets/" + url.PathEscape(roleSetKey) + "/replace",
 		},
 	}
 	client := NewClient(config)
-	deletedResource, err := client.Delete(context.Background(), roleSetKey)
+	deletedResource, err := client.Delete(context.Background(), roleSetKey, &DeleteParams{
+		ReassignmentMappings: &clerk.ReassignmentMappings{
+			"org:member": "org:admin",
+		},
+		DestRoleSetKey: clerk.String("admin-roles"),
+	})
 	require.NoError(t, err)
 	assert.Equal(t, roleSetID, deletedResource.ID)
 	assert.True(t, deletedResource.Deleted)


### PR DESCRIPTION
Add support for reassignment mappings when updating organizations and deleting role sets. This allows mapping old role keys to new role keys during role set transitions. The `ReassignmentMappings` type is a preview feature and not yet available for all customers. Also renames `RemoveRoles` to `RemoveRole` for API consistency and updates the role set delete endpoint to use POST `/replace` method.
