### PR TITLE
fix: Rename `PasswordCompromised` to `SetPasswordCompromised` and adding `UnsetPasswordCompromised`

### DIFF
--- a/user/api.go
+++ b/user/api.go
@@ -126,9 +126,14 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 	return getClient().DeleteExternalAccount(ctx, params)
 }
 
-// PasswordCompromised marks the user's password as compromised.
-func PasswordCompromised(ctx context.Context, params *PasswordCompromisedParams) (*clerk.User, error) {
-	return getClient().PasswordCompromised(ctx, params)
+// SetPasswordCompromised sets the user's password as compromised.
+func SetPasswordCompromised(ctx context.Context, params *SetPasswordCompromisedParams) (*clerk.User, error) {
+	return getClient().SetPasswordCompromised(ctx, params)
+}
+
+// UnsetPasswordCompromised unsets the user's password as compromised.
+func UnsetPasswordCompromised(ctx context.Context, userID string) (*clerk.User, error) {
+	return getClient().UnsetPasswordCompromised(ctx, userID)
 }
 
 func getClient() *Client {

--- a/user/client.go
+++ b/user/client.go
@@ -589,20 +589,32 @@ func (c *Client) DeleteExternalAccount(ctx context.Context, params *DeleteExtern
 	return resource, err
 }
 
-type PasswordCompromisedParams struct {
+type SetPasswordCompromisedParams struct {
 	clerk.APIParams
 	UserID            string `json:"-"`
 	RevokeAllSessions *bool  `json:"revoke_all_sessions,omitempty"`
 }
 
-// PasswordCompromised marks the user's password as compromised.
-func (c *Client) PasswordCompromised(ctx context.Context, params *PasswordCompromisedParams) (*clerk.User, error) {
-	path, err := clerk.JoinPath(path, params.UserID, "/password_compromised")
+// SetPasswordCompromised sets the user's password as compromised.
+func (c *Client) SetPasswordCompromised(ctx context.Context, params *SetPasswordCompromisedParams) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, params.UserID, "password", "set_compromised")
 	if err != nil {
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodPost, path)
 	req.SetParams(params)
+	resource := &clerk.User{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}
+
+// UnsetPasswordCompromised unsets the user's password as compromised.
+func (c *Client) UnsetPasswordCompromised(ctx context.Context, userID string) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, userID, "password", "unset_compromised")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPost, path)
 	resource := &clerk.User{}
 	err = c.Backend.Call(ctx, req, resource)
 	return resource, err

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -661,15 +661,34 @@ func TestUserClientPasswordCompromised(t *testing.T) {
 			T:      t,
 			Method: http.MethodPost,
 			Out:    json.RawMessage(fmt.Sprintf(`{"object":"user","id":"%s","requires_password_reset":true}`, userID)),
-			Path:   fmt.Sprintf("/v1/users/%s/password_compromised", userID),
+			Path:   fmt.Sprintf("/v1/users/%s/password/set_compromised", userID),
 		},
 	}
 	client := NewClient(config)
-	user, err := client.PasswordCompromised(context.Background(), &PasswordCompromisedParams{
+	user, err := client.SetPasswordCompromised(context.Background(), &SetPasswordCompromisedParams{
 		UserID:            userID,
 		RevokeAllSessions: clerk.Bool(true),
 	})
 	require.NoError(t, err)
 	require.Equal(t, userID, user.ID)
 	require.True(t, *user.RequiresPasswordReset)
+}
+
+func TestUserClientUnsetPasswordCompromised(t *testing.T) {
+	t.Parallel()
+	userID := "user_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Method: http.MethodPost,
+			Out:    json.RawMessage(fmt.Sprintf(`{"object":"user","id":"%s","requires_password_reset":false}`, userID)),
+			Path:   fmt.Sprintf("/v1/users/%s/password/unset_compromised", userID),
+		},
+	}
+	client := NewClient(config)
+	user, err := client.UnsetPasswordCompromised(context.Background(), userID)
+	require.NoError(t, err)
+	require.Equal(t, userID, user.ID)
+	require.False(t, *user.RequiresPasswordReset)
 }


### PR DESCRIPTION
This PR renames `PasswordCompromised` to `SetPasswordCompromised` and is adding `UnsetPasswordCompromised`

❗ As this version of the SDK is not stable and also the feature is not used by anyone it's safe to rename that