### PR TITLE
feat: add GetOrganizationSettingsShortcodes endpoint

### DIFF
--- a/instance_settings.go
+++ b/instance_settings.go
@@ -1,5 +1,7 @@
 package clerk
 
+import "encoding/json"
+
 type InstanceRestrictions struct {
 	APIResource
 	Object                             string `json:"object"`
@@ -54,4 +56,14 @@ type OrganizationNameTemplateSettings struct {
 
 type FallbackSettings struct {
 	Name string `json:"name"`
+}
+
+// OrganizationSettingsShortcodes represents the list of available template shortcodes
+// for organization name templates.
+type OrganizationSettingsShortcodes []string
+
+// Read implements the ResponseReader interface by unmarshaling the JSON response
+// into the shortcodes slice.
+func (s *OrganizationSettingsShortcodes) Read(response *APIResponse) {
+	json.Unmarshal(response.RawJSON, s)
 }

--- a/instancesettings/api.go
+++ b/instancesettings/api.go
@@ -23,6 +23,11 @@ func UpdateOrganizationSettings(ctx context.Context, params *UpdateOrganizationS
 	return getClient().UpdateOrganizationSettings(ctx, params)
 }
 
+// GetOrganizationSettingsShortcodes returns the list of available template shortcodes.
+func GetOrganizationSettingsShortcodes(ctx context.Context) (clerk.OrganizationSettingsShortcodes, error) {
+	return getClient().GetOrganizationSettingsShortcodes(ctx)
+}
+
 func getClient() *Client {
 	return &Client{
 		Backend: clerk.GetBackend(),

--- a/instancesettings/client.go
+++ b/instancesettings/client.go
@@ -154,3 +154,17 @@ func (c *Client) UpdateOrganizationSettings(ctx context.Context, params *UpdateO
 	err = c.Backend.Call(ctx, req, orgSettings)
 	return orgSettings, err
 }
+
+// GetOrganizationSettingsShortcodes returns the list of available template shortcodes
+// that can be used in organization name templates.
+func (c *Client) GetOrganizationSettingsShortcodes(ctx context.Context) (clerk.OrganizationSettingsShortcodes, error) {
+	path, err := clerk.JoinPath(path, "/organization_settings/shortcodes")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodGet, path)
+
+	shortcodes := clerk.OrganizationSettingsShortcodes{}
+	err = c.Backend.Call(ctx, req, &shortcodes)
+	return shortcodes, err
+}

--- a/instancesettings/client_test.go
+++ b/instancesettings/client_test.go
@@ -217,3 +217,28 @@ func TestInstanceClientUpdateOrganizationSettingsWithCreationDefaults(t *testing
 	require.Equal(t, "{{user.first_name}}'s Organization", orgSettings.OrganizationCreationDefaults.OrganizationNameTemplate.Template)
 	require.Equal(t, "My Organization", orgSettings.OrganizationCreationDefaults.Fallback.Name)
 }
+
+func TestInstanceClientGetOrganizationSettingsShortcodes(t *testing.T) {
+	t.Parallel()
+	shortcodes := []string{"user.first_name", "user.last_name", "user.full_name", "user.username"}
+	responseJSON, _ := json.Marshal(shortcodes)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(responseJSON),
+			Method: http.MethodGet,
+			Path:   "/v1/instance/organization_settings/shortcodes",
+		},
+	}
+
+	client := NewClient(config)
+	result, err := client.GetOrganizationSettingsShortcodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 4)
+	require.Contains(t, result, "user.first_name")
+	require.Contains(t, result, "user.last_name")
+	require.Contains(t, result, "user.full_name")
+	require.Contains(t, result, "user.username")
+}


### PR DESCRIPTION
Add new method to fetch available template shortcodes for organization name templates. Returns a simple array of shortcode strings.

Changes:
- Add OrganizationSettingsShortcodes type with Read method
- Add GetOrganizationSettingsShortcodes client method
- Add wrapper function in api.go
- Add comprehensive test coverage