### PR TITLE
audit_logs change eventTime to int64

### DIFF
--- a/audit_logs.go
+++ b/audit_logs.go
@@ -1,12 +1,10 @@
 package clerk
 
-import "time"
-
 type AuditLog struct {
 	APIResource
 	Object          string         `json:"object"`
 	ID              string         `json:"id"`
-	EventTime       time.Time      `json:"event_time"`
+	EventTime       int64          `json:"event_time"`
 	SubjectInstance string         `json:"subject_instance"`
 	Actor           string         `json:"actor"`
 	Subject         string         `json:"subject"`

--- a/audit_logs/api_test.go
+++ b/audit_logs/api_test.go
@@ -25,7 +25,7 @@ func TestPackageList(t *testing.T) {
 				"id":               "019400f7-c6e4-7f00-8000-000000000001",
 				"object":           "audit_log",
 				"type":             "user.created",
-				"event_time":       "2024-01-15T10:30:00Z",
+				"event_time":       1705315800000,
 				"subject_instance": "ins_2xPNClBrCHGhpOITVJlhdhBfGS7",
 				"actor":            "user_2xPNClBrCHGhpOITVJlhdhBfGS7",
 				"subject":          "user_2xPNCmYKPnPKaF3h0Ll8qas0I0w",

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -26,7 +26,7 @@ func TestList(t *testing.T) {
 				"id":               "019400f7-c6e4-7f00-8000-000000000001",
 				"object":           "audit_log",
 				"type":             "user.created",
-				"event_time":       "2024-01-15T10:30:00Z",
+				"event_time":       1705315800000,
 				"subject_instance": "ins_2xPNClBrCHGhpOITVJlhdhBfGS7",
 				"actor":            "user_2xPNClBrCHGhpOITVJlhdhBfGS7",
 				"subject":          "user_2xPNCmYKPnPKaF3h0Ll8qas0I0w",


### PR DESCRIPTION
Updates eventTime to int64 according to changes in https://github.com/clerk/clerk_go/pull/16019

USER-4278