### PR TITLE
feat: audit_logs  endpoint add hasNextPage to pagination cursor

### DIFF
--- a/audit_logs.go
+++ b/audit_logs.go
@@ -17,12 +17,13 @@ type AuditLog struct {
 
 type AuditLogList struct {
 	APIResource
-	AuditLogs []*AuditLog              `json:"data"`
-	Cursor    *CursorPaginationCursors `json:"cursor"`
+	AuditLogs []*AuditLog       `json:"data"`
+	Cursor    *PaginationCursor `json:"cursor"`
 }
 
-// CursorPaginationCursors contains the cursors for pagination.
-type CursorPaginationCursors struct {
+// PaginationCursor contains the cursors for pagination.
+type PaginationCursor struct {
 	StartingAfter *string `json:"starting_after"`
 	EndingBefore  *string `json:"ending_before"`
+	HasNextPage   bool    `json:"has_next_page"`
 }

--- a/audit_logs/api_test.go
+++ b/audit_logs/api_test.go
@@ -38,6 +38,7 @@ func TestPackageList(t *testing.T) {
 		"cursor": map[string]interface{}{
 			"starting_after": expectedCursor,
 			"ending_before":  expectedCursor,
+			"has_next_page":  true,
 		},
 	}
 
@@ -85,4 +86,5 @@ func TestPackageList(t *testing.T) {
 
 	assert.NotNil(t, auditLogs.Cursor)
 	assert.Equal(t, expectedCursor, *auditLogs.Cursor.StartingAfter)
+	assert.True(t, auditLogs.Cursor.HasNextPage)
 }


### PR DESCRIPTION
supports hasNextPage field in cursor added by https://github.com/clerk/clerk_go/pull/16057. DAPI uses this endpoint to for `system_logs`