### PR TITLE
feat: audit logs start/end_date renamed to event_time_after/before

### DIFF
--- a/audit_logs/client.go
+++ b/audit_logs/client.go
@@ -41,9 +41,9 @@ type ListParams struct {
 	// Filter audit logs by event type (e.g., email_send).
 	Type *string `json:"type,omitempty"`
 	// Filter audit logs to events on or after this date (Unix timestamp in milliseconds).
-	StartDate *int64 `json:"start_date,omitempty"`
+	EventTimeAfter *int64 `json:"event_time_after,omitempty"`
 	// Filter audit logs to events on or before this date (Unix timestamp in milliseconds).
-	EndDate *int64 `json:"end_date,omitempty"`
+	EventTimeBefore *int64 `json:"event_time_before,omitempty"`
 }
 
 // ToQuery returns the params as url.Values.
@@ -67,11 +67,11 @@ func (params *ListParams) ToQuery() url.Values {
 	if params.Type != nil {
 		q.Add("type", *params.Type)
 	}
-	if params.StartDate != nil {
-		q.Add("start_date", strconv.FormatInt(*params.StartDate, 10))
+	if params.EventTimeAfter != nil {
+		q.Add("event_time_after", strconv.FormatInt(*params.EventTimeAfter, 10))
 	}
-	if params.EndDate != nil {
-		q.Add("end_date", strconv.FormatInt(*params.EndDate, 10))
+	if params.EventTimeBefore != nil {
+		q.Add("event_time_before", strconv.FormatInt(*params.EventTimeBefore, 10))
 	}
 	return q
 }

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -39,6 +39,7 @@ func TestList(t *testing.T) {
 		"cursor": map[string]interface{}{
 			"starting_after": expectedCursor,
 			"ending_before":  expectedCursor,
+			"has_next_page":  true,
 		},
 	}
 
@@ -81,4 +82,5 @@ func TestList(t *testing.T) {
 	require.NotNil(t, list.Cursor)
 	require.Equal(t, expectedCursor, *list.Cursor.StartingAfter)
 	require.Equal(t, expectedCursor, *list.Cursor.EndingBefore)
+	require.True(t, list.Cursor.HasNextPage)
 }


### PR DESCRIPTION
Renamed query params `start_date` `end_date` in audit logs endpoint to `event_time_after` `event_time_before` to follow pattern in user list endpoint