### PR TITLE
feat(users): add LastSignInAt filter parameters to user list endpoint

### DIFF
--- a/user/client.go
+++ b/user/client.go
@@ -240,6 +240,8 @@ type ListParams struct {
 	CreatedAtAfter     *int64 `json:"created_at_after,omitempty"`
 	LastActiveAtBefore *int64 `json:"last_active_at_before,omitempty"`
 	LastActiveAtAfter  *int64 `json:"last_active_at_after,omitempty"`
+	LastSignInAtBefore *int64 `json:"last_sign_in_at_before,omitempty"`
+	LastSignInAtAfter  *int64 `json:"last_sign_in_at_after,omitempty"`
 }
 
 // ToQuery returns url.Values from the params.
@@ -302,6 +304,12 @@ func (params *ListParams) ToQuery() url.Values {
 	}
 	if params.LastActiveAtAfter != nil {
 		q.Add("last_active_at_after", strconv.FormatInt(*params.LastActiveAtAfter, 10))
+	}
+	if params.LastSignInAtBefore != nil {
+		q.Add("last_sign_in_at_before", strconv.FormatInt(*params.LastSignInAtBefore, 10))
+	}
+	if params.LastSignInAtAfter != nil {
+		q.Add("last_sign_in_at_after", strconv.FormatInt(*params.LastSignInAtAfter, 10))
 	}
 	return q
 }

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -73,18 +73,20 @@ func TestUserClientList_Request(t *testing.T) {
 			T:      t,
 			Method: http.MethodGet,
 			Query: &url.Values{
-				"limit":                 []string{"1"},
-				"offset":                []string{"2"},
-				"order_by":              []string{"-created_at"},
-				"email_address":         []string{"foo@bar.com", "baz@bar.com"},
-				"organization_id":       []string{"org_123", "org_456"},
-				"email_address_query":   []string{"@bar.com"},
-				"name_query":            []string{"foobar"},
-				"created_at_before":     []string{"1730333164378"},
-				"created_at_after":      []string{"1730333164378"},
-				"last_active_at_before": []string{"1730333164378"},
-				"last_active_at_after":  []string{"1730333164378"},
-				"banned":                []string{"false"},
+				"limit":                  []string{"1"},
+				"offset":                 []string{"2"},
+				"order_by":               []string{"-created_at"},
+				"email_address":          []string{"foo@bar.com", "baz@bar.com"},
+				"organization_id":        []string{"org_123", "org_456"},
+				"email_address_query":    []string{"@bar.com"},
+				"name_query":             []string{"foobar"},
+				"created_at_before":      []string{"1730333164378"},
+				"created_at_after":       []string{"1730333164378"},
+				"last_active_at_before":  []string{"1730333164378"},
+				"last_active_at_after":   []string{"1730333164378"},
+				"last_sign_in_at_before": []string{"1730333164378"},
+				"last_sign_in_at_after":  []string{"1730333164378"},
+				"banned":                 []string{"false"},
 			},
 		},
 	}
@@ -102,6 +104,8 @@ func TestUserClientList_Request(t *testing.T) {
 	params.CreatedAtAfter = clerk.Int64(1730333164378)
 	params.LastActiveAtBefore = clerk.Int64(1730333164378)
 	params.LastActiveAtAfter = clerk.Int64(1730333164378)
+	params.LastSignInAtBefore = clerk.Int64(1730333164378)
+	params.LastSignInAtAfter = clerk.Int64(1730333164378)
 	params.Banned = clerk.Bool(false)
 	_, err := client.List(context.Background(), params)
 	require.NoError(t, err)


### PR DESCRIPTION
Add support for filtering users by last sign-in timestamp with `LastSignInAtBefore` and `LastSignInAtAfter` parameters in the user `List` operation.