### PR TITLE
feat: implement bulk create for waitlist entries

### DIFF
--- a/waitlist_entries.go
+++ b/waitlist_entries.go
@@ -12,6 +12,11 @@ type WaitlistEntry struct {
 	Invitation   *Invitation `json:"invitation"`
 }
 
+type WaitlistEntries struct {
+	APIResource
+	WaitlistEntries []*WaitlistEntry `json:"data"`
+}
+
 type WaitlistEntriesList struct {
 	APIResource
 	WaitlistEntries []*WaitlistEntry `json:"data"`

--- a/waitlistentry/api.go
+++ b/waitlistentry/api.go
@@ -18,6 +18,11 @@ func Create(ctx context.Context, params *CreateParams) (*clerk.WaitlistEntry, er
 	return getClient().Create(ctx, params)
 }
 
+// BulkCreate creates multiple waitlist entries.
+func BulkCreate(ctx context.Context, params *BulkCreateParams) (*clerk.WaitlistEntries, error) {
+	return getClient().BulkCreate(ctx, params)
+}
+
 // Invite accepts a waitlist entry
 func Invite(ctx context.Context, id string, params *InviteParams) (*clerk.WaitlistEntry, error) {
 	return getClient().Invite(ctx, id, params)

--- a/waitlistentry/client.go
+++ b/waitlistentry/client.go
@@ -2,6 +2,7 @@ package waitlistentry
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -68,6 +69,45 @@ func (c *Client) Create(ctx context.Context, params *CreateParams) (*clerk.Waitl
 	invitation := &clerk.WaitlistEntry{}
 	err := c.Backend.Call(ctx, req, invitation)
 	return invitation, err
+}
+
+type BulkCreateParams struct {
+	clerk.APIParams
+	WaitlistEntries []*CreateParams
+}
+
+func (b BulkCreateParams) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.WaitlistEntries)
+}
+
+type bulkCreateResponse struct {
+	clerk.APIResource
+	WaitlistEntries []*clerk.WaitlistEntry
+}
+
+func (b *bulkCreateResponse) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &b.WaitlistEntries)
+}
+
+// BulkCreate creates multiple waitlist entries.
+func (c *Client) BulkCreate(ctx context.Context, params *BulkCreateParams) (*clerk.WaitlistEntries, error) {
+	path, err := clerk.JoinPath(path, "bulk")
+	if err != nil {
+		return nil, err
+	}
+
+	req := clerk.NewAPIRequest(http.MethodPost, path)
+	req.SetParams(params)
+
+	res := &bulkCreateResponse{}
+	if err := c.Backend.Call(ctx, req, res); err != nil {
+		return nil, err
+	}
+
+	return &clerk.WaitlistEntries{
+		APIResource:     res.APIResource,
+		WaitlistEntries: res.WaitlistEntries,
+	}, nil
 }
 
 type InviteParams struct {

--- a/waitlistentry/waitlistentry_test.go
+++ b/waitlistentry/waitlistentry_test.go
@@ -138,6 +138,50 @@ func TestWaitlistEntryCreate_Error(t *testing.T) {
 	require.Equal(t, "create-error-code", apiErr.Errors[0].Code)
 }
 
+func TestBulkWaitlistEntryCreate(t *testing.T) {
+	emailAddresses := []string{"foo@bar.com", "bar@foo.com"}
+	ids := []string{"wle_123", "wle_456"}
+	createdAt := int64(1700000000)
+	updatedAt := int64(1700000100)
+
+	clerk.SetBackend(clerk.NewBackend(&clerk.BackendConfig{
+		HTTPClient: &http.Client{
+			Transport: &clerktest.RoundTripper{
+				T:  t,
+				In: json.RawMessage(fmt.Sprintf(`[{"email_address":"%s"},{"email_address":"%s"}]`, emailAddresses[0], emailAddresses[1])),
+				Out: json.RawMessage(fmt.Sprintf(
+					`[{"object":"waitlist_entry","id":"%s","email_address":"%s","status":"pending","is_locked":false,"created_at":%d,"updated_at":%d,"invitation":null},{"object":"waitlist_entry","id":"%s","email_address":"%s","status":"pending","is_locked":false,"created_at":%d,"updated_at":%d,"invitation":null}]`,
+					ids[0], emailAddresses[0], createdAt, updatedAt, ids[1], emailAddresses[1], createdAt, updatedAt,
+				)),
+				Method: http.MethodPost,
+				Path:   "/v1/waitlist_entries/bulk",
+			},
+		},
+	}))
+
+	params := BulkCreateParams{
+		WaitlistEntries: []*CreateParams{
+			{EmailAddress: emailAddresses[0]},
+			{EmailAddress: emailAddresses[1]},
+		},
+	}
+
+	response, err := BulkCreate(context.Background(), &params)
+	require.NoError(t, err)
+	require.Len(t, response.WaitlistEntries, 2)
+
+	for i, entry := range response.WaitlistEntries {
+		require.Equal(t, "waitlist_entry", entry.Object)
+		require.Equal(t, ids[i], entry.ID)
+		require.Equal(t, emailAddresses[i], entry.EmailAddress)
+		require.Equal(t, "pending", entry.Status)
+		require.False(t, entry.IsLocked)
+		require.Equal(t, createdAt, entry.CreatedAt)
+		require.Equal(t, updatedAt, entry.UpdatedAt)
+		require.Nil(t, entry.Invitation)
+	}
+}
+
 func TestWaitlistEntryInvite(t *testing.T) {
 	id := "wle_123"
 	clerk.SetBackend(clerk.NewBackend(&clerk.BackendConfig{


### PR DESCRIPTION
Add BulkCreate functionality to create multiple waitlist entries in a single API call.
