### PR TITLE
feat: add impersonation field to  audit logs response

### DIFF
--- a/audit_logs.go
+++ b/audit_logs.go
@@ -2,19 +2,20 @@ package clerk
 
 type AuditLog struct {
 	APIResource
-	Object       string          `json:"object"`
-	ID           string          `json:"id"`
-	EventTime    int64           `json:"event_time"`
-	Actor        string          `json:"actor"`
-	Subject      string          `json:"subject"`
-	Type         string          `json:"type"`
-	Source       *string         `json:"source"`
-	ClientID     *string         `json:"client_id"`
-	TraceID      string          `json:"trace_id"`
-	SpanID       string          `json:"span_id"`
-	ParentSpanID *string         `json:"parent_span_id"`
-	Payload      map[string]any  `json:"payload"`
-	EventContext AuditLogContext `json:"event_context"`
+	Object       string                `json:"object"`
+	ID           string                `json:"id"`
+	EventTime    int64                 `json:"event_time"`
+	Actor        string                `json:"actor"`
+	Impersonator *ImpersonatorResponse `json:"impersonator"`
+	Subject      string                `json:"subject"`
+	Type         string                `json:"type"`
+	Source       *string               `json:"source"`
+	ClientID     *string               `json:"client_id"`
+	TraceID      string                `json:"trace_id"`
+	SpanID       string                `json:"span_id"`
+	ParentSpanID *string               `json:"parent_span_id"`
+	Payload      map[string]any        `json:"payload"`
+	EventContext AuditLogContext       `json:"event_context"`
 }
 
 type AuditLogList struct {
@@ -71,4 +72,8 @@ type BrowserContext struct {
 type LocationContext struct {
 	City    *string `json:"city"`
 	Country *string `json:"country"`
+}
+
+type ImpersonatorResponse struct {
+	UserID *string `json:"user_id"`
 }

--- a/audit_logs/api_test.go
+++ b/audit_logs/api_test.go
@@ -32,6 +32,9 @@ func TestPackageList(t *testing.T) {
 				"span_id":        "0000000000000001",
 				"parent_span_id": nil,
 				"payload":        map[string]interface{}{},
+				"impersonator": map[string]interface{}{
+					"user_id": "user_2xPNClBrCHGhpOITVJlhdhBfGS8",
+				},
 			},
 		},
 		"cursor": map[string]interface{}{
@@ -81,6 +84,9 @@ func TestPackageList(t *testing.T) {
 	assert.Equal(t, "0000000000000001", auditLog.SpanID)
 	assert.Nil(t, auditLog.ParentSpanID)
 	assert.NotNil(t, auditLog.Payload)
+	assert.NotNil(t, auditLog.Impersonator)
+	assert.NotNil(t, auditLog.Impersonator.UserID)
+	assert.Equal(t, "user_2xPNClBrCHGhpOITVJlhdhBfGS8", *auditLog.Impersonator.UserID)
 
 	assert.NotNil(t, auditLogs.Cursor)
 	assert.Equal(t, expectedCursor, *auditLogs.Cursor.StartingAfter)

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -35,6 +35,9 @@ func TestList(t *testing.T) {
 				"span_id":        "0000000000000001",
 				"parent_span_id": nil,
 				"payload":        map[string]interface{}{},
+				"impersonator": map[string]interface{}{
+					"user_id": "user_2xPNClBrCHGhpOITVJlhdhBfGS8",
+				},
 				"event_context": map[string]interface{}{
 					"environment": map[string]interface{}{
 						"type": "production",
@@ -149,6 +152,11 @@ func TestList(t *testing.T) {
 	require.NotNil(t, auditLog.EventContext.DeviceInfo.Location)
 	require.Equal(t, "New York", *auditLog.EventContext.DeviceInfo.Location.City)
 	require.Equal(t, "US", *auditLog.EventContext.DeviceInfo.Location.Country)
+
+	// Verify Impersonator field
+	require.NotNil(t, auditLog.Impersonator)
+	require.NotNil(t, auditLog.Impersonator.UserID)
+	require.Equal(t, "user_2xPNClBrCHGhpOITVJlhdhBfGS8", *auditLog.Impersonator.UserID)
 
 	require.NotNil(t, list.Cursor)
 	require.Equal(t, expectedCursor, *list.Cursor.StartingAfter)


### PR DESCRIPTION
Supports functionality added in https://github.com/clerk/clerk_go/pull/16537