### PR TITLE
feat(oauth2idp): add `access_token_ttl` property to PATCH OAuthApplication

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -521,3 +521,36 @@ func Bool(v bool) *bool {
 func JSONRawMessage(v json.RawMessage) *json.RawMessage {
 	return &v
 }
+
+// OptionalNullableInt64 represents an optional nullable int64 for PATCH semantics:
+// nil (omit) = do not change; value with Value=nil = reset to default (null); value with Value set = use that number.
+// Use as a pointer field with json:",omitempty" so the key is omitted when nil.
+type OptionalNullableInt64 struct {
+	Value *int64
+}
+
+// Interface implementations
+var _ json.Marshaler = (*OptionalNullableInt64)(nil)
+var _ json.Unmarshaler = (*OptionalNullableInt64)(nil)
+
+// MarshalJSON implements json.Marshaler. When Value is nil outputs null; otherwise outputs the number.
+func (o OptionalNullableInt64) MarshalJSON() ([]byte, error) {
+	if o.Value == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(*o.Value)
+}
+
+// UnmarshalJSON implements json.Unmarshaler. Accepts null or a number.
+func (o *OptionalNullableInt64) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		o.Value = nil
+		return nil
+	}
+	var v int64
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	o.Value = &v
+	return nil
+}

--- a/oauth_application.go
+++ b/oauth_application.go
@@ -24,6 +24,9 @@ type OAuthApplication struct {
 	CreatedAt             int64    `json:"created_at"`
 	UpdatedAt             int64    `json:"updated_at"`
 
+	// AccessTokenTTL is the TTL for access tokens issued by this OAuth application, in seconds. Nil means use default.
+	AccessTokenTTL *int64 `json:"access_token_ttl,omitempty"`
+
 	// Deprecated: Use RedirectURIs instead
 	CallbackURL string `json:"callback_url"`
 }

--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -96,6 +96,9 @@ type UpdateParams struct {
 	PKCERequired         *bool    `json:"pkce_required,omitempty"`
 	ConsentScreenEnabled *bool    `json:"consent_screen_enabled,omitempty"`
 
+	// AccessTokenTTL is the TTL for access tokens in seconds. Omit = no change; null = reset to default; number = set. Only used when instance has the feature enabled.
+	AccessTokenTTL *clerk.OptionalNullableInt64 `json:"access_token_ttl,omitempty"`
+
 	// Deprecated: Use RedirectURIs instead
 	CallbackURL *string `json:"callback_url,omitempty"`
 }

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -1,7 +1,6 @@
 package oauthapplication
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -42,7 +41,7 @@ func TestOAuthApplicationClientCreate(t *testing.T) {
 		ConsentScreenEnabled: clerk.Bool(true),
 		PKCERequired:         clerk.Bool(true),
 	}
-	oauthApp, err := client.Create(context.Background(), params)
+	oauthApp, err := client.Create(t.Context(), params)
 	require.NoError(t, err)
 	require.Equal(t, id, oauthApp.ID)
 	require.Equal(t, name, oauthApp.Name)
@@ -71,7 +70,7 @@ func TestOrganizationClientCreate_Error(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	_, err := client.Create(context.Background(), &CreateParams{})
+	_, err := client.Create(t.Context(), &CreateParams{})
 	require.Error(t, err)
 	apiErr, ok := err.(*clerk.APIErrorResponse)
 	require.True(t, ok)
@@ -99,7 +98,7 @@ func TestOAuthApplicationClientGet(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	oauthApp, err := client.Get(context.Background(), id)
+	oauthApp, err := client.Get(t.Context(), id)
 	require.NoError(t, err)
 	require.Equal(t, id, oauthApp.ID)
 	require.Equal(t, name, oauthApp.Name)
@@ -136,7 +135,7 @@ func TestOAuthApplicationClientUpdate(t *testing.T) {
 		ConsentScreenEnabled: clerk.Bool(false),
 		PKCERequired:         clerk.Bool(true),
 	}
-	oauthApp, err := client.Update(context.Background(), id, params)
+	oauthApp, err := client.Update(t.Context(), id, params)
 	require.NoError(t, err)
 	require.Equal(t, id, oauthApp.ID)
 	require.Equal(t, updatedName, oauthApp.Name)
@@ -145,6 +144,82 @@ func TestOAuthApplicationClientUpdate(t *testing.T) {
 	require.Equal(t, []string{callbackURL1, callbackURL2}, oauthApp.RedirectURIs)
 	require.False(t, oauthApp.ConsentScreenEnabled)
 	require.Equal(t, true, oauthApp.PKCERequired)
+	require.Nil(t, oauthApp.AccessTokenTTL)
+}
+
+func TestOAuthApplicationClientUpdate_AccessTokenTTL(t *testing.T) {
+	t.Parallel()
+	id := "app_123"
+	updatedTTL := int64(3600)
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"access_token_ttl":%d}`, updatedTTL)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","access_token_ttl":%d}`, id, updatedTTL)),
+			Method: http.MethodPatch,
+			Path:   fmt.Sprintf("/v1/oauth_applications/%s", id),
+		},
+	}
+	client := NewClient(config)
+	params := &UpdateParams{
+		AccessTokenTTL: &clerk.OptionalNullableInt64{Value: &updatedTTL},
+	}
+	oauthApp, err := client.Update(t.Context(), id, params)
+	require.NoError(t, err)
+	require.Equal(t, id, oauthApp.ID)
+	require.Equal(t, updatedTTL, *oauthApp.AccessTokenTTL)
+}
+
+// Demonstrates setting access token TTL to null to reset to default.
+func TestOAuthApplicationClientUpdate_AccessTokenTTL_ResetToDefault_Null(t *testing.T) {
+	t.Parallel()
+	id := "app_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage((`{"access_token_ttl":null}`)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","access_token_ttl":null}`, id)),
+			Method: http.MethodPatch,
+			Path:   fmt.Sprintf("/v1/oauth_applications/%s", id),
+		},
+	}
+	client := NewClient(config)
+	params := &UpdateParams{
+		// Specify null to reset to default
+		AccessTokenTTL: &clerk.OptionalNullableInt64{Value: nil},
+	}
+	oauthApp, err := client.Update(t.Context(), id, params)
+	require.NoError(t, err)
+	require.Equal(t, id, oauthApp.ID)
+	require.Nil(t, oauthApp.AccessTokenTTL)
+}
+
+// Demonstrates that omitting access token TTL does not pass the field to the API, and leaves it unchanged.
+func TestOAuthApplicationClientUpdate_AccessTokenTTL_Omit(t *testing.T) {
+	t.Parallel()
+	id := "app_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage((`{"name":"Test Application"}`)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"Test Application","access_token_ttl":42}`, id)),
+			Method: http.MethodPatch,
+			Path:   fmt.Sprintf("/v1/oauth_applications/%s", id),
+		},
+	}
+	client := NewClient(config)
+	params := &UpdateParams{
+		Name: clerk.String("Test Application"),
+		// Omit access token TTL
+	}
+	oauthApp, err := client.Update(t.Context(), id, params)
+	require.NoError(t, err)
+	require.Equal(t, id, oauthApp.ID)
+	require.Equal(t, int64(42), *oauthApp.AccessTokenTTL)
+	require.Equal(t, "Test Application", oauthApp.Name)
 }
 
 func TestOrganizationClientUpdate_Error(t *testing.T) {
@@ -163,7 +238,7 @@ func TestOrganizationClientUpdate_Error(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	_, err := client.Update(context.Background(), "oauth_123", &UpdateParams{})
+	_, err := client.Update(t.Context(), "oauth_123", &UpdateParams{})
 	require.Error(t, err)
 	apiErr, ok := err.(*clerk.APIErrorResponse)
 	require.True(t, ok)
@@ -185,7 +260,7 @@ func TestOAuthApplicationClientDelete(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	deletedApp, err := client.DeleteOAuthApplication(context.Background(), id)
+	deletedApp, err := client.DeleteOAuthApplication(t.Context(), id)
 	require.NoError(t, err)
 	require.Equal(t, id, deletedApp.ID)
 	require.True(t, deletedApp.Deleted)
@@ -217,7 +292,7 @@ func TestOAuthApplicationClientList(t *testing.T) {
 	params.Offset = clerk.Int64(0)
 	params.OrderBy = clerk.String("-name")
 	params.NameQuery = clerk.String("app_123")
-	appList, err := client.List(context.Background(), params)
+	appList, err := client.List(t.Context(), params)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), appList.TotalCount)
 	require.Equal(t, "oauth_app_123", appList.OAuthApplications[0].ID)
@@ -238,7 +313,7 @@ func TestOAuthApplicationClientRotateClientSecret(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	updatedApp, err := client.RotateClientSecret(context.Background(), id)
+	updatedApp, err := client.RotateClientSecret(t.Context(), id)
 	require.NoError(t, err)
 	require.Equal(t, id, updatedApp.ID)
 	require.Equal(t, newSecret, *updatedApp.ClientSecret)


### PR DESCRIPTION
So that DAPI can read/patch the OAuth Access Token lifetime.

The `access_token_ttl` property in the PATCH request will be optional and nullable:

- Omitting `access_token_ttl` means "do not modify"
- Specifying `access_token_ttl: null` means "reset to default" (i.e. set to null in the DB)

SDK consumers would set the parameters like this:

```
	params := &UpdateParams{
		Name: clerk.String("Test Application"),
		// Omit access token TTL, so unchanged
	}
```

```
	params := &UpdateParams{
		// Specify null to reset to default
		AccessTokenTTL: &clerk.OptionalNullableInt64{Value: nil},
	}
```

```
	updatedTTL := int64(3600)
	params := &UpdateParams{
		// Set to 1 hour
		AccessTokenTTL: &clerk.OptionalNullableInt64{Value: &updatedTTL},
	}
```

We have used this pattern in APIs before, but this seems to be the first time adding an optional in the Go SDK.

https://github.com/clerk/clerk_go/blob/b2fcf5076451c8a83ad7e4fbe3ebd23d2fcbb30b/pkg/json/int.go#L11-L15

Part of [USER-4657](https://linear.app/clerk/issue/USER-4657/add-bapidapi-support-to-update-oauth-access-token-ttl)
