### PR TITLE
fix(organization-domains): Move `domains` filter to `/organization_domains`

### DIFF
--- a/organizationdomain/client.go
+++ b/organizationdomain/client.go
@@ -89,7 +89,6 @@ type ListParams struct {
 	clerk.ListParams
 	Verified        *bool     `json:"verified,omitempty"`
 	EnrollmentModes *[]string `json:"enrollment_mode,omitempty"`
-	Domains         *[]string `json:"domains,omitempty"`
 }
 
 // ToQuery returns the parameters as url.Values so they can be used
@@ -103,10 +102,6 @@ func (params *ListParams) ToQuery() url.Values {
 
 	if params.EnrollmentModes != nil && len(*params.EnrollmentModes) > 0 {
 		q["enrollment_mode"] = *params.EnrollmentModes
-	}
-
-	if params.Domains != nil && len(*params.Domains) > 0 {
-		q["domains"] = *params.Domains
 	}
 
 	return q
@@ -128,11 +123,12 @@ func (c *Client) List(ctx context.Context, organizationID string, params *ListPa
 type ListAllFromInstanceParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	Verified       *bool   `json:"verified,omitempty"`
-	EnrollmentMode *string `json:"enrollment_mode,omitempty"`
-	OrganizationID *string `json:"organization_id,omitempty"`
-	OrderBy        *string `json:"order_by,omitempty"`
-	Query          *string `json:"query,omitempty"`
+	Verified       *bool     `json:"verified,omitempty"`
+	EnrollmentMode *string   `json:"enrollment_mode,omitempty"`
+	OrganizationID *string   `json:"organization_id,omitempty"`
+	OrderBy        *string   `json:"order_by,omitempty"`
+	Query          *string   `json:"query,omitempty"`
+	Domains        *[]string `json:"domains,omitempty"`
 }
 
 // ToQuery returns the parameters as url.Values so they can be used
@@ -158,6 +154,10 @@ func (params *ListAllFromInstanceParams) ToQuery() url.Values {
 
 	if params.Query != nil {
 		q.Set("query", *params.Query)
+	}
+
+	if params.Domains != nil && len(*params.Domains) > 0 {
+		q["domains"] = *params.Domains
 	}
 
 	return q

--- a/organizationdomain/client_test.go
+++ b/organizationdomain/client_test.go
@@ -149,7 +149,6 @@ func TestOrganizationDomainClientList(t *testing.T) {
 	organizationID := "org_123"
 	verified := true
 
-	domainsFilter := []string{"mydomain.com", "other.com"}
 	config := &clerk.ClientConfig{}
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
@@ -168,7 +167,6 @@ func TestOrganizationDomainClientList(t *testing.T) {
 				"offset":          []string{"2"},
 				"verified":        []string{"true"},
 				"enrollment_mode": []string{"automatic_invitation"},
-				"domains":         domainsFilter,
 			},
 		},
 	}
@@ -176,7 +174,6 @@ func TestOrganizationDomainClientList(t *testing.T) {
 	params := &ListParams{
 		Verified:        &verified,
 		EnrollmentModes: &[]string{"automatic_invitation"},
-		Domains:         &domainsFilter,
 	}
 	params.Limit = clerk.Int64(1)
 	params.Offset = clerk.Int64(2)
@@ -196,6 +193,7 @@ func TestOrganizationDomainClientListFromInstance(t *testing.T) {
 	organizationID2 := "org_456"
 	verified := true
 	query := "mydomain.com"
+	domainsFilter := []string{"mydomain.com", "other.com"}
 
 	publicOrganizationData := `{"id": "org_123", "name": "My Organization", "slug": "my-organization", "image_url": "https://example.com/image.png", "has_image": true}`
 
@@ -221,6 +219,7 @@ func TestOrganizationDomainClientListFromInstance(t *testing.T) {
 				"organization_id": []string{"org_123"},
 				"order_by":        []string{"-created_at"},
 				"query":           []string{"mydomain.com"},
+				"domains":         domainsFilter,
 			},
 		},
 	}
@@ -231,6 +230,7 @@ func TestOrganizationDomainClientListFromInstance(t *testing.T) {
 		OrganizationID: clerk.String("org_123"),
 		OrderBy:        clerk.String("-created_at"),
 		Query:          clerk.String(query),
+		Domains:        &domainsFilter,
 	}
 	params.Limit = clerk.Int64(10)
 	params.Offset = clerk.Int64(0)


### PR DESCRIPTION
Fix previous PR that added the `domains` filter to scoped-organization endpoint instead of instance-wide