### PR TITLE
feat(scim-directory): Add attribute_mapping field support

### DIFF
--- a/scim_directory.go
+++ b/scim_directory.go
@@ -3,16 +3,16 @@ package clerk
 // SCIMDirectory represents a SCIM directory resource.
 type SCIMDirectory struct {
 	APIResource
-	Object                 string  `json:"object"`
-	ID                     string  `json:"id"`
-	Name                   string  `json:"name"`
-	EnterpriseConnectionID *string `json:"enterprise_connection_id"`
-	EndpointURL            string  `json:"endpoint_url"`
-	Provider               string  `json:"provider"`
-	Enabled                bool    `json:"enabled"`
-	APIKey                 *string `json:"api_key,omitempty"`
-	CreatedAt              int64   `json:"created_at"`
-	UpdatedAt              int64   `json:"updated_at"`
+	Object                 string            `json:"object"`
+	ID                     string            `json:"id"`
+	Name                   string            `json:"name"`
+	EnterpriseConnectionID *string           `json:"enterprise_connection_id"`
+	EndpointURL            string            `json:"endpoint_url"`
+	Provider               string            `json:"provider"`
+	Enabled                bool              `json:"enabled"`
+	APIKey                 *string           `json:"api_key,omitempty"`
+	CreatedAt              int64             `json:"created_at"`
+	UpdatedAt              int64             `json:"updated_at"`
 	AttributeMapping       map[string]string `json:"attribute_mapping,omitempty"`
 }
 

--- a/scim_directory.go
+++ b/scim_directory.go
@@ -13,6 +13,7 @@ type SCIMDirectory struct {
 	APIKey                 *string `json:"api_key,omitempty"`
 	CreatedAt              int64   `json:"created_at"`
 	UpdatedAt              int64   `json:"updated_at"`
+	AttributeMapping       map[string]string `json:"attribute_mapping,omitempty"`
 }
 
 // SCIMDirectoryList represents a paginated list of SCIM directories.

--- a/scimdirectory/client.go
+++ b/scimdirectory/client.go
@@ -59,6 +59,12 @@ type UpdateParams struct {
 	Name     *string `json:"name,omitempty"`
 	Provider *string `json:"provider,omitempty"`
 	Enabled  *bool   `json:"enabled,omitempty"`
+	// AttributeMapping is a map of SCIM attributes to Clerk attributes.
+	// The semantics of the PATCH request are as follows:
+	//   - If the attribute is not present in the request, it will be left unchanged.
+	//   - If the attribute is present in the request, it will be updated to the new value.
+	//   - If the attribute is present in the request and the value is null, it will be removed.
+	AttributeMapping *map[string]string `json:"attribute_mapping,omitempty"`
 }
 
 // Update updates a SCIM directory.

--- a/scimdirectory/client_test.go
+++ b/scimdirectory/client_test.go
@@ -28,6 +28,7 @@ func TestCreate(t *testing.T) {
 		"api_key":                  "sk_test_xxxxx",
 		"created_at":               1640995200,
 		"updated_at":               1640995200,
+		"attribute_mapping":        map[string]string{"first_name": "first_name", "last_name": "last_name"},
 	}
 
 	responseJSON, _ := json.Marshal(response)
@@ -58,6 +59,7 @@ func TestCreate(t *testing.T) {
 	assert.True(t, scimDirectory.Enabled)
 	assert.Equal(t, "sk_test_xxxxx", *scimDirectory.APIKey)
 	assert.Equal(t, enterpriseConnectionID, *scimDirectory.EnterpriseConnectionID)
+	assert.Equal(t, map[string]string{"first_name": "first_name", "last_name": "last_name"}, scimDirectory.AttributeMapping)
 }
 
 func TestGet(t *testing.T) {
@@ -73,6 +75,7 @@ func TestGet(t *testing.T) {
 		"enabled":                  true,
 		"created_at":               1640995200,
 		"updated_at":               1640995200,
+		"attribute_mapping":        map[string]string{"first_name": "given_name", "last_name": "family_name"},
 	}
 
 	responseJSON, _ := json.Marshal(response)
@@ -94,6 +97,7 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, "Test SCIM Directory", scimDirectory.Name)
 	assert.Equal(t, "okta", scimDirectory.Provider)
 	assert.True(t, scimDirectory.Enabled)
+	assert.Equal(t, map[string]string{"first_name": "given_name", "last_name": "family_name"}, scimDirectory.AttributeMapping)
 }
 
 func TestUpdate(t *testing.T) {
@@ -136,6 +140,58 @@ func TestUpdate(t *testing.T) {
 	assert.False(t, scimDirectory.Enabled)
 }
 
+func TestUpdateAttributeMapping(t *testing.T) {
+	t.Parallel()
+
+	attributeMapping := map[string]string{
+		"first_name": "given_name",
+		"last_name":  "family_name",
+		"email":      "primary_email",
+	}
+
+	response := map[string]interface{}{
+		"object":                   "scim_directory",
+		"id":                       "scim_test123",
+		"name":                     "Test SCIM Directory",
+		"enterprise_connection_id": "entc_123",
+		"endpoint_url":             "https://scim.example.com",
+		"provider":                 "okta",
+		"enabled":                  true,
+		"created_at":               1640995200,
+		"updated_at":               1640995200,
+		"attribute_mapping":        attributeMapping,
+	}
+
+	responseJSON, _ := json.Marshal(response)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"attribute_mapping":{"email":"primary_email","first_name":"given_name","last_name":"family_name"}}`),
+			Out:    json.RawMessage(responseJSON),
+			Method: http.MethodPatch,
+			Path:   "/v1/scim_directories/scim_test123",
+		},
+	}
+
+	client := NewClient(config)
+	params := &UpdateParams{
+		AttributeMapping: &map[string]string{
+			"first_name": "given_name",
+			"last_name":  "family_name",
+			"email":      "primary_email",
+		},
+	}
+
+	scimDirectory, err := client.Update(context.Background(), "scim_test123", params)
+	require.NoError(t, err)
+	assert.Equal(t, "scim_test123", scimDirectory.ID)
+	assert.Equal(t, "Test SCIM Directory", scimDirectory.Name)
+	assert.True(t, scimDirectory.Enabled)
+	assert.Equal(t, attributeMapping, scimDirectory.AttributeMapping)
+}
+
 func TestList(t *testing.T) {
 	t.Parallel()
 
@@ -151,6 +207,7 @@ func TestList(t *testing.T) {
 				"enabled":                  true,
 				"created_at":               1640995200,
 				"updated_at":               1640995200,
+				"attribute_mapping":        map[string]string{"first_name": "first_name"},
 			},
 			{
 				"object":                   "scim_directory",
@@ -162,6 +219,7 @@ func TestList(t *testing.T) {
 				"enabled":                  true,
 				"created_at":               1640995200,
 				"updated_at":               1640995200,
+				"attribute_mapping":        map[string]string{"first_name": "given_name"},
 			},
 		},
 		"total_count": int64(2),
@@ -193,7 +251,9 @@ func TestList(t *testing.T) {
 	assert.Equal(t, int64(2), list.TotalCount)
 	assert.Len(t, list.SCIMDirectories, 2)
 	assert.Equal(t, "scim_test123", list.SCIMDirectories[0].ID)
+	assert.Equal(t, map[string]string{"first_name": "first_name"}, list.SCIMDirectories[0].AttributeMapping)
 	assert.Equal(t, "scim_test456", list.SCIMDirectories[1].ID)
+	assert.Equal(t, map[string]string{"first_name": "given_name"}, list.SCIMDirectories[1].AttributeMapping)
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Add support for the attribute_mapping field in SCIMDirectory:
- Add AttributeMapping field to SCIMDirectory struct
- Add AttributeMapping parameter to UpdateParams with PATCH semantics documentation
- Update all existing tests to include attribute_mapping in responses
- Add dedicated test for updating attribute mappings
