### PR TITLE
fix(oauth2idp): round-trip serialization of optional int64 type

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -521,36 +521,3 @@ func Bool(v bool) *bool {
 func JSONRawMessage(v json.RawMessage) *json.RawMessage {
 	return &v
 }
-
-// OptionalNullableInt64 represents an optional nullable int64 for PATCH semantics:
-// nil (omit) = do not change; value with Value=nil = reset to default (null); value with Value set = use that number.
-// Use as a pointer field with json:",omitempty" so the key is omitted when nil.
-type OptionalNullableInt64 struct {
-	Value *int64
-}
-
-// Interface implementations
-var _ json.Marshaler = (*OptionalNullableInt64)(nil)
-var _ json.Unmarshaler = (*OptionalNullableInt64)(nil)
-
-// MarshalJSON implements json.Marshaler. When Value is nil outputs null; otherwise outputs the number.
-func (o OptionalNullableInt64) MarshalJSON() ([]byte, error) {
-	if o.Value == nil {
-		return []byte("null"), nil
-	}
-	return json.Marshal(*o.Value)
-}
-
-// UnmarshalJSON implements json.Unmarshaler. Accepts null or a number.
-func (o *OptionalNullableInt64) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		o.Value = nil
-		return nil
-	}
-	var v int64
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	o.Value = &v
-	return nil
-}

--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/clerk/clerk-sdk-go/v3"
+	"github.com/clerk/clerk-sdk-go/v3/optional"
 )
 
 //go:generate go run ../cmd/gen/main.go
@@ -97,7 +98,7 @@ type UpdateParams struct {
 	ConsentScreenEnabled *bool    `json:"consent_screen_enabled,omitempty"`
 
 	// AccessTokenTTL is the TTL for access tokens in seconds. Omit = no change; null = reset to default; number = set. Only used when instance has the feature enabled.
-	AccessTokenTTL *clerk.OptionalNullableInt64 `json:"access_token_ttl,omitempty"`
+	AccessTokenTTL optional.Int64 `json:"access_token_ttl,omitzero"`
 
 	// Deprecated: Use RedirectURIs instead
 	CallbackURL *string `json:"callback_url,omitempty"`

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/clerk/clerk-sdk-go/v3"
 	"github.com/clerk/clerk-sdk-go/v3/clerktest"
+	"github.com/clerk/clerk-sdk-go/v3/optional"
 	"github.com/stretchr/testify/require"
 )
 
@@ -163,7 +164,7 @@ func TestOAuthApplicationClientUpdate_AccessTokenTTL(t *testing.T) {
 	}
 	client := NewClient(config)
 	params := &UpdateParams{
-		AccessTokenTTL: &clerk.OptionalNullableInt64{Value: &updatedTTL},
+		AccessTokenTTL: optional.Int64FromPtr(&updatedTTL),
 	}
 	oauthApp, err := client.Update(t.Context(), id, params)
 	require.NoError(t, err)
@@ -188,7 +189,7 @@ func TestOAuthApplicationClientUpdate_AccessTokenTTL_ResetToDefault_Null(t *test
 	client := NewClient(config)
 	params := &UpdateParams{
 		// Specify null to reset to default
-		AccessTokenTTL: &clerk.OptionalNullableInt64{Value: nil},
+		AccessTokenTTL: optional.Int64FromPtr(nil),
 	}
 	oauthApp, err := client.Update(t.Context(), id, params)
 	require.NoError(t, err)

--- a/optional/int64.go
+++ b/optional/int64.go
@@ -1,0 +1,63 @@
+// Credits
+// https://www.calhoun.io/how-to-determine-if-a-json-key-has-been-set-to-null-or-not-provided/
+
+package optional
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// Int64 represents an optional nullable int64 for PATCH semantics:
+// IsSet false = key absent (do not change); IsSet true and Valid false = null (reset); IsSet true and Valid true = value.
+type Int64 struct {
+	Value int64 // The value of the field
+	Valid bool  // Whether the value is present (i.e. not null)
+	IsSet bool  // Whether the key was set in the payload or not
+}
+
+var (
+	_ json.Marshaler   = (*Int64)(nil)
+	_ json.Unmarshaler = (*Int64)(nil)
+)
+
+func (i *Int64) UnmarshalJSON(data []byte) error {
+	// If this method was called, the value was set.
+	i.IsSet = true
+
+	if string(data) == "null" {
+		i.Valid = false
+		return nil
+	}
+
+	var temp int64
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	i.Value = temp
+	i.Valid = true
+	return nil
+}
+
+func (i Int64) MarshalJSON() ([]byte, error) {
+	if !i.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(i.Value)
+}
+
+// Int64FromPtr creates a new json.Int64
+func Int64FromPtr(i *int64) Int64 {
+	if i == nil {
+		return Int64{0, false, true}
+	}
+	return Int64{*i, true, true}
+}
+
+// Int64Valuer extracts the value for this custom type so that go validator can perform its checks on it
+func Int64Valuer(field reflect.Value) any {
+	if i, ok := field.Interface().(Int64); ok {
+		return i.Value
+	}
+	return nil
+}


### PR DESCRIPTION
so that it works as expected when DAPI relays the request to BAPI.

The code is slightly easier to understand, but for better or worse, it includes a code clone of an optional type.

See https://github.com/clerk/clerk_go/pull/16769 for the integration test