### PR TITLE
feat(organization-memberships): Add missing fields on create and metadata endpoint

### DIFF
--- a/organizationmembership/api.go
+++ b/organizationmembership/api.go
@@ -28,8 +28,9 @@ func List(ctx context.Context, params *ListParams) (*clerk.OrganizationMembershi
 	return getClient().List(ctx, params)
 }
 
-// UpdateMetadata merges and updates organization membership metadata
-func UpdateMetadata(ctx context.Context, params *MetadataParams) (*clerk.OrganizationMembership, error) {
+// UpdateMetadata updates the organization membership's metadata by merging the
+// provided values with the existing ones.
+func UpdateMetadata(ctx context.Context, params *UpdateMetadataParams) (*clerk.OrganizationMembership, error) {
 	return getClient().UpdateMetadata(ctx, params)
 }
 

--- a/organizationmembership/api.go
+++ b/organizationmembership/api.go
@@ -28,6 +28,11 @@ func List(ctx context.Context, params *ListParams) (*clerk.OrganizationMembershi
 	return getClient().List(ctx, params)
 }
 
+// UpdateMetadata merges and updates organization membership metadata
+func UpdateMetadata(ctx context.Context, params *MetadataParams) (*clerk.OrganizationMembership, error) {
+	return getClient().UpdateMetadata(ctx, params)
+}
+
 func getClient() *Client {
 	return &Client{
 		Backend: clerk.GetBackend(),

--- a/organizationmembership/client.go
+++ b/organizationmembership/client.go
@@ -176,7 +176,7 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*clerk.Organizat
 	return list, err
 }
 
-type MetadataParams struct {
+type UpdateMetadataParams struct {
 	clerk.APIParams
 	PublicMetadata  *json.RawMessage `json:"public_metadata,omitempty"`
 	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
@@ -184,8 +184,9 @@ type MetadataParams struct {
 	OrganizationID  string           `json:"-"`
 }
 
-// UpdateMetadata merges and updates organization membership metadata
-func (c *Client) UpdateMetadata(ctx context.Context, params *MetadataParams) (*clerk.OrganizationMembership, error) {
+// UpdateMetadata updates the organization membership's metadata by merging the
+// provided values with the existing ones.
+func (c *Client) UpdateMetadata(ctx context.Context, params *UpdateMetadataParams) (*clerk.OrganizationMembership, error) {
 	path, err := clerk.JoinPath(path, params.OrganizationID, "/memberships", params.UserID, "/metadata")
 	if err != nil {
 		return nil, err

--- a/organizationmembership/client.go
+++ b/organizationmembership/client.go
@@ -3,6 +3,7 @@ package organizationmembership
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -27,9 +28,11 @@ func NewClient(config *clerk.ClientConfig) *Client {
 
 type CreateParams struct {
 	clerk.APIParams
-	UserID         *string `json:"user_id,omitempty"`
-	Role           *string `json:"role,omitempty"`
-	OrganizationID string  `json:"-"`
+	UserID          *string          `json:"user_id,omitempty"`
+	Role            *string          `json:"role,omitempty"`
+	PublicMetadata  *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
+	OrganizationID  string           `json:"-"`
 }
 
 // Create adds a new member to the organization.
@@ -171,4 +174,25 @@ func (c *Client) List(ctx context.Context, params *ListParams) (*clerk.Organizat
 	list := &clerk.OrganizationMembershipList{}
 	err = c.Backend.Call(ctx, req, list)
 	return list, err
+}
+
+type MetadataParams struct {
+	clerk.APIParams
+	PublicMetadata  *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
+	UserID          string           `json:"-"`
+	OrganizationID  string           `json:"-"`
+}
+
+// UpdateMetadata merges and updates organization membership metadata
+func (c *Client) UpdateMetadata(ctx context.Context, params *MetadataParams) (*clerk.OrganizationMembership, error) {
+	path, err := clerk.JoinPath(path, params.OrganizationID, "/memberships", params.UserID, "/metadata")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPatch, path)
+	req.SetParams(params)
+	membership := &clerk.OrganizationMembership{}
+	err = c.Backend.Call(ctx, req, membership)
+	return membership, err
 }

--- a/organizationmembership/client_test.go
+++ b/organizationmembership/client_test.go
@@ -48,6 +48,54 @@ func TestOrganizationMembershipClientCreate(t *testing.T) {
 	require.Equal(t, userID, membership.PublicUserData.UserID)
 }
 
+func TestOrganizationMembershipClientCreate_WithMetadata(t *testing.T) {
+	t.Parallel()
+	id := "orgmem_123"
+	organizationID := "org_123"
+	userID := "user_123"
+	role := "admin"
+	publicMeta := `{"plan":"enterprise"}`
+	privateMeta := `{"internal_id":"abc"}`
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T: t,
+			In: json.RawMessage(fmt.Sprintf(
+				`{"user_id":"%s","role":"%s","public_metadata":%s,"private_metadata":%s}`,
+				userID, role, publicMeta, privateMeta,
+			)),
+			Out: json.RawMessage(fmt.Sprintf(`{
+"id":"%s",
+"role":"%s",
+"organization":{"id":"%s"},
+"public_user_data":{"user_id":"%s"},
+"public_metadata":%s,
+"private_metadata":%s
+}`,
+				id, role, organizationID, userID, publicMeta, privateMeta)),
+			Method: http.MethodPost,
+			Path:   "/v1/organizations/" + organizationID + "/memberships",
+		},
+	}
+	client := NewClient(config)
+	pubMeta := json.RawMessage(publicMeta)
+	privMeta := json.RawMessage(privateMeta)
+	membership, err := client.Create(context.Background(), &CreateParams{
+		UserID:          clerk.String(userID),
+		Role:            clerk.String(role),
+		OrganizationID:  organizationID,
+		PublicMetadata:  &pubMeta,
+		PrivateMetadata: &privMeta,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, membership.ID)
+	require.Equal(t, role, membership.Role)
+	require.Equal(t, organizationID, membership.Organization.ID)
+	require.Equal(t, userID, membership.PublicUserData.UserID)
+	require.JSONEq(t, publicMeta, string(membership.PublicMetadata))
+	require.JSONEq(t, privateMeta, string(membership.PrivateMetadata))
+}
+
 func TestOrganizationMembershipClientCreate_Error(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}
@@ -231,4 +279,73 @@ func TestOrganizationMembershipClientList(t *testing.T) {
 	require.Equal(t, userID, list.OrganizationMemberships[0].PublicUserData.UserID)
 	require.Equal(t, "string", list.OrganizationMemberships[0].RoleName)
 	require.Equal(t, "string", list.OrganizationMemberships[0].Role)
+}
+
+func TestOrganizationMembershipClientUpdateMetadata(t *testing.T) {
+	t.Parallel()
+	id := "orgmem_123"
+	organizationID := "org_123"
+	userID := "user_123"
+	publicMeta := `{"plan":"enterprise"}`
+	privateMeta := `{"internal_id":"abc"}`
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T: t,
+			In: json.RawMessage(fmt.Sprintf(
+				`{"public_metadata":%s,"private_metadata":%s}`,
+				publicMeta, privateMeta,
+			)),
+			Out: json.RawMessage(fmt.Sprintf(`{
+"id":"%s",
+"organization":{"id":"%s"},
+"public_user_data":{"user_id":"%s"},
+"public_metadata":%s,
+"private_metadata":%s
+}`,
+				id, organizationID, userID, publicMeta, privateMeta)),
+			Method: http.MethodPatch,
+			Path:   "/v1/organizations/" + organizationID + "/memberships/" + userID + "/metadata",
+		},
+	}
+	client := NewClient(config)
+	pubMeta := json.RawMessage(publicMeta)
+	privMeta := json.RawMessage(privateMeta)
+	membership, err := client.UpdateMetadata(context.Background(), &MetadataParams{
+		OrganizationID:  organizationID,
+		UserID:          userID,
+		PublicMetadata:  &pubMeta,
+		PrivateMetadata: &privMeta,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, membership.ID)
+	require.Equal(t, organizationID, membership.Organization.ID)
+	require.Equal(t, userID, membership.PublicUserData.UserID)
+	require.JSONEq(t, publicMeta, string(membership.PublicMetadata))
+	require.JSONEq(t, privateMeta, string(membership.PrivateMetadata))
+}
+
+func TestOrganizationMembershipClientUpdateMetadata_Error(t *testing.T) {
+	t.Parallel()
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Status: http.StatusBadRequest,
+			Out: json.RawMessage(`{
+  "errors":[{
+		"code":"update-metadata-error-code"
+	}],
+	"clerk_trace_id":"update-metadata-trace-id"
+}`),
+		},
+	}
+	client := NewClient(config)
+	_, err := client.UpdateMetadata(context.Background(), &MetadataParams{})
+	require.Error(t, err)
+	apiErr, ok := err.(*clerk.APIErrorResponse)
+	require.True(t, ok)
+	require.Equal(t, "update-metadata-trace-id", apiErr.TraceID)
+	require.Equal(t, 1, len(apiErr.Errors))
+	require.Equal(t, "update-metadata-error-code", apiErr.Errors[0].Code)
 }

--- a/organizationmembership/client_test.go
+++ b/organizationmembership/client_test.go
@@ -311,7 +311,7 @@ func TestOrganizationMembershipClientUpdateMetadata(t *testing.T) {
 	client := NewClient(config)
 	pubMeta := json.RawMessage(publicMeta)
 	privMeta := json.RawMessage(privateMeta)
-	membership, err := client.UpdateMetadata(context.Background(), &MetadataParams{
+	membership, err := client.UpdateMetadata(context.Background(), &UpdateMetadataParams{
 		OrganizationID:  organizationID,
 		UserID:          userID,
 		PublicMetadata:  &pubMeta,
@@ -341,7 +341,7 @@ func TestOrganizationMembershipClientUpdateMetadata_Error(t *testing.T) {
 		},
 	}
 	client := NewClient(config)
-	_, err := client.UpdateMetadata(context.Background(), &MetadataParams{})
+	_, err := client.UpdateMetadata(context.Background(), &UpdateMetadataParams{})
 	require.Error(t, err)
 	apiErr, ok := err.(*clerk.APIErrorResponse)
 	require.True(t, ok)


### PR DESCRIPTION
Closes #517 

Release notes:

- Add missing fields on `CreateParams` to include `PrivateMetadata` and `PublicMetadata`. See Clerk [API docs for membership creations](https://clerk.com/docs/reference/backend-api/tag/organization-memberships/post/organizations/%7Borganization_id%7D/memberships)
- Add missing endpoints for merging and updating membership metadata. See Clerk [API docs for membership metadata](https://clerk.com/docs/reference/backend-api/tag/organization-memberships/get/organizations/%7Borganization_id%7D/memberships).