### PR TITLE
Adds token format to m2m tokens create params

### DIFF
--- a/m2m_token/client.go
+++ b/m2m_token/client.go
@@ -30,6 +30,7 @@ type CreateParams struct {
 	clerk.APIParams
 	SecondsUntilExpiration *int64           `json:"seconds_until_expiration,omitempty"`
 	Claims                 *json.RawMessage `json:"claims,omitempty"`
+	TokenFormat            *string          `json:"token_format,omitempty"`
 }
 
 // Create creates a new M2M token.

--- a/m2m_token/client_test.go
+++ b/m2m_token/client_test.go
@@ -7,11 +7,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/clerk/clerk-sdk-go/v2"
 	"github.com/clerk/clerk-sdk-go/v2/clerktest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreate(t *testing.T) {

--- a/m2m_token/client_test.go
+++ b/m2m_token/client_test.go
@@ -7,10 +7,11 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/clerk/clerk-sdk-go/v2"
-	"github.com/clerk/clerk-sdk-go/v2/clerktest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/clerk/clerk-sdk-go/v2"
+	"github.com/clerk/clerk-sdk-go/v2/clerktest"
 )
 
 func TestCreate(t *testing.T) {
@@ -38,7 +39,7 @@ func TestCreate(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(`{"claims":{"foo":"bar"},"seconds_until_expiration":3600}`),
+			In:     json.RawMessage(`{"claims":{"foo":"bar"},"seconds_until_expiration":3600,"token_format":"opaque"}`),
 			Out:    json.RawMessage(responseJSON),
 			Method: http.MethodPost,
 			Path:   "/v1/m2m_tokens",
@@ -50,6 +51,7 @@ func TestCreate(t *testing.T) {
 	params := &CreateParams{
 		Claims:                 &claims,
 		SecondsUntilExpiration: clerk.Int64(3600),
+		TokenFormat:            clerk.String("opaque"),
 	}
 
 	token, err := client.Create(context.Background(), params)


### PR DESCRIPTION
This PR  adds a new optional  field `token_format` to the m2m_tokens create endpoint which accepts value of `opaque` or `jwt`