### PR TITLE
feat(saml-connection): add `custom_attributes` field support

### DIFF
--- a/saml_connection.go
+++ b/saml_connection.go
@@ -1,5 +1,11 @@
 package clerk
 
+type CustomAttribute struct {
+	Name *string `json:"name"`
+	Key  *string `json:"key"`
+	Path *string `json:"path"`
+}
+
 type SAMLConnection struct {
 	APIResource
 	ID     string `json:"id"`
@@ -27,6 +33,7 @@ type SAMLConnection struct {
 	AllowIdpInitiated                bool                           `json:"allow_idp_initiated"`
 	DisableAdditionalIdentifications bool                           `json:"disable_additional_identifications"`
 	ForceAuthn                       bool                           `json:"force_authn"`
+	CustomAttributes                 *[]CustomAttribute             `json:"custom_attributes,omitempty"`
 	CreatedAt                        int64                          `json:"created_at"`
 	UpdatedAt                        int64                          `json:"updated_at"`
 }

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -105,6 +105,8 @@ type UpdateParams struct {
 	DisableAdditionalIdentifications *bool                   `json:"disable_additional_identifications,omitempty"`
 	ForceAuthn                       *bool                   `json:"force_authn,omitempty"`
 	ConsentVerifiedDomainsDeletion   *bool                   `json:"consent_verified_domains_deletion,omitempty"`
+	// CustomAttributes is an Experimental feature, not available for all customers.
+	CustomAttributes *[]clerk.CustomAttribute `json:"custom_attributes,omitempty"`
 }
 
 // Update updates the SAML Connection specified by id.

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -182,8 +182,8 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s", "disable_additional_identifications": %t, "organization_id": "", "force_authn": %t}`, name, disableAdditionalIdentifications, forceAuthn)),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","disable_additional_identifications": %t,"force_authn": %t, "enterprise_connection_id": null}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s", "disable_additional_identifications": %t, "organization_id": "", "force_authn": %t, "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "path": "custom_attribute_path"}]}`, name, disableAdditionalIdentifications, forceAuthn)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","disable_additional_identifications": %t,"force_authn": %t, "enterprise_connection_id": null, "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "path": "custom_attribute_path"}]}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
 			Method: http.MethodPatch,
 			Path:   "/v1/saml_connections/" + id,
 		},
@@ -194,9 +194,23 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 		DisableAdditionalIdentifications: clerk.Bool(disableAdditionalIdentifications),
 		OrganizationID:                   clerk.String(""),
 		ForceAuthn:                       clerk.Bool(forceAuthn),
+		CustomAttributes: &[]clerk.CustomAttribute{
+			{
+				Name: clerk.String("custom_attribute_name"),
+				Key:  clerk.String("custom_attribute_key"),
+				Path: clerk.String("custom_attribute_path"),
+			},
+		},
 	})
 	require.NoError(t, err)
 	require.Equal(t, id, samlConnection.ID)
+	require.Equal(t, &[]clerk.CustomAttribute{
+		{
+			Name: clerk.String("custom_attribute_name"),
+			Key:  clerk.String("custom_attribute_key"),
+			Path: clerk.String("custom_attribute_path"),
+		},
+	}, samlConnection.CustomAttributes)
 	require.Equal(t, name, samlConnection.Name)
 	require.Equal(t, disableAdditionalIdentifications, samlConnection.DisableAdditionalIdentifications)
 	require.Equal(t, forceAuthn, samlConnection.ForceAuthn)

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -146,7 +146,7 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s", "disable_additional_identifications": %t, "force_authn": %t, "enterprise_connection_id": "entconn_2abc123def456"}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s", "disable_additional_identifications": %t, "force_authn": %t, "enterprise_connection_id": "entconn_2abc123def456", "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "path": "custom_attribute_path"}]}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
 			Method: http.MethodGet,
 			Path:   "/v1/saml_connections/" + id,
 		},
@@ -161,6 +161,13 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	require.Equal(t, provider, samlConnection.Provider)
 	require.Equal(t, disableAdditionalIdentifications, samlConnection.DisableAdditionalIdentifications)
 	require.Equal(t, forceAuthn, samlConnection.ForceAuthn)
+	require.Equal(t, &[]clerk.CustomAttribute{
+		{
+			Name: clerk.String("custom_attribute_name"),
+			Key:  clerk.String("custom_attribute_key"),
+			Path: clerk.String("custom_attribute_path"),
+		},
+	}, samlConnection.CustomAttributes)
 }
 
 func TestSAMLConnectionClientUpdate(t *testing.T) {


### PR DESCRIPTION
Introduces a new `CustomAttribute` struct with `name`, `key`, and `path` fields, and adds the `custom_attributes` optional field to `SAMLConnection`. Includes test coverage for round-trip serialization of the new field.
