### PR TITLE
feat(audit_logs): add offset param and total_count to list response

### DIFF
--- a/audit_logs.go
+++ b/audit_logs.go
@@ -20,8 +20,9 @@ type AuditLog struct {
 
 type AuditLogList struct {
 	APIResource
-	AuditLogs []*AuditLog       `json:"data"`
-	Cursor    *PaginationCursor `json:"cursor"`
+	AuditLogs  []*AuditLog       `json:"data"`
+	Cursor     *PaginationCursor `json:"cursor,omitempty"`
+	TotalCount *int64            `json:"total_count,omitempty"`
 }
 
 // PaginationCursor contains the cursors for pagination.

--- a/audit_logs/client.go
+++ b/audit_logs/client.go
@@ -53,6 +53,9 @@ type ListParams struct {
 	// When true, only returns events marked as end-user facing.
 	// When false or omitted, returns all events.
 	EndUserFacingOnly *bool `json:"end_user_facing_only,omitempty"`
+	// An offset for pagination. When provided, offset-based pagination is used
+	// instead of cursor-based pagination.
+	Offset *int64 `json:"offset,omitempty"`
 }
 
 // ToQuery returns the params as url.Values.
@@ -93,6 +96,9 @@ func (params *ListParams) ToQuery() url.Values {
 	}
 	if params.EndUserFacingOnly != nil {
 		q.Add("end_user_facing_only", strconv.FormatBool(*params.EndUserFacingOnly))
+	}
+	if params.Offset != nil {
+		q.Add("offset", strconv.FormatInt(*params.Offset, 10))
 	}
 	return q
 }


### PR DESCRIPTION
Add Offset field to ListParams to support offset-based pagination as an alternative to cursor-based pagination. When provided, the API returns results starting at the given offset position.

Add TotalCount field to AuditLogList response, populated when offset-based pagination is used, to allow clients to know the total number of matching records.