### PR TITLE
feat: Add `AllowOrganizationAccountLinking` flag for enterprise connections

### DIFF
--- a/enterprise_connection.go
+++ b/enterprise_connection.go
@@ -18,6 +18,7 @@ type EnterpriseConnection struct {
 	AllowSubdomains                  bool     `json:"allow_subdomains"`
 	AllowIdpInitiated                bool     `json:"allow_idp_initiated"`
 	ForceAuthn                       bool     `json:"force_authn"`
+	AllowOrganizationAccountLinking  bool     `json:"allow_organization_account_linking"`
 	CreatedAt                        int64    `json:"created_at"`
 	UpdatedAt                        int64    `json:"updated_at"`
 

--- a/enterpriseconnection/client.go
+++ b/enterpriseconnection/client.go
@@ -124,13 +124,13 @@ type UpdateParamsOidc struct {
 // Set Saml for SAML connections; set Oidc for OIDC connections.
 type UpdateParams struct {
 	clerk.APIParams
-	Name                             *string   `json:"name,omitempty"`
-	OrganizationID                   *string   `json:"organization_id,omitempty"`
-	Domains                          *[]string `json:"domains,omitempty"`
-	Active                           *bool     `json:"active,omitempty"`
-	SyncUserAttributes               *bool     `json:"sync_user_attributes,omitempty"`
-	DisableAdditionalIdentifications *bool     `json:"disable_additional_identifications,omitempty"`
-	AllowOrganizationAccountLinking  *bool
+	Name                             *string           `json:"name,omitempty"`
+	OrganizationID                   *string           `json:"organization_id,omitempty"`
+	Domains                          *[]string         `json:"domains,omitempty"`
+	Active                           *bool             `json:"active,omitempty"`
+	SyncUserAttributes               *bool             `json:"sync_user_attributes,omitempty"`
+	DisableAdditionalIdentifications *bool             `json:"disable_additional_identifications,omitempty"`
+	AllowOrganizationAccountLinking  *bool             `json:"allow_organization_account_linking,omitempty"`
 	Saml                             *UpdateParamsSaml `json:"saml,omitempty"`
 	Oidc                             *UpdateParamsOidc `json:"oidc,omitempty"`
 }

--- a/enterpriseconnection/client.go
+++ b/enterpriseconnection/client.go
@@ -124,12 +124,13 @@ type UpdateParamsOidc struct {
 // Set Saml for SAML connections; set Oidc for OIDC connections.
 type UpdateParams struct {
 	clerk.APIParams
-	Name                             *string           `json:"name,omitempty"`
-	OrganizationID                   *string           `json:"organization_id,omitempty"`
-	Domains                          *[]string         `json:"domains,omitempty"`
-	Active                           *bool             `json:"active,omitempty"`
-	SyncUserAttributes               *bool             `json:"sync_user_attributes,omitempty"`
-	DisableAdditionalIdentifications *bool             `json:"disable_additional_identifications,omitempty"`
+	Name                             *string   `json:"name,omitempty"`
+	OrganizationID                   *string   `json:"organization_id,omitempty"`
+	Domains                          *[]string `json:"domains,omitempty"`
+	Active                           *bool     `json:"active,omitempty"`
+	SyncUserAttributes               *bool     `json:"sync_user_attributes,omitempty"`
+	DisableAdditionalIdentifications *bool     `json:"disable_additional_identifications,omitempty"`
+	AllowOrganizationAccountLinking  *bool
 	Saml                             *UpdateParamsSaml `json:"saml,omitempty"`
 	Oidc                             *UpdateParamsOidc `json:"oidc,omitempty"`
 }

--- a/saml_connection.go
+++ b/saml_connection.go
@@ -33,6 +33,7 @@ type SAMLConnection struct {
 	AllowIdpInitiated                bool                           `json:"allow_idp_initiated"`
 	DisableAdditionalIdentifications bool                           `json:"disable_additional_identifications"`
 	ForceAuthn                       bool                           `json:"force_authn"`
+	AllowOrganizationAccountLinking  bool                           `json:"allow_organization_account_linking"`
 	CustomAttributes                 *[]CustomAttribute             `json:"custom_attributes,omitempty"`
 	CreatedAt                        int64                          `json:"created_at"`
 	UpdatedAt                        int64                          `json:"updated_at"`

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -115,8 +115,9 @@ type UpdateParams struct {
 	AllowSubdomains                  *bool                   `json:"allow_subdomains,omitempty"`
 	AllowIdpInitiated                *bool                   `json:"allow_idp_initiated,omitempty"`
 	DisableAdditionalIdentifications *bool                   `json:"disable_additional_identifications,omitempty"`
-	ForceAuthn                       *bool                   `json:"force_authn,omitempty"`
-	ConsentVerifiedDomainsDeletion   *bool                   `json:"consent_verified_domains_deletion,omitempty"`
+	AllowOrganizationAccountLinking  *bool
+	ForceAuthn                       *bool `json:"force_authn,omitempty"`
+	ConsentVerifiedDomainsDeletion   *bool `json:"consent_verified_domains_deletion,omitempty"`
 	// CustomAttributes is an Experimental feature, not available for all customers.
 	CustomAttributes *[]clerk.CustomAttribute `json:"custom_attributes,omitempty"`
 }

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -115,9 +115,9 @@ type UpdateParams struct {
 	AllowSubdomains                  *bool                   `json:"allow_subdomains,omitempty"`
 	AllowIdpInitiated                *bool                   `json:"allow_idp_initiated,omitempty"`
 	DisableAdditionalIdentifications *bool                   `json:"disable_additional_identifications,omitempty"`
-	AllowOrganizationAccountLinking  *bool
-	ForceAuthn                       *bool `json:"force_authn,omitempty"`
-	ConsentVerifiedDomainsDeletion   *bool `json:"consent_verified_domains_deletion,omitempty"`
+	AllowOrganizationAccountLinking  *bool                   `json:"allow_organization_account_linking,omitempty"`
+	ForceAuthn                       *bool                   `json:"force_authn,omitempty"`
+	ConsentVerifiedDomainsDeletion   *bool                   `json:"consent_verified_domains_deletion,omitempty"`
 	// CustomAttributes is an Experimental feature, not available for all customers.
 	CustomAttributes *[]clerk.CustomAttribute `json:"custom_attributes,omitempty"`
 }


### PR DESCRIPTION
Add new enterprise account linking property from https://github.com/clerk/clerk_go/pull/17520