### PR TITLE
feat: Add `Authenticatable` flag for enterprise connections

### DIFF
--- a/enterprise_connection.go
+++ b/enterprise_connection.go
@@ -19,6 +19,7 @@ type EnterpriseConnection struct {
 	AllowIdpInitiated                bool     `json:"allow_idp_initiated"`
 	ForceAuthn                       bool     `json:"force_authn"`
 	AllowOrganizationAccountLinking  bool     `json:"allow_organization_account_linking"`
+	Authenticatable                  bool     `json:"authenticatable"`
 	CreatedAt                        int64    `json:"created_at"`
 	UpdatedAt                        int64    `json:"updated_at"`
 

--- a/enterpriseconnection/client.go
+++ b/enterpriseconnection/client.go
@@ -131,6 +131,7 @@ type UpdateParams struct {
 	SyncUserAttributes               *bool             `json:"sync_user_attributes,omitempty"`
 	DisableAdditionalIdentifications *bool             `json:"disable_additional_identifications,omitempty"`
 	AllowOrganizationAccountLinking  *bool             `json:"allow_organization_account_linking,omitempty"`
+	Authenticatable                  *bool             `json:"authenticatable,omitempty"`
 	Saml                             *UpdateParamsSaml `json:"saml,omitempty"`
 	Oidc                             *UpdateParamsOidc `json:"oidc,omitempty"`
 }

--- a/saml_connection.go
+++ b/saml_connection.go
@@ -35,6 +35,7 @@ type SAMLConnection struct {
 	ForceAuthn                       bool                           `json:"force_authn"`
 	AllowOrganizationAccountLinking  bool                           `json:"allow_organization_account_linking"`
 	CustomAttributes                 *[]CustomAttribute             `json:"custom_attributes,omitempty"`
+	Authenticatable                  bool                           `json:"authenticatable"`
 	CreatedAt                        int64                          `json:"created_at"`
 	UpdatedAt                        int64                          `json:"updated_at"`
 }

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -118,6 +118,7 @@ type UpdateParams struct {
 	AllowOrganizationAccountLinking  *bool                   `json:"allow_organization_account_linking,omitempty"`
 	ForceAuthn                       *bool                   `json:"force_authn,omitempty"`
 	ConsentVerifiedDomainsDeletion   *bool                   `json:"consent_verified_domains_deletion,omitempty"`
+	Authenticatable                  *bool                   `json:"authenticatable,omitempty"`
 	// CustomAttributes is an Experimental feature, not available for all customers.
 	CustomAttributes *[]clerk.CustomAttribute `json:"custom_attributes,omitempty"`
 }


### PR DESCRIPTION
Follow-up from https://github.com/clerk/clerk_go/pull/17857