### PR TITLE
audit_logs: update pagination cursor 

### DIFF
--- a/apikey/api_test.go
+++ b/apikey/api_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Note: tests in this file cannot run in parallel because they call clerk.SetBackend,
+// which modifies a global variable. Parallel tests would race on that shared state.
+
 func TestPackageCreate(t *testing.T) {
 
 	response := map[string]interface{}{

--- a/apikey/api_test.go
+++ b/apikey/api_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestPackageCreate(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"object":            "api_key",
@@ -69,7 +68,6 @@ func TestPackageCreate(t *testing.T) {
 }
 
 func TestPackageGet(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"object":            "api_key",
@@ -115,7 +113,6 @@ func TestPackageGet(t *testing.T) {
 }
 
 func TestPackageList(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"data": []map[string]interface{}{
@@ -173,7 +170,6 @@ func TestPackageList(t *testing.T) {
 }
 
 func TestPackageGetSecret(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"secret": "ak_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
@@ -200,7 +196,6 @@ func TestPackageGetSecret(t *testing.T) {
 }
 
 func TestPackageUpdate(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"object":            "api_key",
@@ -247,7 +242,6 @@ func TestPackageUpdate(t *testing.T) {
 }
 
 func TestPackageDelete(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"object":  "api_key",
@@ -278,7 +272,6 @@ func TestPackageDelete(t *testing.T) {
 }
 
 func TestPackageUpdateWithSecondsUntilExpiration(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"object":            "api_key",
@@ -327,7 +320,6 @@ func TestPackageUpdateWithSecondsUntilExpiration(t *testing.T) {
 }
 
 func TestPackageUpdateSecondsUntilExpirationOnly(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"object":            "api_key",
@@ -375,7 +367,6 @@ func TestPackageUpdateSecondsUntilExpirationOnly(t *testing.T) {
 }
 
 func TestPackageRevoke(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"object":            "api_key",
@@ -423,7 +414,6 @@ func TestPackageRevoke(t *testing.T) {
 }
 
 func TestPackageVerify(t *testing.T) {
-	t.Parallel()
 
 	response := map[string]interface{}{
 		"object":            "api_key",

--- a/audit_logs.go
+++ b/audit_logs.go
@@ -37,9 +37,12 @@ const (
 )
 
 type ExtendedPaginationCursor struct {
-	StartingAfter *string        `json:"starting_after"`
-	EndingBefore  *string        `json:"ending_before"`
-	HasNextPage   NextPageStatus `json:"has_next_page"`
+	StartingAfter *string `json:"starting_after"`
+	EndingBefore  *string `json:"ending_before"`
+	// Deprecated: Use NextPageStatus instead. HasNextPage is kept for backwards
+	// compatibility and is derived as NextPageStatus != NextPageFalse.
+	HasNextPage    bool           `json:"has_next_page"`
+	NextPageStatus NextPageStatus `json:"next_page_status"`
 }
 
 // PaginationCursor contains the cursors for pagination.

--- a/audit_logs.go
+++ b/audit_logs.go
@@ -20,8 +20,26 @@ type AuditLog struct {
 
 type AuditLogList struct {
 	APIResource
-	AuditLogs []*AuditLog       `json:"data"`
-	Cursor    *PaginationCursor `json:"cursor"`
+	AuditLogs []*AuditLog               `json:"data"`
+	Cursor    *ExtendedPaginationCursor `json:"cursor"`
+}
+
+// NextPageStatus is the tri-state value for has_next_page in cursor pagination.
+// It is "true" when there is a next page, "false" when there is not, and
+// "unknown" when the query was bounded by a time window and more results may
+// exist beyond that window.
+type NextPageStatus string
+
+const (
+	NextPageTrue    NextPageStatus = "true"
+	NextPageFalse   NextPageStatus = "false"
+	NextPageUnknown NextPageStatus = "unknown"
+)
+
+type ExtendedPaginationCursor struct {
+	StartingAfter *string        `json:"starting_after"`
+	EndingBefore  *string        `json:"ending_before"`
+	HasNextPage   NextPageStatus `json:"has_next_page"`
 }
 
 // PaginationCursor contains the cursors for pagination.

--- a/audit_logs/api_test.go
+++ b/audit_logs/api_test.go
@@ -91,6 +91,5 @@ func TestPackageList(t *testing.T) {
 
 	assert.NotNil(t, auditLogs.Cursor)
 	assert.Equal(t, expectedCursor, *auditLogs.Cursor.StartingAfter)
-	assert.True(t, auditLogs.Cursor.HasNextPage)
 	assert.Equal(t, clerk.NextPageTrue, auditLogs.Cursor.NextPageStatus)
 }

--- a/audit_logs/api_test.go
+++ b/audit_logs/api_test.go
@@ -40,7 +40,7 @@ func TestPackageList(t *testing.T) {
 		"cursor": map[string]interface{}{
 			"starting_after": expectedCursor,
 			"ending_before":  expectedCursor,
-			"has_next_page":  true,
+			"has_next_page":  "true",
 		},
 	}
 
@@ -90,5 +90,5 @@ func TestPackageList(t *testing.T) {
 
 	assert.NotNil(t, auditLogs.Cursor)
 	assert.Equal(t, expectedCursor, *auditLogs.Cursor.StartingAfter)
-	assert.True(t, auditLogs.Cursor.HasNextPage)
+	assert.Equal(t, clerk.NextPageTrue, auditLogs.Cursor.HasNextPage)
 }

--- a/audit_logs/api_test.go
+++ b/audit_logs/api_test.go
@@ -38,9 +38,10 @@ func TestPackageList(t *testing.T) {
 			},
 		},
 		"cursor": map[string]interface{}{
-			"starting_after": expectedCursor,
-			"ending_before":  expectedCursor,
-			"has_next_page":  "true",
+			"starting_after":   expectedCursor,
+			"ending_before":    expectedCursor,
+			"has_next_page":    true,
+			"next_page_status": "true",
 		},
 	}
 
@@ -90,5 +91,6 @@ func TestPackageList(t *testing.T) {
 
 	assert.NotNil(t, auditLogs.Cursor)
 	assert.Equal(t, expectedCursor, *auditLogs.Cursor.StartingAfter)
-	assert.Equal(t, clerk.NextPageTrue, auditLogs.Cursor.HasNextPage)
+	assert.True(t, auditLogs.Cursor.HasNextPage)
+	assert.Equal(t, clerk.NextPageTrue, auditLogs.Cursor.NextPageStatus)
 }

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -76,7 +76,7 @@ func TestList(t *testing.T) {
 		"cursor": map[string]interface{}{
 			"starting_after": expectedCursor,
 			"ending_before":  expectedCursor,
-			"has_next_page":  true,
+			"has_next_page":  "true",
 		},
 	}
 
@@ -165,5 +165,5 @@ func TestList(t *testing.T) {
 	require.NotNil(t, list.Cursor)
 	require.Equal(t, expectedCursor, *list.Cursor.StartingAfter)
 	require.Equal(t, expectedCursor, *list.Cursor.EndingBefore)
-	require.True(t, list.Cursor.HasNextPage)
+	require.Equal(t, clerk.NextPageTrue, list.Cursor.HasNextPage)
 }

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -166,6 +166,5 @@ func TestList(t *testing.T) {
 	require.NotNil(t, list.Cursor)
 	require.Equal(t, expectedCursor, *list.Cursor.StartingAfter)
 	require.Equal(t, expectedCursor, *list.Cursor.EndingBefore)
-	require.True(t, list.Cursor.HasNextPage)
 	require.Equal(t, clerk.NextPageTrue, list.Cursor.NextPageStatus)
 }

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -74,9 +74,10 @@ func TestList(t *testing.T) {
 			},
 		},
 		"cursor": map[string]interface{}{
-			"starting_after": expectedCursor,
-			"ending_before":  expectedCursor,
-			"has_next_page":  "true",
+			"starting_after":   expectedCursor,
+			"ending_before":    expectedCursor,
+			"has_next_page":    true,
+			"next_page_status": "true",
 		},
 	}
 
@@ -165,5 +166,6 @@ func TestList(t *testing.T) {
 	require.NotNil(t, list.Cursor)
 	require.Equal(t, expectedCursor, *list.Cursor.StartingAfter)
 	require.Equal(t, expectedCursor, *list.Cursor.EndingBefore)
-	require.Equal(t, clerk.NextPageTrue, list.Cursor.HasNextPage)
+	require.True(t, list.Cursor.HasNextPage)
+	require.Equal(t, clerk.NextPageTrue, list.Cursor.NextPageStatus)
 }


### PR DESCRIPTION
Matches changes made in https://github.com/clerk/clerk_go/pull/17925 to support new pagination style in audit logs. 

also fixes https://linear.app/clerk/issue/USER-4807/flaky-test-race-in-testpackagerevoke-testpackageverify-in-clerk-sdk-go