### PR TITLE
fix: update CustomAttribute to use sso_path and scim_path fields

### DIFF
--- a/saml_connection.go
+++ b/saml_connection.go
@@ -1,9 +1,10 @@
 package clerk
 
 type CustomAttribute struct {
-	Name *string `json:"name"`
-	Key  *string `json:"key"`
-	Path *string `json:"path"`
+	Name     *string `json:"name"`
+	Key      *string `json:"key"`
+	SSOPath  *string `json:"sso_path"`
+	SCIMPath *string `json:"scim_path"`
 }
 
 type SAMLConnection struct {

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -146,7 +146,7 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s", "disable_additional_identifications": %t, "force_authn": %t, "enterprise_connection_id": "entconn_2abc123def456", "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "path": "custom_attribute_path"}]}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s", "disable_additional_identifications": %t, "force_authn": %t, "enterprise_connection_id": "entconn_2abc123def456", "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "sso_path": "custom_attribute_sso_path", "scim_path": "custom_attribute_scim_path"}]}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
 			Method: http.MethodGet,
 			Path:   "/v1/saml_connections/" + id,
 		},
@@ -163,9 +163,10 @@ func TestSAMLConnectionClientGet(t *testing.T) {
 	require.Equal(t, forceAuthn, samlConnection.ForceAuthn)
 	require.Equal(t, &[]clerk.CustomAttribute{
 		{
-			Name: clerk.String("custom_attribute_name"),
-			Key:  clerk.String("custom_attribute_key"),
-			Path: clerk.String("custom_attribute_path"),
+			Name:     clerk.String("custom_attribute_name"),
+			Key:      clerk.String("custom_attribute_key"),
+			SSOPath:  clerk.String("custom_attribute_sso_path"),
+			SCIMPath: clerk.String("custom_attribute_scim_path"),
 		},
 	}, samlConnection.CustomAttributes)
 }
@@ -182,8 +183,8 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s", "disable_additional_identifications": %t, "organization_id": "", "force_authn": %t, "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "path": "custom_attribute_path"}]}`, name, disableAdditionalIdentifications, forceAuthn)),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","disable_additional_identifications": %t,"force_authn": %t, "enterprise_connection_id": null, "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "path": "custom_attribute_path"}]}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s", "disable_additional_identifications": %t, "organization_id": "", "force_authn": %t, "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "sso_path": "custom_attribute_sso_path", "scim_path": "custom_attribute_scim_path"}]}`, name, disableAdditionalIdentifications, forceAuthn)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","disable_additional_identifications": %t,"force_authn": %t, "enterprise_connection_id": null, "custom_attributes": [{"name": "custom_attribute_name", "key": "custom_attribute_key", "sso_path": "custom_attribute_sso_path", "scim_path": "custom_attribute_scim_path"}]}`, id, name, domain, provider, disableAdditionalIdentifications, forceAuthn)),
 			Method: http.MethodPatch,
 			Path:   "/v1/saml_connections/" + id,
 		},
@@ -196,9 +197,10 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 		ForceAuthn:                       clerk.Bool(forceAuthn),
 		CustomAttributes: &[]clerk.CustomAttribute{
 			{
-				Name: clerk.String("custom_attribute_name"),
-				Key:  clerk.String("custom_attribute_key"),
-				Path: clerk.String("custom_attribute_path"),
+				Name:     clerk.String("custom_attribute_name"),
+				Key:      clerk.String("custom_attribute_key"),
+				SSOPath:  clerk.String("custom_attribute_sso_path"),
+				SCIMPath: clerk.String("custom_attribute_scim_path"),
 			},
 		},
 	})
@@ -206,9 +208,10 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 	require.Equal(t, id, samlConnection.ID)
 	require.Equal(t, &[]clerk.CustomAttribute{
 		{
-			Name: clerk.String("custom_attribute_name"),
-			Key:  clerk.String("custom_attribute_key"),
-			Path: clerk.String("custom_attribute_path"),
+			Name:     clerk.String("custom_attribute_name"),
+			Key:      clerk.String("custom_attribute_key"),
+			SSOPath:  clerk.String("custom_attribute_sso_path"),
+			SCIMPath: clerk.String("custom_attribute_scim_path"),
 		},
 	}, samlConnection.CustomAttributes)
 	require.Equal(t, name, samlConnection.Name)

--- a/scim_directory.go
+++ b/scim_directory.go
@@ -13,8 +13,7 @@ type SCIMDirectory struct {
 	APIKey                 *string           `json:"api_key,omitempty"`
 	CreatedAt              int64             `json:"created_at"`
 	UpdatedAt              int64             `json:"updated_at"`
-	AttributeMapping       map[string]string  `json:"attribute_mapping,omitempty"`
-	CustomAttributes       *[]CustomAttribute `json:"custom_attributes,omitempty"`
+	AttributeMapping       map[string]string `json:"attribute_mapping,omitempty"`
 }
 
 // SCIMDirectoryList represents a paginated list of SCIM directories.

--- a/scim_directory.go
+++ b/scim_directory.go
@@ -13,7 +13,8 @@ type SCIMDirectory struct {
 	APIKey                 *string           `json:"api_key,omitempty"`
 	CreatedAt              int64             `json:"created_at"`
 	UpdatedAt              int64             `json:"updated_at"`
-	AttributeMapping       map[string]string `json:"attribute_mapping,omitempty"`
+	AttributeMapping       map[string]string  `json:"attribute_mapping,omitempty"`
+	CustomAttributes       *[]CustomAttribute `json:"custom_attributes,omitempty"`
 }
 
 // SCIMDirectoryList represents a paginated list of SCIM directories.


### PR DESCRIPTION
## Summary

- Update `CustomAttribute` struct to use `SSOPath` and `SCIMPath` fields instead of a single `Path` field, matching the backend serialization format (`sso_path`, `scim_path`)
- Add `CustomAttributes` field to `SCIMDirectory` struct

The backend returns separate `sso_path` and `scim_path` JSON fields for custom attributes, but the SDK had a single `path` field that didn't match either tag. This caused both values to be silently dropped during deserialization — DAPI endpoints that proxy through the SDK (e.g. `/saml_connections`) returned `path: null` instead of the correct values.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./samlconnection/...` passes with updated fixtures
- [x] `go test ./enterpriseconnection/...` passes