### PR TITLE
audit_logs: add retention_limit_reached field

### DIFF
--- a/audit_logs.go
+++ b/audit_logs.go
@@ -43,6 +43,10 @@ type ExtendedPaginationCursor struct {
 	// compatibility and is derived as NextPageStatus != NextPageFalse.
 	HasNextPage    bool           `json:"has_next_page"`
 	NextPageStatus NextPageStatus `json:"next_page_status"`
+	// RetentionLimitReached is true when next_page_status is "false" and the limit
+	// was the plan's retention period, not the caller's event_time_after bound.
+	// When true, extending event_time_after further back will not yield more results.
+	RetentionLimitReached bool `json:"retention_limit_reached"`
 }
 
 // PaginationCursor contains the cursors for pagination.

--- a/audit_logs/api_test.go
+++ b/audit_logs/api_test.go
@@ -92,4 +92,5 @@ func TestPackageList(t *testing.T) {
 	assert.NotNil(t, auditLogs.Cursor)
 	assert.Equal(t, expectedCursor, *auditLogs.Cursor.StartingAfter)
 	assert.Equal(t, clerk.NextPageTrue, auditLogs.Cursor.NextPageStatus)
+	assert.False(t, auditLogs.Cursor.RetentionLimitReached)
 }

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -167,4 +167,38 @@ func TestList(t *testing.T) {
 	require.Equal(t, expectedCursor, *list.Cursor.StartingAfter)
 	require.Equal(t, expectedCursor, *list.Cursor.EndingBefore)
 	require.Equal(t, clerk.NextPageTrue, list.Cursor.NextPageStatus)
+	require.False(t, list.Cursor.RetentionLimitReached)
+}
+
+func TestList_RetentionLimitReached(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"data": []map[string]interface{}{},
+		"cursor": map[string]interface{}{
+			"starting_after":          nil,
+			"ending_before":           nil,
+			"has_next_page":           false,
+			"next_page_status":        "false",
+			"retention_limit_reached": true,
+		},
+	}
+
+	responseJSON, _ := json.Marshal(response)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    responseJSON,
+			Method: http.MethodGet,
+			Path:   "/v1/audit_logs",
+		},
+	}
+	client := NewClient(config)
+	list, err := client.List(context.Background(), &ListParams{})
+	require.NoError(t, err)
+	require.NotNil(t, list.Cursor)
+	require.Equal(t, clerk.NextPageFalse, list.Cursor.NextPageStatus)
+	require.True(t, list.Cursor.RetentionLimitReached)
 }


### PR DESCRIPTION
Supports new field  added in https://github.com/clerk/clerk_go/pull/18106