### PR TITLE
feat(audit_logs): add session_id field to AuditLog

### DIFF
--- a/audit_logs.go
+++ b/audit_logs.go
@@ -14,6 +14,7 @@ type AuditLog struct {
 	TraceID      string                `json:"trace_id"`
 	SpanID       string                `json:"span_id"`
 	ParentSpanID *string               `json:"parent_span_id"`
+	SessionID    *string               `json:"session_id"`
 	Payload      map[string]any        `json:"payload"`
 	EventContext AuditLogContext       `json:"event_context"`
 }

--- a/audit_logs/api_test.go
+++ b/audit_logs/api_test.go
@@ -31,6 +31,7 @@ func TestPackageList(t *testing.T) {
 				"trace_id":       "00000000000000000000000000000001",
 				"span_id":        "0000000000000001",
 				"parent_span_id": nil,
+				"session_id":     "0000000000000001",
 				"payload":        map[string]interface{}{},
 				"impersonator": map[string]interface{}{
 					"user_id": "user_2xPNClBrCHGhpOITVJlhdhBfGS8",
@@ -83,6 +84,7 @@ func TestPackageList(t *testing.T) {
 	assert.Equal(t, "user_2xPNCmYKPnPKaF3h0Ll8qas0I0w", auditLog.Subject)
 	assert.Equal(t, "00000000000000000000000000000001", auditLog.TraceID)
 	assert.Equal(t, "0000000000000001", auditLog.SpanID)
+	assert.Equal(t, "0000000000000001", *auditLog.SessionID)
 	assert.Nil(t, auditLog.ParentSpanID)
 	assert.NotNil(t, auditLog.Payload)
 	assert.NotNil(t, auditLog.Impersonator)

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -34,6 +34,7 @@ func TestList(t *testing.T) {
 				"trace_id":       "00000000000000000000000000000001",
 				"span_id":        "0000000000000001",
 				"parent_span_id": nil,
+				"session_id":     "0000000000000001",
 				"payload":        map[string]interface{}{},
 				"impersonator": map[string]interface{}{
 					"user_id": "user_2xPNClBrCHGhpOITVJlhdhBfGS8",
@@ -121,6 +122,7 @@ func TestList(t *testing.T) {
 	require.Equal(t, "client_123", *auditLog.ClientID)
 	require.Equal(t, "00000000000000000000000000000001", auditLog.TraceID)
 	require.Equal(t, "0000000000000001", auditLog.SpanID)
+	require.Equal(t, "0000000000000001", *auditLog.SessionID)
 	require.Nil(t, auditLog.ParentSpanID)
 	require.NotNil(t, auditLog.Payload)
 


### PR DESCRIPTION
Add the SessionID field to the AuditLog struct to support the new session_id attribute returned by the API. Update tests to include the new field in fixtures and assertions.