### PR TITLE
chore: Harden JoinPath against traversal

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -477,9 +477,44 @@ func NewClock() Clock {
 // Regular expression that matches multiple forward slashes in a row.
 var extraForwardslashesRE = regexp.MustCompile("(^/+|([^:])//+)")
 
+// checkPathTraversal returns an error if el contains a "." or ".." segment
+// in its path portion, either raw or (repeatedly) percent-encoded. Query
+// strings and fragments are ignored since they are not part of the request
+// path.
+func checkPathTraversal(el string) error {
+	p := el
+	if i := strings.IndexAny(p, "?#"); i >= 0 {
+		p = p[:i]
+	}
+	// Decode until the string no longer changes to catch double-encoded
+	// sequences like %252e%252e. Reject input that remains encoded after
+	// maxDecodeIterations passes to guard against pathological input.
+	const maxDecodeIterations = 10
+	for range maxDecodeIterations {
+		for seg := range strings.SplitSeq(p, "/") {
+			if seg == "." || seg == ".." {
+				return fmt.Errorf("clerk: path traversal sequence in path element %q", el)
+			}
+		}
+		decoded, err := url.PathUnescape(p)
+		if err != nil || decoded == p {
+			return nil
+		}
+		p = decoded
+	}
+	return fmt.Errorf("clerk: path element %q exceeds maximum decode iterations", el)
+}
+
 // JoinPath returns a URL string with the provided path elements joined
 // with the base path.
 func JoinPath(base string, elem ...string) (string, error) {
+	// Reject path traversal sequences in any element so that user-provided
+	// IDs cannot redirect requests to unintended API endpoints.
+	for _, el := range elem {
+		if err := checkPathTraversal(el); err != nil {
+			return "", err
+		}
+	}
 	// Concatenate all paths.
 	var sb strings.Builder
 	sb.WriteString(base)

--- a/clerk_test.go
+++ b/clerk_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -488,4 +489,33 @@ func TestJoinPath(t *testing.T) {
 
 	_, err := JoinPath("https://clerk.com", "*%{wontwork$")
 	require.Error(t, err)
+}
+
+func TestJoinPath_RejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+	for _, id := range []string{
+		"..",
+		".",
+		"../../v1/instance",
+		"foo/../bar",
+		"foo/./bar",
+		"foo/%2e./bar",
+		"foo/%252e%252e/bar",
+		"%2e%2e/v1/instance",
+		"%2E%2E%2Fv1%2Finstance",
+		"foo/%2e%2e/bar",
+	} {
+		_, err := JoinPath("https://api.clerk.com/v1", "users", id)
+		require.Error(t, err, "expected error for id %q", id)
+	}
+}
+
+func TestJoinPath_RejectsExcessiveEncoding(t *testing.T) {
+	t.Parallel()
+	// 12 layers of percent-encoding of "A": "%" + "25"*12 + "41" decodes
+	// one layer per pass (each "%25" -> "%"), requiring 13 decode passes
+	// to reach plain "A". That exceeds the decode iteration cap in JoinPath.
+	id := "%" + strings.Repeat("25", 12) + "41"
+	_, err := JoinPath("https://api.clerk.com/v1", "users", id)
+	require.ErrorContains(t, err, "exceeds maximum decode iterations")
 }


### PR DESCRIPTION
There is no immediate vulnerability but it could be possible that someone uses one of the functions that call `JoinPath` in a way that accepts user input and allows traversal on the backend API. This adds protection to avoid this problem.