### PR TITLE
fix: Improve error visibility when JWK kid lookup fails

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -130,6 +130,8 @@ type AuthorizationParams struct {
 	// fails. Pass a custom http.Handler to control the http.Response for
 	// invalid authorization. The default is a Response with an empty body
 	// and 401 Unauthorized status.
+	// Errors are passed to the handler in the http.Request context under
+	// the auth_error key.
 	AuthorizationFailureHandler http.Handler
 	// JWKSClient is the jwks.Client that will be used to fetch the
 	// JSON Web Key Set. A default client will be used if none is

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -14,6 +14,8 @@ import (
 	"github.com/clerk/clerk-sdk-go/v2/jwt"
 )
 
+const authErrorContextKey string = "auth_error"
+
 // RequireHeaderAuthorization will respond with HTTP 403 Forbidden if
 // the Authorization header does not contain a valid session token.
 func RequireHeaderAuthorization(opts ...AuthorizationOption) func(http.Handler) http.Handler {
@@ -69,6 +71,7 @@ func WithHeaderAuthorization(opts ...AuthorizationOption) func(http.Handler) htt
 			if params.JWK == nil {
 				params.JWK, err = getJWK(r.Context(), params.JWKSClient, decoded.KeyID, params.Clock)
 				if err != nil {
+					r := requestWithAuthError(r, err)
 					params.AuthorizationFailureHandler.ServeHTTP(w, r)
 					return
 				}
@@ -76,6 +79,7 @@ func WithHeaderAuthorization(opts ...AuthorizationOption) func(http.Handler) htt
 			params.Token = token
 			claims, err := jwt.Verify(r.Context(), &params.VerifyParams)
 			if err != nil {
+				r := requestWithAuthError(r, err)
 				params.AuthorizationFailureHandler.ServeHTTP(w, r)
 				return
 			}
@@ -380,4 +384,9 @@ func NeedsSessionReverification(policy clerk.SessionReverificationPolicy) func(h
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func requestWithAuthError(r *http.Request, err error) *http.Request {
+	ctx := context.WithValue(r.Context(), authErrorContextKey, err)
+	return r.WithContext(ctx)
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -286,7 +286,7 @@ func GetJSONWebKey(ctx context.Context, params *GetJSONWebKeyParams) (*clerk.JSO
 		}
 	}
 
-	othersMsg := "no other keys returned from endpoint"
+	othersMsg := "no keys returned from endpoint"
 	if matched {
 		othersMsg = "other keys found that did not match"
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -275,10 +275,20 @@ func GetJSONWebKey(ctx context.Context, params *GetJSONWebKeyParams) (*clerk.JSO
 		return nil, fmt.Errorf("no jwks found")
 	}
 
+	matched := false
 	for _, k := range jwks.Keys {
-		if k != nil && k.KeyID == params.KeyID {
-			return k, nil
+		if k != nil {
+			if k.KeyID == params.KeyID  {
+				return k, nil
+			} else {
+				matched = true
+			}
 		}
 	}
-	return nil, fmt.Errorf("no json web key found for kid: %q", params.KeyID)
+
+	othersMsg := "no other keys returned from endpoint"
+	if matched {
+		othersMsg = "other keys found that did not match"
+	}
+	return nil, fmt.Errorf("no json web key found for kid: %q; %s", params.KeyID, othersMsg)
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -280,5 +280,5 @@ func GetJSONWebKey(ctx context.Context, params *GetJSONWebKeyParams) (*clerk.JSO
 			return k, nil
 		}
 	}
-	return nil, fmt.Errorf("missing json web key")
+	return nil, fmt.Errorf("no json web key found for kid: %q", params.KeyID)
 }


### PR DESCRIPTION
## Problem

When GetJSONWebKey fails to find a matching key in the JWKS response, the current error message is:
```
missing json web key
```
This is misleading in two ways:

It implies no keys exist at all, when keys may exist but none matched the token's kid
It gives no indication of what kid was being looked for, making debugging extremely difficult

In practice this error surfaces when CLERK_SECRET_KEY is misconfigured — the JWKS endpoint returns keys for a different instance, none of which match the token's kid. The opaque error message makes this nearly impossible to diagnose withthout a few hours of source diving and manual tracing with delve.

## Fix

Distinguish between two failure modes and include the kid being searched for in both:

`"other keys found that did not match"` => indicates wrong Clerk instance, key rotation, or misconfigured secret key
`"no keys returned from endpoint"` => No keys returned at all → indicates JWKS fetch returned an empty response

To make these errors surfaceable via the "default" way to use this package, the middleware, I've also taken the liberty of attaching them to the request context before handing control to failure handlers.

## tl;dr

Before:
```
  "missing json web key"
```

After (keys exist but none matched):
```
  "no json web key found for kid \"ins_xxx\": other keys found that did not match"
```

After (no keys returned):
```
  "no json web key found for kid \"ins_xxx\": no keys returned from endpoint"
```