### PR TITLE
feat: Add instance communication settings

### DIFF
--- a/instance_settings.go
+++ b/instance_settings.go
@@ -1,5 +1,11 @@
 package clerk
 
+type InstanceCommunication struct {
+	APIResource
+	Object              string   `json:"object"`
+	BlockedCountryCodes []string `json:"blocked_country_codes"`
+}
+
 type InstanceRestrictions struct {
 	APIResource
 	Object                             string `json:"object"`

--- a/instancesettings/api.go
+++ b/instancesettings/api.go
@@ -18,6 +18,16 @@ func UpdateRestrictions(ctx context.Context, params *UpdateRestrictionsParams) (
 	return getClient().UpdateRestrictions(ctx, params)
 }
 
+// GetCommunication retrieves the communication settings of the instance.
+func GetCommunication(ctx context.Context) (*clerk.InstanceCommunication, error) {
+	return getClient().GetCommunication(ctx)
+}
+
+// UpdateCommunication updates the communication settings of the instance.
+func UpdateCommunication(ctx context.Context, params *UpdateCommunicationParams) (*clerk.InstanceCommunication, error) {
+	return getClient().UpdateCommunication(ctx, params)
+}
+
 // UpdateOrganizationSettings updates the organization settings of the instance.
 func UpdateOrganizationSettings(ctx context.Context, params *UpdateOrganizationSettingsParams) (*clerk.OrganizationSettings, error) {
 	return getClient().UpdateOrganizationSettings(ctx, params)

--- a/instancesettings/client.go
+++ b/instancesettings/client.go
@@ -100,6 +100,39 @@ func (c *Client) UpdateRestrictions(ctx context.Context, params *UpdateRestricti
 	return instanceRestrictions, err
 }
 
+type UpdateCommunicationParams struct {
+	clerk.APIParams
+	// BlockedCountryCodes is the list of ISO-3166-1 alpha-2 country codes
+	// for which SMS messages will not be delivered. Pass an empty slice to
+	// clear the blocklist.
+	BlockedCountryCodes *[]string `json:"blocked_country_codes,omitempty"`
+}
+
+// GetCommunication retrieves the communication settings of the instance.
+func (c *Client) GetCommunication(ctx context.Context) (*clerk.InstanceCommunication, error) {
+	path, err := clerk.JoinPath(path, "/communication")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodGet, path)
+	communication := &clerk.InstanceCommunication{}
+	err = c.Backend.Call(ctx, req, communication)
+	return communication, err
+}
+
+// UpdateCommunication updates the communication settings of the instance.
+func (c *Client) UpdateCommunication(ctx context.Context, params *UpdateCommunicationParams) (*clerk.InstanceCommunication, error) {
+	path, err := clerk.JoinPath(path, "/communication")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPatch, path)
+	req.SetParams(params)
+	communication := &clerk.InstanceCommunication{}
+	err = c.Backend.Call(ctx, req, communication)
+	return communication, err
+}
+
 type UpdateOrganizationSettingsParams struct {
 	clerk.APIParams
 	Enabled                      *bool                                     `json:"enabled,omitempty"`

--- a/instancesettings/client_test.go
+++ b/instancesettings/client_test.go
@@ -100,6 +100,45 @@ func TestInstanceClientUpdateRestrictions_Error(t *testing.T) {
 	require.Equal(t, "update-error-code", apiErr.Errors[0].Code)
 }
 
+func TestInstanceClientGetCommunication(t *testing.T) {
+	t.Parallel()
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(`{"object":"instance_communication","blocked_country_codes":["CN","RU"]}`),
+			Method: http.MethodGet,
+			Path:   "/v1/instance/communication",
+		},
+	}
+	client := NewClient(config)
+	communication, err := client.GetCommunication(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "instance_communication", communication.Object)
+	require.Equal(t, []string{"CN", "RU"}, communication.BlockedCountryCodes)
+}
+
+func TestInstanceClientUpdateCommunication(t *testing.T) {
+	t.Parallel()
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"blocked_country_codes":["CN","RU"]}`),
+			Out:    json.RawMessage(`{"object":"instance_communication","blocked_country_codes":["CN","RU"]}`),
+			Method: http.MethodPatch,
+			Path:   "/v1/instance/communication",
+		},
+	}
+	client := NewClient(config)
+	communication, err := client.UpdateCommunication(t.Context(), &UpdateCommunicationParams{
+		BlockedCountryCodes: &[]string{"CN", "RU"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "instance_communication", communication.Object)
+	require.Equal(t, []string{"CN", "RU"}, communication.BlockedCountryCodes)
+}
+
 func TestInstanceClientUpdateOrganizationSettings(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}


### PR DESCRIPTION
Support GET and PATCH endpoints for the instance communication settings. Currently the backend only supports SMS blocklists.