### PR TITLE
feat(oauth): Adds support for dynamically_registered param to OAuth applications 

### DIFF
--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/clerk/clerk-sdk-go/v3"
 	"github.com/clerk/clerk-sdk-go/v3/optional"
@@ -39,8 +40,9 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.OAuthApplication, e
 type ListParams struct {
 	clerk.APIParams
 	clerk.ListParams
-	OrderBy   *string `json:"order_by,omitempty"`
-	NameQuery *string `json:"name_query,omitempty"`
+	OrderBy               *string `json:"order_by,omitempty"`
+	NameQuery             *string `json:"name_query,omitempty"`
+	DynamicallyRegistered *bool   `json:"dynamically_registered,omitempty"`
 }
 
 func (params *ListParams) ToQuery() url.Values {
@@ -52,6 +54,10 @@ func (params *ListParams) ToQuery() url.Values {
 
 	if params.NameQuery != nil {
 		q.Set("name_query", *params.NameQuery)
+	}
+
+	if params.DynamicallyRegistered != nil {
+		q.Set("dynamically_registered", strconv.FormatBool(*params.DynamicallyRegistered))
 	}
 
 	return q

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -300,6 +300,40 @@ func TestOAuthApplicationClientList(t *testing.T) {
 	require.Equal(t, "OAuth App 1", appList.OAuthApplications[0].Name)
 }
 
+func TestOAuthApplicationClientList_DynamicallyRegistered(t *testing.T) {
+	t.Parallel()
+	for _, dynamicallyRegistered := range []bool{true, false} {
+		t.Run(fmt.Sprintf("%v", dynamicallyRegistered), func(t *testing.T) {
+			t.Parallel()
+			config := &clerk.ClientConfig{}
+			config.HTTPClient = &http.Client{
+				Transport: &clerktest.RoundTripper{
+					T: t,
+					Out: json.RawMessage(`{
+						"data": [{"id":"oauth_app_123","name":"OAuth App 1"}],
+						"total_count": 1
+					}`),
+					Method: http.MethodGet,
+					Path:   "/v1/oauth_applications",
+					Query: &url.Values{
+						"limit":                  []string{"10"},
+						"offset":                 []string{"0"},
+						"dynamically_registered": []string{fmt.Sprintf("%v", dynamicallyRegistered)},
+					},
+				},
+			}
+			client := NewClient(config)
+			params := &ListParams{}
+			params.Limit = clerk.Int64(10)
+			params.Offset = clerk.Int64(0)
+			params.DynamicallyRegistered = clerk.Bool(dynamicallyRegistered)
+			appList, err := client.List(t.Context(), params)
+			require.NoError(t, err)
+			require.Equal(t, int64(1), appList.TotalCount)
+		})
+	}
+}
+
 func TestOAuthApplicationClientRotateClientSecret(t *testing.T) {
 	t.Parallel()
 	id := "oauth_app_123"

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -280,10 +280,11 @@ func TestOAuthApplicationClientList(t *testing.T) {
 			Method: http.MethodGet,
 			Path:   "/v1/oauth_applications",
 			Query: &url.Values{
-				"limit":      []string{"10"},
-				"offset":     []string{"0"},
-				"order_by":   []string{"-name"},
-				"name_query": []string{"app_123"},
+				"limit":                  []string{"10"},
+				"offset":                 []string{"0"},
+				"order_by":               []string{"-name"},
+				"name_query":             []string{"app_123"},
+				"dynamically_registered": []string{"true"},
 			},
 		},
 	}
@@ -293,45 +294,12 @@ func TestOAuthApplicationClientList(t *testing.T) {
 	params.Offset = clerk.Int64(0)
 	params.OrderBy = clerk.String("-name")
 	params.NameQuery = clerk.String("app_123")
+	params.DynamicallyRegistered = clerk.Bool(true)
 	appList, err := client.List(t.Context(), params)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), appList.TotalCount)
 	require.Equal(t, "oauth_app_123", appList.OAuthApplications[0].ID)
 	require.Equal(t, "OAuth App 1", appList.OAuthApplications[0].Name)
-}
-
-func TestOAuthApplicationClientList_DynamicallyRegistered(t *testing.T) {
-	t.Parallel()
-	for _, dynamicallyRegistered := range []bool{true, false} {
-		t.Run(fmt.Sprintf("%v", dynamicallyRegistered), func(t *testing.T) {
-			t.Parallel()
-			config := &clerk.ClientConfig{}
-			config.HTTPClient = &http.Client{
-				Transport: &clerktest.RoundTripper{
-					T: t,
-					Out: json.RawMessage(`{
-						"data": [{"id":"oauth_app_123","name":"OAuth App 1"}],
-						"total_count": 1
-					}`),
-					Method: http.MethodGet,
-					Path:   "/v1/oauth_applications",
-					Query: &url.Values{
-						"limit":                  []string{"10"},
-						"offset":                 []string{"0"},
-						"dynamically_registered": []string{fmt.Sprintf("%v", dynamicallyRegistered)},
-					},
-				},
-			}
-			client := NewClient(config)
-			params := &ListParams{}
-			params.Limit = clerk.Int64(10)
-			params.Offset = clerk.Int64(0)
-			params.DynamicallyRegistered = clerk.Bool(dynamicallyRegistered)
-			appList, err := client.List(t.Context(), params)
-			require.NoError(t, err)
-			require.Equal(t, int64(1), appList.TotalCount)
-		})
-	}
 }
 
 func TestOAuthApplicationClientRotateClientSecret(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `DynamicallyRegistered *bool` to `oauthapplication.ListParams`, allowing callers to filter the OAuth applications list by whether an application was dynamically registered (e.g. via DCR)
- Serializes the field as `dynamically_registered=true/false` in `ToQuery()` following the same pattern as other boolean filter params in the SDK (e.g. `Banned` in `user.ListParams`)

Required by https://github.com/clerk/clerk_go/pull/18572