### PR TITLE
chore(m2m): support min remaining ttl for m2m token creation

### DIFF
--- a/m2m_token/api_test.go
+++ b/m2m_token/api_test.go
@@ -39,7 +39,7 @@ func TestPackageCreate(t *testing.T) {
 		HTTPClient: &http.Client{
 			Transport: &clerktest.RoundTripper{
 				T:      t,
-				In:     json.RawMessage(`{"claims":{"foo":"bar"},"seconds_until_expiration":3600}`),
+				In:     json.RawMessage(`{"claims":{"foo":"bar"},"seconds_until_expiration":3600,"min_remaining_ttl_seconds":240}`),
 				Out:    json.RawMessage(responseJSON),
 				Method: http.MethodPost,
 				Path:   "/v1/m2m_tokens",
@@ -54,6 +54,7 @@ func TestPackageCreate(t *testing.T) {
 	params := &CreateParams{
 		Claims:                 &claims,
 		SecondsUntilExpiration: clerk.Int64(3600),
+		MinRemainingTTLSeconds: clerk.Int64(240),
 	}
 
 	token, err := Create(context.Background(), params)

--- a/m2m_token/client.go
+++ b/m2m_token/client.go
@@ -29,6 +29,7 @@ func NewClient(config *clerk.ClientConfig) *Client {
 type CreateParams struct {
 	clerk.APIParams
 	SecondsUntilExpiration *int64           `json:"seconds_until_expiration,omitempty"`
+	MinRemainingTTLSeconds *int64           `json:"min_remaining_ttl_seconds,omitempty"`
 	Claims                 *json.RawMessage `json:"claims,omitempty"`
 	TokenFormat            *string          `json:"token_format,omitempty"`
 }

--- a/m2m_token/client_test.go
+++ b/m2m_token/client_test.go
@@ -38,7 +38,7 @@ func TestCreate(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(`{"claims":{"foo":"bar"},"seconds_until_expiration":3600,"token_format":"opaque"}`),
+			In:     json.RawMessage(`{"claims":{"foo":"bar"},"seconds_until_expiration":3600,"min_remaining_ttl_seconds":240,"token_format":"opaque"}`),
 			Out:    json.RawMessage(responseJSON),
 			Method: http.MethodPost,
 			Path:   "/v1/m2m_tokens",
@@ -50,6 +50,7 @@ func TestCreate(t *testing.T) {
 	params := &CreateParams{
 		Claims:                 &claims,
 		SecondsUntilExpiration: clerk.Int64(3600),
+		MinRemainingTTLSeconds: clerk.Int64(240),
 		TokenFormat:            clerk.String("opaque"),
 	}
 


### PR DESCRIPTION
Maps to the backend API field `min_remaining_ttl_seconds` for `POST /m2m_tokens`.