### PR TITLE
audit_logs: support OR-ing list filters via FilterMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for listing and creating waitlist entries with the `waitlistentry.List` and `waitlistentry.Create` methods.
 - Add support for fetching an organization with its members count, via a new `organizations.GetWithParams` method.
 - Add support for session reverification with `SessionClaims.NeedsReverification()`, `SessionReverificationPolicy`, predefined policies like `SessionReverificationStrict`, and middleware via `http.NeedsSessionReverification()`.
+- Add support for OR-ing audit log list filters via `audit_logs.ListParams.FilterMatch`. Pass `clerk.AuditLogFilterMatchAny` to match events that satisfy any one of `Subject`, `Type`, `Actor`, `TraceID`, `ClientID`, or `ImpersonatorUserID`. Defaults to `clerk.AuditLogFilterMatchAll` (AND) when omitted, preserving existing behavior.
 
 ## 2.2.0
 

--- a/audit_logs.go
+++ b/audit_logs.go
@@ -43,6 +43,25 @@ const (
 	NextPageUnknown NextPageStatus = "unknown"
 )
 
+// AuditLogFilterMatch controls how the string filters on the audit logs list
+// endpoint (subject, type, actor, trace_id, client_id, impersonator_user_id)
+// are combined when more than one is supplied.
+//
+//   - AuditLogFilterMatchAll (default): every supplied filter must match.
+//     Filters are joined with AND.
+//   - AuditLogFilterMatchAny: an event matches if at least one of the
+//     supplied filters matches. Filters are joined with OR.
+//
+// Time bounds (event_time_after, event_time_before) and end_user_facing_only
+// are always ANDed with the (possibly OR-ed) string filter group regardless
+// of the value.
+type AuditLogFilterMatch string
+
+const (
+	AuditLogFilterMatchAll AuditLogFilterMatch = "all"
+	AuditLogFilterMatchAny AuditLogFilterMatch = "any"
+)
+
 type ExtendedPaginationCursor struct {
 	StartingAfter *string `json:"starting_after"`
 	EndingBefore  *string `json:"ending_before"`

--- a/audit_logs/client.go
+++ b/audit_logs/client.go
@@ -47,6 +47,18 @@ type ListParams struct {
 	ClientID *string `json:"client_id,omitempty"`
 	// Filter audit logs by impersonator user ID.
 	ImpersonatorUserID *string `json:"impersonator_user_id,omitempty"`
+	// FilterMatch controls how Subject, Type, Actor, TraceID, ClientID, and
+	// ImpersonatorUserID are combined when more than one is supplied.
+	//
+	//   - AuditLogFilterMatchAll (default, also when nil): every supplied
+	//     filter must match (AND).
+	//   - AuditLogFilterMatchAny: an event matches if at least one of the
+	//     supplied filters matches (OR).
+	//
+	// EventTimeAfter, EventTimeBefore, and EndUserFacingOnly are always
+	// ANDed with the (possibly OR-ed) string filter group regardless of
+	// FilterMatch.
+	FilterMatch *clerk.AuditLogFilterMatch `json:"filter_match,omitempty"`
 	// Filter audit logs to events on or after this date (Unix timestamp in milliseconds).
 	EventTimeAfter *int64 `json:"event_time_after,omitempty"`
 	// Filter audit logs to events on or before this date (Unix timestamp in milliseconds).
@@ -85,6 +97,9 @@ func (params *ListParams) ToQuery() url.Values {
 	}
 	if params.ImpersonatorUserID != nil {
 		q.Add("impersonator_user_id", *params.ImpersonatorUserID)
+	}
+	if params.FilterMatch != nil {
+		q.Add("filter_match", string(*params.FilterMatch))
 	}
 	if params.EventTimeAfter != nil {
 		q.Add("event_time_after", strconv.FormatInt(*params.EventTimeAfter, 10))

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -170,6 +170,169 @@ func TestList(t *testing.T) {
 	require.False(t, list.Cursor.RetentionLimitReached)
 }
 
+// TestList_FilterMatchAny verifies that the filter_match query parameter is
+// serialized correctly when set to the OR-mode value, and exercises a
+// multi-axis filter combination similar to a real "show me everything for
+// this user OR this trace" query.
+func TestList_FilterMatchAny(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"data": []map[string]interface{}{},
+		"cursor": map[string]interface{}{
+			"starting_after":   nil,
+			"ending_before":    nil,
+			"has_next_page":    false,
+			"next_page_status": "false",
+		},
+	}
+	responseJSON, _ := json.Marshal(response)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    responseJSON,
+			Method: http.MethodGet,
+			Path:   "/v1/audit_logs",
+			Query: &url.Values{
+				"subject":      []string{"user_alpha"},
+				"actor":        []string{"actor_b"},
+				"trace_id":     []string{"00000000000000000000000000000001"},
+				"filter_match": []string{"any"},
+			},
+		},
+	}
+	client := NewClient(config)
+
+	filterMatch := clerk.AuditLogFilterMatchAny
+	params := &ListParams{
+		Subject:     clerk.String("user_alpha"),
+		Actor:       clerk.String("actor_b"),
+		TraceID:     clerk.String("00000000000000000000000000000001"),
+		FilterMatch: &filterMatch,
+	}
+	_, err := client.List(context.Background(), params)
+	require.NoError(t, err)
+}
+
+// TestList_FilterMatchAll verifies the explicit AND-mode value also
+// round-trips as a query parameter.
+func TestList_FilterMatchAll(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"data": []map[string]interface{}{},
+		"cursor": map[string]interface{}{
+			"starting_after":   nil,
+			"ending_before":    nil,
+			"has_next_page":    false,
+			"next_page_status": "false",
+		},
+	}
+	responseJSON, _ := json.Marshal(response)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    responseJSON,
+			Method: http.MethodGet,
+			Path:   "/v1/audit_logs",
+			Query: &url.Values{
+				"subject":      []string{"user_alpha"},
+				"type":         []string{"user.created"},
+				"filter_match": []string{"all"},
+			},
+		},
+	}
+	client := NewClient(config)
+
+	filterMatch := clerk.AuditLogFilterMatchAll
+	params := &ListParams{
+		Subject:     clerk.String("user_alpha"),
+		Type:        clerk.String("user.created"),
+		FilterMatch: &filterMatch,
+	}
+	_, err := client.List(context.Background(), params)
+	require.NoError(t, err)
+}
+
+// TestList_FilterMatchOmitted verifies that a nil FilterMatch is not
+// emitted to the query string at all (preserving the API's default
+// behavior).
+func TestList_FilterMatchOmitted(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"data": []map[string]interface{}{},
+		"cursor": map[string]interface{}{
+			"starting_after":   nil,
+			"ending_before":    nil,
+			"has_next_page":    false,
+			"next_page_status": "false",
+		},
+	}
+	responseJSON, _ := json.Marshal(response)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    responseJSON,
+			Method: http.MethodGet,
+			Path:   "/v1/audit_logs",
+			Query: &url.Values{
+				"subject": []string{"user_alpha"},
+			},
+		},
+	}
+	client := NewClient(config)
+
+	params := &ListParams{
+		Subject: clerk.String("user_alpha"),
+	}
+	_, err := client.List(context.Background(), params)
+	require.NoError(t, err)
+}
+
+// TestListParams_ToQuery_FilterMatch unit-tests ListParams.ToQuery
+// directly to lock the query parameter name and serialized value.
+func TestListParams_ToQuery_FilterMatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		filterMatch *clerk.AuditLogFilterMatch
+		want        []string
+	}{
+		{name: "nil omits the param", filterMatch: nil, want: nil},
+		{
+			name:        "any serializes as \"any\"",
+			filterMatch: filterMatchPtr(clerk.AuditLogFilterMatchAny),
+			want:        []string{"any"},
+		},
+		{
+			name:        "all serializes as \"all\"",
+			filterMatch: filterMatchPtr(clerk.AuditLogFilterMatchAll),
+			want:        []string{"all"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			params := &ListParams{FilterMatch: tc.filterMatch}
+			got := params.ToQuery()["filter_match"]
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func filterMatchPtr(v clerk.AuditLogFilterMatch) *clerk.AuditLogFilterMatch {
+	return &v
+}
+
 func TestList_RetentionLimitReached(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds a FilterMatch field on audit_logs.ListParams that controls how Subject, Type, Actor, TraceID, ClientID, and ImpersonatorUserID are combined when more than one is supplied:

  - clerk.AuditLogFilterMatchAll (default, also when nil): every supplied filter must match (AND). Preserves existing behavior.
  - clerk.AuditLogFilterMatchAny: an event matches if at least one of the supplied filters matches (OR).

EventTimeAfter, EventTimeBefore, and EndUserFacingOnly are always ANDed with the (possibly OR-ed) string filter group regardless of FilterMatch.

Merge after https://github.com/clerk/clerk_go/pull/18613