### PR TITLE
feat(enterprisedomainverification): add new top-level resource

### DIFF
--- a/enterprise_domain_verification.go
+++ b/enterprise_domain_verification.go
@@ -1,0 +1,20 @@
+package clerk
+
+type EnterpriseDomainVerificationDetails struct {
+	Status       string  `json:"status"`
+	Strategy     string  `json:"strategy"`
+	Attempts     *int    `json:"attempts"`
+	ExpireAt     *int64  `json:"expire_at"`
+	DNSTxtRecord *string `json:"dns_txt_record,omitempty"`
+}
+
+type EnterpriseDomainVerification struct {
+	APIResource
+	Object                 string                               `json:"object"`
+	ID                     string                               `json:"id"`
+	Domain                 string                               `json:"domain"`
+	EnterpriseConnectionID *string                              `json:"enterprise_connection_id"`
+	EnterpriseDomainID     *string                              `json:"enterprise_domain_id"`
+	Verified               bool                                 `json:"verified"`
+	Verification           *EnterpriseDomainVerificationDetails `json:"verification"`
+}

--- a/enterprisedomainverification/client.go
+++ b/enterprisedomainverification/client.go
@@ -1,0 +1,67 @@
+// Package enterprisedomainverification provides the Enterprise Domain
+// Verification API — standalone domain-ownership challenges that exist
+// independently of any enterprise connection. Once verified, a record is
+// linked to an enterprise connection when the connection is created with the
+// matching domain.
+package enterprisedomainverification
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/clerk/clerk-sdk-go/v3"
+)
+
+//go:generate go run ../cmd/gen/main.go
+
+const path = "/enterprise_domain_verifications"
+
+// Client is used to invoke the Enterprise Domain Verification API.
+type Client struct {
+	Backend clerk.Backend
+}
+
+func NewClient(config *clerk.ClientConfig) *Client {
+	return &Client{
+		Backend: clerk.NewBackend(&config.BackendConfig),
+	}
+}
+
+// PrepareParams is the request body for starting a new domain verification.
+type PrepareParams struct {
+	clerk.APIParams
+	Strategy                *string `json:"strategy,omitempty"`
+	Domain                  *string `json:"domain,omitempty"`
+	AffiliationEmailAddress *string `json:"affiliation_email_address,omitempty"`
+}
+
+// Prepare creates a new standalone domain verification.
+func (c *Client) Prepare(ctx context.Context, params *PrepareParams) (*clerk.EnterpriseDomainVerification, error) {
+	req := clerk.NewAPIRequest(http.MethodPost, path)
+	req.SetParams(params)
+	res := &clerk.EnterpriseDomainVerification{}
+	err := c.Backend.Call(ctx, req, res)
+	return res, err
+}
+
+// AttemptParams is the request body for completing a previously prepared
+// domain verification.
+type AttemptParams struct {
+	clerk.APIParams
+	VerificationID string  `json:"-"`
+	Strategy       *string `json:"strategy,omitempty"`
+	Code           *string `json:"code,omitempty"`
+}
+
+// Attempt completes a previously prepared domain verification.
+func (c *Client) Attempt(ctx context.Context, params *AttemptParams) (*clerk.EnterpriseDomainVerification, error) {
+	p, err := clerk.JoinPath(path, params.VerificationID, "/attempt_verification")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPost, p)
+	req.SetParams(params)
+	res := &clerk.EnterpriseDomainVerification{}
+	err = c.Backend.Call(ctx, req, res)
+	return res, err
+}

--- a/enterprisedomainverification/client_test.go
+++ b/enterprisedomainverification/client_test.go
@@ -1,0 +1,133 @@
+package enterprisedomainverification
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/clerk/clerk-sdk-go/v3"
+	"github.com/clerk/clerk-sdk-go/v3/clerktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnterpriseDomainVerificationClientPrepareDNSTxt(t *testing.T) {
+	t.Parallel()
+	id := "entd_ver_123"
+	domain := "example.com"
+	strategy := "dns_txt"
+	record := "clerk-verification=abc123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"strategy":"%s","domain":"%s"}`, strategy, domain)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"enterprise_domain_verification","domain":"%s","enterprise_connection_id":null,"enterprise_domain_id":null,"verified":false,"verification":{"status":"unverified","strategy":"%s","attempts":0,"expire_at":1715520000000,"dns_txt_record":"%s"}}`, id, domain, strategy, record)),
+			Method: http.MethodPost,
+			Path:   "/v1/enterprise_domain_verifications",
+		},
+	}
+	client := NewClient(config)
+	res, err := client.Prepare(context.Background(), &PrepareParams{
+		Strategy: clerk.String(strategy),
+		Domain:   clerk.String(domain),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, res.ID)
+	require.Equal(t, domain, res.Domain)
+	require.False(t, res.Verified)
+	require.Nil(t, res.EnterpriseConnectionID)
+	require.Nil(t, res.EnterpriseDomainID)
+	require.NotNil(t, res.Verification)
+	require.Equal(t, "unverified", res.Verification.Status)
+	require.Equal(t, strategy, res.Verification.Strategy)
+	require.NotNil(t, res.Verification.DNSTxtRecord)
+	require.Equal(t, record, *res.Verification.DNSTxtRecord)
+}
+
+func TestEnterpriseDomainVerificationClientPrepareEmailCode(t *testing.T) {
+	t.Parallel()
+	id := "entd_ver_456"
+	domain := "example.com"
+	strategy := "email_code"
+	storedStrategy := "enterprise_email_code"
+	email := "admin@example.com"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"strategy":"%s","domain":"%s","affiliation_email_address":"%s"}`, strategy, domain, email)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"enterprise_domain_verification","domain":"%s","enterprise_connection_id":null,"enterprise_domain_id":null,"verified":false,"verification":{"status":"unverified","strategy":"%s","attempts":0,"expire_at":1715520000000}}`, id, domain, storedStrategy)),
+			Method: http.MethodPost,
+			Path:   "/v1/enterprise_domain_verifications",
+		},
+	}
+	client := NewClient(config)
+	res, err := client.Prepare(context.Background(), &PrepareParams{
+		Strategy:                clerk.String(strategy),
+		Domain:                  clerk.String(domain),
+		AffiliationEmailAddress: clerk.String(email),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, res.ID)
+	require.Equal(t, domain, res.Domain)
+	require.False(t, res.Verified)
+	require.NotNil(t, res.Verification)
+	require.Equal(t, storedStrategy, res.Verification.Strategy)
+	require.Nil(t, res.Verification.DNSTxtRecord)
+}
+
+func TestEnterpriseDomainVerificationClientAttemptDNSTxt(t *testing.T) {
+	t.Parallel()
+	id := "entd_ver_789"
+	domain := "example.com"
+	strategy := "dns_txt"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"strategy":"%s"}`, strategy)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"enterprise_domain_verification","domain":"%s","enterprise_connection_id":null,"enterprise_domain_id":null,"verified":true,"verification":{"status":"verified","strategy":"%s","attempts":1,"expire_at":1715520000000}}`, id, domain, strategy)),
+			Method: http.MethodPost,
+			Path:   "/v1/enterprise_domain_verifications/" + id + "/attempt_verification",
+		},
+	}
+	client := NewClient(config)
+	res, err := client.Attempt(context.Background(), &AttemptParams{
+		VerificationID: id,
+		Strategy:       clerk.String(strategy),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, res.ID)
+	require.True(t, res.Verified)
+	require.Equal(t, "verified", res.Verification.Status)
+}
+
+func TestEnterpriseDomainVerificationClientAttemptEmailCode(t *testing.T) {
+	t.Parallel()
+	id := "entd_ver_abc"
+	domain := "example.com"
+	strategy := "email_code"
+	storedStrategy := "enterprise_email_code"
+	code := "424242"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"strategy":"%s","code":"%s"}`, strategy, code)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"enterprise_domain_verification","domain":"%s","enterprise_connection_id":null,"enterprise_domain_id":null,"verified":true,"verification":{"status":"verified","strategy":"%s","attempts":1,"expire_at":1715520000000}}`, id, domain, storedStrategy)),
+			Method: http.MethodPost,
+			Path:   "/v1/enterprise_domain_verifications/" + id + "/attempt_verification",
+		},
+	}
+	client := NewClient(config)
+	res, err := client.Attempt(context.Background(), &AttemptParams{
+		VerificationID: id,
+		Strategy:       clerk.String(strategy),
+		Code:           clerk.String(code),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, res.ID)
+	require.True(t, res.Verified)
+}


### PR DESCRIPTION
Verifies ownership of a domain — via DNS TXT or an emailed OTP — independently of any enterprise connection. Once verified, the record can be linked to an enterprise connection during connection creation.

Endpoints:
  POST /enterprise_domain_verifications
  POST /enterprise_domain_verifications/{id}/attempt_verification