### PR TITLE
feat(saml-connections): expose multi_valued on custom attributes

### DIFF
--- a/enterpriseconnection/client.go
+++ b/enterpriseconnection/client.go
@@ -42,6 +42,8 @@ type CreateParamsSaml struct {
 	IdpMetadata      *string                 `json:"idp_metadata,omitempty"`
 	AttributeMapping *AttributeMappingParams `json:"attribute_mapping,omitempty"`
 	ForceAuthn       *bool                   `json:"force_authn,omitempty"`
+	// CustomAttributes is an Experimental feature, not available for all customers.
+	CustomAttributes *[]clerk.CustomAttribute `json:"custom_attributes,omitempty"`
 }
 
 // CreateParamsOidc is the request body for creating an OIDC enterprise connection.

--- a/enterpriseconnection/client_test.go
+++ b/enterpriseconnection/client_test.go
@@ -104,6 +104,102 @@ func TestEnterpriseConnectionClientUpdate(t *testing.T) {
 	require.Equal(t, name, conn.Name)
 }
 
+// TestEnterpriseConnectionClientCreate_WithMultiValuedCustomAttributes verifies the
+// SAML enterprise connection create endpoint accepts custom attributes that carry
+// the `multi_valued` flag, covering both true and false values.
+func TestEnterpriseConnectionClientCreate_WithMultiValuedCustomAttributes(t *testing.T) {
+	t.Parallel()
+	id := "entconn_456"
+	name := "Acme SAML"
+	provider := "saml_custom"
+	protocol := "saml"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","provider":"%s","protocol":"%s","saml":{"custom_attributes":[{"name":"groups","key":"groups","sso_path":"$.groups","scim_path":"groups","multi_valued":true},{"name":"manager","key":"manager","sso_path":"$.manager","scim_path":"manager","multi_valued":false}]}}`, name, provider, protocol)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","provider":"%s","protocol":"%s","object":"enterprise_connection","active":true,"custom_attributes":[{"name":"groups","key":"groups","sso_path":"$.groups","scim_path":"groups","multi_valued":true},{"name":"manager","key":"manager","sso_path":"$.manager","scim_path":"manager","multi_valued":false}]}`, id, name, provider, protocol)),
+			Method: http.MethodPost,
+			Path:   "/v1/enterprise_connections",
+		},
+	}
+	client := NewClient(config)
+	conn, err := client.Create(context.Background(), &CreateParams{
+		Name:     clerk.String(name),
+		Provider: clerk.String(provider),
+		Protocol: clerk.String(protocol),
+		Saml: &CreateParamsSaml{
+			CustomAttributes: &[]clerk.CustomAttribute{
+				{
+					Name:        clerk.String("groups"),
+					Key:         clerk.String("groups"),
+					SSOPath:     clerk.String("$.groups"),
+					SCIMPath:    clerk.String("groups"),
+					MultiValued: clerk.Bool(true),
+				},
+				{
+					Name:        clerk.String("manager"),
+					Key:         clerk.String("manager"),
+					SSOPath:     clerk.String("$.manager"),
+					SCIMPath:    clerk.String("manager"),
+					MultiValued: clerk.Bool(false),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, conn.ID)
+	require.NotNil(t, conn.CustomAttributes)
+	require.Equal(t, 2, len(*conn.CustomAttributes))
+	require.Equal(t, true, *(*conn.CustomAttributes)[0].MultiValued)
+	require.Equal(t, false, *(*conn.CustomAttributes)[1].MultiValued)
+}
+
+// TestEnterpriseConnectionClientUpdate_WithMultiValuedCustomAttributes verifies the
+// SAML enterprise connection update endpoint accepts custom attributes that carry
+// the `multi_valued` flag, covering both true and false values.
+func TestEnterpriseConnectionClientUpdate_WithMultiValuedCustomAttributes(t *testing.T) {
+	t.Parallel()
+	id := "entconn_789"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"saml":{"custom_attributes":[{"name":"groups","key":"groups","sso_path":"$.groups","scim_path":"groups","multi_valued":true},{"name":"department","key":"department","sso_path":"$.department","scim_path":"department","multi_valued":false}]}}`),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"enterprise_connection","protocol":"saml","provider":"saml_custom","active":true,"custom_attributes":[{"name":"groups","key":"groups","sso_path":"$.groups","scim_path":"groups","multi_valued":true},{"name":"department","key":"department","sso_path":"$.department","scim_path":"department","multi_valued":false}]}`, id)),
+			Method: http.MethodPatch,
+			Path:   "/v1/enterprise_connections/" + id,
+		},
+	}
+	client := NewClient(config)
+	conn, err := client.Update(context.Background(), id, &UpdateParams{
+		Saml: &UpdateParamsSaml{
+			CustomAttributes: &[]clerk.CustomAttribute{
+				{
+					Name:        clerk.String("groups"),
+					Key:         clerk.String("groups"),
+					SSOPath:     clerk.String("$.groups"),
+					SCIMPath:    clerk.String("groups"),
+					MultiValued: clerk.Bool(true),
+				},
+				{
+					Name:        clerk.String("department"),
+					Key:         clerk.String("department"),
+					SSOPath:     clerk.String("$.department"),
+					SCIMPath:    clerk.String("department"),
+					MultiValued: clerk.Bool(false),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, conn.ID)
+	require.NotNil(t, conn.CustomAttributes)
+	require.Equal(t, 2, len(*conn.CustomAttributes))
+	require.Equal(t, true, *(*conn.CustomAttributes)[0].MultiValued)
+	require.Equal(t, false, *(*conn.CustomAttributes)[1].MultiValued)
+}
+
 func TestEnterpriseConnectionClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "entconn_del"

--- a/m2m_token/api_test.go
+++ b/m2m_token/api_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPackageCreate(t *testing.T) {
-	t.Parallel()
+	// Not parallel: these tests mutate the global backend via clerk.SetBackend.
 
 	response := map[string]interface{}{
 		"object":            "machine_to_machine_token",
@@ -65,7 +65,7 @@ func TestPackageCreate(t *testing.T) {
 }
 
 func TestPackageList(t *testing.T) {
-	t.Parallel()
+	// Not parallel: these tests mutate the global backend via clerk.SetBackend.
 
 	response := map[string]interface{}{
 		"m2m_tokens": []map[string]interface{}{
@@ -121,7 +121,7 @@ func TestPackageList(t *testing.T) {
 }
 
 func TestPackageRevoke(t *testing.T) {
-	t.Parallel()
+	// Not parallel: these tests mutate the global backend via clerk.SetBackend.
 
 	response := map[string]interface{}{
 		"object":            "machine_to_machine_token",
@@ -167,7 +167,7 @@ func TestPackageRevoke(t *testing.T) {
 }
 
 func TestPackageVerify(t *testing.T) {
-	t.Parallel()
+	// Not parallel: these tests mutate the global backend via clerk.SetBackend.
 
 	response := map[string]interface{}{
 		"object":            "machine_to_machine_token",

--- a/saml_connection.go
+++ b/saml_connection.go
@@ -1,10 +1,11 @@
 package clerk
 
 type CustomAttribute struct {
-	Name     *string `json:"name"`
-	Key      *string `json:"key"`
-	SSOPath  *string `json:"sso_path"`
-	SCIMPath *string `json:"scim_path"`
+	Name        *string `json:"name"`
+	Key         *string `json:"key"`
+	SSOPath     *string `json:"sso_path"`
+	SCIMPath    *string `json:"scim_path"`
+	MultiValued *bool   `json:"multi_valued,omitempty"`
 }
 
 type SAMLConnection struct {

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -54,6 +54,8 @@ type CreateParams struct {
 	IdpMetadata      *string                 `json:"idp_metadata,omitempty"`
 	AttributeMapping *AttributeMappingParams `json:"attribute_mapping,omitempty"`
 	ForceAuthn       *bool                   `json:"force_authn,omitempty"`
+	// CustomAttributes is an Experimental feature, not available for all customers.
+	CustomAttributes *[]clerk.CustomAttribute `json:"custom_attributes,omitempty"`
 }
 
 // Create creates a new SAML Connection.

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -305,6 +305,99 @@ func TestSAMLConnectionClientUpdate_WithDomains(t *testing.T) {
 	require.Equal(t, provider, samlConnection.Provider)
 }
 
+// TestSAMLConnectionClientCreate_WithMultiValuedCustomAttributes verifies the client
+// can create a SAML connection with custom attributes that include the `multi_valued`
+// flag, covering both true and false values to ensure the boolean serializes correctly
+// in either state.
+func TestSAMLConnectionClientCreate_WithMultiValuedCustomAttributes(t *testing.T) {
+	t.Parallel()
+	id := "samlc__123"
+	name := "the-name"
+	domain := "example.com"
+	provider := "saml_custom"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","domain":"%s","provider":"%s","custom_attributes":[{"name":"groups","key":"groups","sso_path":"$.groups","scim_path":"groups","multi_valued":true},{"name":"manager","key":"manager","sso_path":"$.manager","scim_path":"manager","multi_valued":false}]}`, name, domain, provider)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","domain":"%s","provider":"%s","custom_attributes":[{"name":"groups","key":"groups","sso_path":"$.groups","scim_path":"groups","multi_valued":true},{"name":"manager","key":"manager","sso_path":"$.manager","scim_path":"manager","multi_valued":false}]}`, id, name, domain, provider)),
+			Method: http.MethodPost,
+			Path:   "/v1/saml_connections",
+		},
+	}
+	client := NewClient(config)
+	samlConnection, err := client.Create(context.Background(), &CreateParams{
+		Name:     clerk.String(name),
+		Domain:   clerk.String(domain),
+		Provider: clerk.String(provider),
+		CustomAttributes: &[]clerk.CustomAttribute{
+			{
+				Name:        clerk.String("groups"),
+				Key:         clerk.String("groups"),
+				SSOPath:     clerk.String("$.groups"),
+				SCIMPath:    clerk.String("groups"),
+				MultiValued: clerk.Bool(true),
+			},
+			{
+				Name:        clerk.String("manager"),
+				Key:         clerk.String("manager"),
+				SSOPath:     clerk.String("$.manager"),
+				SCIMPath:    clerk.String("manager"),
+				MultiValued: clerk.Bool(false),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, samlConnection.ID)
+	require.NotNil(t, samlConnection.CustomAttributes)
+	require.Equal(t, 2, len(*samlConnection.CustomAttributes))
+	require.Equal(t, true, *(*samlConnection.CustomAttributes)[0].MultiValued)
+	require.Equal(t, false, *(*samlConnection.CustomAttributes)[1].MultiValued)
+}
+
+// TestSAMLConnectionClientUpdate_WithMultiValuedCustomAttributes verifies the client
+// can update a SAML connection with custom attributes that include the `multi_valued`
+// flag, covering both true and false values.
+func TestSAMLConnectionClientUpdate_WithMultiValuedCustomAttributes(t *testing.T) {
+	t.Parallel()
+	id := "samlc__123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"custom_attributes":[{"name":"groups","key":"groups","sso_path":"$.groups","scim_path":"groups","multi_valued":true},{"name":"department","key":"department","sso_path":"$.department","scim_path":"department","multi_valued":false}]}`),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","custom_attributes":[{"name":"groups","key":"groups","sso_path":"$.groups","scim_path":"groups","multi_valued":true},{"name":"department","key":"department","sso_path":"$.department","scim_path":"department","multi_valued":false}]}`, id)),
+			Method: http.MethodPatch,
+			Path:   "/v1/saml_connections/" + id,
+		},
+	}
+	client := NewClient(config)
+	samlConnection, err := client.Update(context.Background(), id, &UpdateParams{
+		CustomAttributes: &[]clerk.CustomAttribute{
+			{
+				Name:        clerk.String("groups"),
+				Key:         clerk.String("groups"),
+				SSOPath:     clerk.String("$.groups"),
+				SCIMPath:    clerk.String("groups"),
+				MultiValued: clerk.Bool(true),
+			},
+			{
+				Name:        clerk.String("department"),
+				Key:         clerk.String("department"),
+				SSOPath:     clerk.String("$.department"),
+				SCIMPath:    clerk.String("department"),
+				MultiValued: clerk.Bool(false),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, samlConnection.ID)
+	require.NotNil(t, samlConnection.CustomAttributes)
+	require.Equal(t, 2, len(*samlConnection.CustomAttributes))
+	require.Equal(t, true, *(*samlConnection.CustomAttributes)[0].MultiValued)
+	require.Equal(t, false, *(*samlConnection.CustomAttributes)[1].MultiValued)
+}
+
 func TestSAMLConnectionClientDelete(t *testing.T) {
 	t.Parallel()
 	id := "samlc__123"


### PR DESCRIPTION
## Summary

Adds `MultiValued *bool` to `clerk.CustomAttribute` so SAML connection custom attributes can opt into multi-value mapping (multiple `<saml:AttributeValue>` children flowing into `public_metadata` as an array instead of being flattened to the first value).

Round-trips through both:
- `samlconnection` package — adds `CustomAttributes *[]clerk.CustomAttribute` to `CreateParams` (already on `UpdateParams` in v3).
- `enterpriseconnection` package — adds `CustomAttributes` to `CreateParamsSaml` for parity with `UpdateParamsSaml`.

## Why

Multi-value `<saml:Attribute>` is SAML-spec compliant and emitted by common IdPs (e.g. Okta groups, Azure AD roles). The current behavior flattens to the first value, which makes group/role mapping unreliable. Backend support is being added in parallel; this PR surfaces the field in the public SDK so consumers can read/write `multi_valued` per attribute.

## Changes

- `clerk.CustomAttribute`: new `MultiValued *bool` field (JSON `multi_valued,omitempty`)
- `samlconnection.CreateParams.CustomAttributes` (new)
- `enterpriseconnection.CreateParamsSaml.CustomAttributes` (new)
- `sdkVersion` -> `v3.1.0`
- CHANGELOG entry

## Backwards compatibility

- Pointer field, omitempty — existing callers unaffected.
- Field absent on response = nil = current behavior (single-value, first-only mapping).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — 398 tests, 45 packages, all pass
- [x] New tests: create + update round-trip with `multi_valued: true` and `multi_valued: false`, both `samlconnection` and `enterpriseconnection`