### PR TITLE
remove metadata fields in user and organization Update method

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,6 +69,33 @@ user.ReplaceMetadata(ctx, userID, &user.ReplaceMetadataParams{
 })
 ```
 
+### Updating Organization Metadata
+
+Organization metadata can no longer be updated via `organization.Update`. The `PublicMetadata` and `PrivateMetadata` fields have been removed from `organization.UpdateParams`. Use the dedicated `organization.UpdateMetadata` function instead.
+
+```diff
+import (
+    "github.com/clerk/clerk-sdk-go/v3/organization"
+)
+
+func updateOrgMetadata(ctx context.Context, orgID string, publicMetadata json.RawMessage) {
+-   organization.Update(ctx, orgID, &organization.UpdateParams{
+-       PublicMetadata: &publicMetadata,
+-   })
++   organization.UpdateMetadata(ctx, orgID, &organization.UpdateMetadataParams{
++       PublicMetadata: &publicMetadata,
++   })
+}
+```
+
+`organization.UpdateMetadata` deep-merges the provided values into the existing metadata. If you need to fully overwrite a metadata column (rather than merge into it), use `organization.ReplaceMetadata` instead. Both leave omitted fields untouched; passing `{}` for a field via `ReplaceMetadata` clears that column.
+
+```go
+organization.ReplaceMetadata(ctx, orgID, &organization.ReplaceMetadataParams{
+    PublicMetadata: &publicMetadata, // overwrites public_metadata entirely
+})
+```
+
 ## 1.x.x to 2.x.x
 
 The `v2` version of the Clerk Go SDK is a complete rewrite and introduces

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -61,6 +61,14 @@ func updateUserMetadata(ctx context.Context, userID string, publicMetadata json.
 }
 ```
 
+`user.UpdateMetadata` deep-merges the provided values into the existing metadata. If you need to fully overwrite a metadata column (rather than merge into it), use `user.ReplaceMetadata` instead. Both leave omitted fields untouched; passing `{}` for a field via `ReplaceMetadata` clears that column.
+
+```go
+user.ReplaceMetadata(ctx, userID, &user.ReplaceMetadataParams{
+    PublicMetadata: &publicMetadata, // overwrites public_metadata entirely
+})
+```
+
 ## 1.x.x to 2.x.x
 
 The `v2` version of the Clerk Go SDK is a complete rewrite and introduces

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,6 +42,25 @@ func (s *Service) fetchOrgExample(idOrSlug string, includeMembersCount bool) {
 }
 ```
 
+### Updating User Metadata
+
+User metadata can no longer be updated via `user.Update`. The `PublicMetadata`, `PrivateMetadata`, and `UnsafeMetadata` fields have been removed from `user.UpdateParams`. Use the dedicated `user.UpdateMetadata` function instead.
+
+```diff
+import (
+    "github.com/clerk/clerk-sdk-go/v3/user"
+)
+
+func updateUserMetadata(ctx context.Context, userID string, publicMetadata json.RawMessage) {
+-   user.Update(ctx, userID, &user.UpdateParams{
+-       PublicMetadata: &publicMetadata,
+-   })
++   user.UpdateMetadata(ctx, userID, &user.UpdateMetadataParams{
++       PublicMetadata: &publicMetadata,
++   })
+}
+```
+
 ## 1.x.x to 2.x.x
 
 The `v2` version of the Clerk Go SDK is a complete rewrite and introduces

--- a/audit_logs/api.go
+++ b/audit_logs/api.go
@@ -8,14 +8,15 @@ import (
 	"github.com/clerk/clerk-sdk-go/v3"
 )
 
+// Get retrieves a single audit log by its composite key (event_time_ms:event_id).
+// Unlike List, the returned object includes the full event payload.
+func Get(ctx context.Context, params *GetParams) (*clerk.AuditLogWithPayload, error) {
+	return getClient().Get(ctx, params)
+}
+
 // List returns a list of audit logs.
 func List(ctx context.Context, params *ListParams) (*clerk.AuditLogList, error) {
 	return getClient().List(ctx, params)
-}
-
-// Get retrieves a single audit log by its composite key.
-func Get(ctx context.Context, params *GetParams) (*clerk.AuditLogWithPayload, error) {
-	return getClient().Get(ctx, params)
 }
 
 func getClient() *Client {

--- a/clerk.go
+++ b/clerk.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	sdkVersion      string = "v3.0.0"
-	clerkAPIVersion string = "2025-04-10"
+	clerkAPIVersion string = "2026-05-12"
 )
 
 const (

--- a/organization/api.go
+++ b/organization/api.go
@@ -30,6 +30,14 @@ func UpdateMetadata(ctx context.Context, id string, params *UpdateMetadataParams
 	return getClient().UpdateMetadata(ctx, id, params)
 }
 
+// ReplaceMetadata replaces the organization's metadata. Each metadata
+// field included in the request overwrites the stored value (rather than
+// merging with it). Fields omitted from the request are left untouched.
+// To clear a column, pass an empty object ({}) for that field.
+func ReplaceMetadata(ctx context.Context, id string, params *ReplaceMetadataParams) (*clerk.Organization, error) {
+	return getClient().ReplaceMetadata(ctx, id, params)
+}
+
 // Delete deletes an organization.
 func Delete(ctx context.Context, id string) (*clerk.DeletedResource, error) {
 	return getClient().Delete(ctx, id)

--- a/organization/client.go
+++ b/organization/client.go
@@ -80,12 +80,10 @@ func (c *Client) Get(ctx context.Context, idOrSlug string, params *GetParams) (*
 
 type UpdateParams struct {
 	clerk.APIParams
-	Name                  *string          `json:"name,omitempty"`
-	Slug                  *string          `json:"slug,omitempty"`
-	MaxAllowedMemberships *int64           `json:"max_allowed_memberships,omitempty"`
-	PublicMetadata        *json.RawMessage `json:"public_metadata,omitempty"`
-	PrivateMetadata       *json.RawMessage `json:"private_metadata,omitempty"`
-	AdminDeleteEnabled    *bool            `json:"admin_delete_enabled,omitempty"`
+	Name                  *string `json:"name,omitempty"`
+	Slug                  *string `json:"slug,omitempty"`
+	MaxAllowedMemberships *int64  `json:"max_allowed_memberships,omitempty"`
+	AdminDeleteEnabled    *bool   `json:"admin_delete_enabled,omitempty"`
 	// RoleSetKey and ReassignmentMappings are preview fields and are not available yet for all customers.
 	// The use of this field will cause an error to be returned.
 	RoleSetKey           *string                     `json:"role_set_key,omitempty"`
@@ -119,6 +117,27 @@ func (c *Client) UpdateMetadata(ctx context.Context, id string, params *UpdateMe
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodPatch, path)
+	req.SetParams(params)
+	organization := &clerk.Organization{}
+	err = c.Backend.Call(ctx, req, organization)
+	return organization, err
+}
+
+type ReplaceMetadataParams struct {
+	clerk.APIParams
+	PublicMetadata  *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
+}
+
+// ReplaceMetadata replaces the organization's metadata. Each metadata
+// field included in the request overwrites the stored value (rather than
+// merging with it).
+func (c *Client) ReplaceMetadata(ctx context.Context, id string, params *ReplaceMetadataParams) (*clerk.Organization, error) {
+	path, err := clerk.JoinPath(path, id, "/metadata")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPut, path)
 	req.SetParams(params)
 	organization := &clerk.Organization{}
 	err = c.Backend.Call(ctx, req, organization)

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -330,3 +330,27 @@ func TestOrganizationClientUpdateMetadata(t *testing.T) {
 	require.Equal(t, id, organization.ID)
 	require.JSONEq(t, metadata, string(organization.PrivateMetadata))
 }
+
+func TestOrganizationClientReplaceMetadata(t *testing.T) {
+	t.Parallel()
+	id := "org_123"
+	metadata := `{"foo":"bar"}`
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"private_metadata":%s}`, metadata)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","private_metadata":%s}`, id, metadata)),
+			Method: http.MethodPut,
+			Path:   "/v1/organizations/" + id + "/metadata",
+		},
+	}
+	client := NewClient(config)
+	metadataParam := json.RawMessage(metadata)
+	organization, err := client.ReplaceMetadata(context.Background(), id, &ReplaceMetadataParams{
+		PrivateMetadata: &metadataParam,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, organization.ID)
+	require.JSONEq(t, metadata, string(organization.PrivateMetadata))
+}

--- a/user/api.go
+++ b/user/api.go
@@ -39,6 +39,15 @@ func UpdateMetadata(ctx context.Context, id string, params *UpdateMetadataParams
 	return getClient().UpdateMetadata(ctx, id, params)
 }
 
+// ReplaceMetadata replaces the user's metadata. Each metadata
+// field included in the request overwrites the stored value
+// (rather than merging with it). Fields omitted from the request
+// are left untouched. To clear a column, pass an empty object
+// ({}) for that field.
+func ReplaceMetadata(ctx context.Context, id string, params *ReplaceMetadataParams) (*clerk.User, error) {
+	return getClient().ReplaceMetadata(ctx, id, params)
+}
+
 // Delete deletes a user.
 func Delete(ctx context.Context, id string) (*clerk.DeletedResource, error) {
 	return getClient().Delete(ctx, id)

--- a/user/client.go
+++ b/user/client.go
@@ -85,27 +85,27 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.User, error) {
 
 type UpdateParams struct {
 	clerk.APIParams
-	FirstName                        *string          `json:"first_name,omitempty"`
-	LastName                         *string          `json:"last_name,omitempty"`
-	PrimaryEmailAddressID            *string          `json:"primary_email_address_id,omitempty"`
-	NotifyPrimaryEmailAddressChanged *bool            `json:"notify_primary_email_address_changed,omitempty"`
-	PrimaryPhoneNumberID             *string          `json:"primary_phone_number_id,omitempty"`
-	PrimaryWeb3WalletID              *string          `json:"primary_web3_wallet_id,omitempty"`
-	Username                         *string          `json:"username,omitempty"`
-	ProfileImageID                   *string          `json:"profile_image_id,omitempty"`
-	ProfileImage                     *string          `json:"profile_image,omitempty"`
-	Password                         *string          `json:"password,omitempty"`
-	PasswordDigest                   *string          `json:"password_digest,omitempty"`
-	PasswordHasher                   *string          `json:"password_hasher,omitempty"`
-	SkipPasswordChecks               *bool            `json:"skip_password_checks,omitempty"`
-	SignOutOfOtherSessions           *bool            `json:"sign_out_of_other_sessions,omitempty"`
-	ExternalID                       *string          `json:"external_id,omitempty"`
-	TOTPSecret                       *string          `json:"totp_secret,omitempty"`
-	BackupCodes                      *[]string        `json:"backup_codes,omitempty"`
-	DeleteSelfEnabled                *bool            `json:"delete_self_enabled,omitempty"`
-	BypassClientTrust                *bool            `json:"bypass_client_trust,omitempty"`
-	CreateOrganizationEnabled        *bool            `json:"create_organization_enabled,omitempty"`
-	CreateOrganizationsLimit         *int             `json:"create_organizations_limit,omitempty"`
+	FirstName                        *string   `json:"first_name,omitempty"`
+	LastName                         *string   `json:"last_name,omitempty"`
+	PrimaryEmailAddressID            *string   `json:"primary_email_address_id,omitempty"`
+	NotifyPrimaryEmailAddressChanged *bool     `json:"notify_primary_email_address_changed,omitempty"`
+	PrimaryPhoneNumberID             *string   `json:"primary_phone_number_id,omitempty"`
+	PrimaryWeb3WalletID              *string   `json:"primary_web3_wallet_id,omitempty"`
+	Username                         *string   `json:"username,omitempty"`
+	ProfileImageID                   *string   `json:"profile_image_id,omitempty"`
+	ProfileImage                     *string   `json:"profile_image,omitempty"`
+	Password                         *string   `json:"password,omitempty"`
+	PasswordDigest                   *string   `json:"password_digest,omitempty"`
+	PasswordHasher                   *string   `json:"password_hasher,omitempty"`
+	SkipPasswordChecks               *bool     `json:"skip_password_checks,omitempty"`
+	SignOutOfOtherSessions           *bool     `json:"sign_out_of_other_sessions,omitempty"`
+	ExternalID                       *string   `json:"external_id,omitempty"`
+	TOTPSecret                       *string   `json:"totp_secret,omitempty"`
+	BackupCodes                      *[]string `json:"backup_codes,omitempty"`
+	DeleteSelfEnabled                *bool     `json:"delete_self_enabled,omitempty"`
+	BypassClientTrust                *bool     `json:"bypass_client_trust,omitempty"`
+	CreateOrganizationEnabled        *bool     `json:"create_organization_enabled,omitempty"`
+	CreateOrganizationsLimit         *int      `json:"create_organizations_limit,omitempty"`
 	// Specified in RFC3339 format
 	LegalAcceptedAt *string `json:"legal_accepted_at,omitempty"`
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`

--- a/user/client.go
+++ b/user/client.go
@@ -100,9 +100,6 @@ type UpdateParams struct {
 	SkipPasswordChecks               *bool            `json:"skip_password_checks,omitempty"`
 	SignOutOfOtherSessions           *bool            `json:"sign_out_of_other_sessions,omitempty"`
 	ExternalID                       *string          `json:"external_id,omitempty"`
-	PublicMetadata                   *json.RawMessage `json:"public_metadata,omitempty"`
-	PrivateMetadata                  *json.RawMessage `json:"private_metadata,omitempty"`
-	UnsafeMetadata                   *json.RawMessage `json:"unsafe_metadata,omitempty"`
 	TOTPSecret                       *string          `json:"totp_secret,omitempty"`
 	BackupCodes                      *[]string        `json:"backup_codes,omitempty"`
 	DeleteSelfEnabled                *bool            `json:"delete_self_enabled,omitempty"`

--- a/user/client.go
+++ b/user/client.go
@@ -200,6 +200,30 @@ func (c *Client) UpdateMetadata(ctx context.Context, id string, params *UpdateMe
 	return resource, err
 }
 
+type ReplaceMetadataParams struct {
+	clerk.APIParams
+	PublicMetadata  *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
+	UnsafeMetadata  *json.RawMessage `json:"unsafe_metadata,omitempty"`
+}
+
+// ReplaceMetadata replaces the user's metadata. Each metadata
+// field included in the request overwrites the stored value
+// (rather than merging with it). Fields omitted from the request
+// are left untouched. To clear a column, pass an empty object
+// ({}) for that field.
+func (c *Client) ReplaceMetadata(ctx context.Context, id string, params *ReplaceMetadataParams) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, id, "/metadata")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPut, path)
+	req.SetParams(params)
+	resource := &clerk.User{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}
+
 // Delete deletes a user.
 func (c *Client) Delete(ctx context.Context, id string) (*clerk.DeletedResource, error) {
 	path, err := clerk.JoinPath(path, id)

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -352,6 +352,29 @@ func TestUserClientUpdateMetadata(t *testing.T) {
 	require.JSONEq(t, string(metadata), string(user.PrivateMetadata))
 }
 
+func TestUserClientReplaceMetadata(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	metadata := json.RawMessage(`{"foo":"bar"}`)
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"private_metadata":%s}`, string(metadata))),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","private_metadata":%s}`, id, string(metadata))),
+			Method: http.MethodPut,
+			Path:   "/v1/users/" + id + "/metadata",
+		},
+	}
+	client := NewClient(config)
+	user, err := client.ReplaceMetadata(context.Background(), id, &ReplaceMetadataParams{
+		PrivateMetadata: &metadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, user.ID)
+	require.JSONEq(t, string(metadata), string(user.PrivateMetadata))
+}
+
 func TestUserClientListOAuthAccessTokens(t *testing.T) {
 	t.Parallel()
 	id := "user_123"


### PR DESCRIPTION
This PR introduces a breaking change to the `user.Update` and `organization.Update` method removing metadata fields to align with the latest API contract.

- [x] update api version