### PR TITLE
deprecate metadata fields in user and organization update method

### DIFF
--- a/clerk.go
+++ b/clerk.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	sdkVersion      string = "v2.0.0"
-	clerkAPIVersion string = "2025-11-10"
+	clerkAPIVersion string = "2026-05-12"
 )
 
 const (

--- a/organization/api.go
+++ b/organization/api.go
@@ -26,6 +26,12 @@ func GetWithParams(ctx context.Context, idOrSlug string, params *GetParams) (*cl
 }
 
 // Update updates an organization.
+//
+// If any of the deprecated metadata fields on UpdateParams is set, the
+// SDK splits the call: non-metadata fields are sent via PATCH /organizations/{id}
+// and the metadata fields are then sent via PUT /organizations/{id}/metadata (the dedicated metadata endpoint).
+// When only metadata fields are set, the PATCH call is skipped. The returned organization
+// reflects the response of the final call made.
 func Update(ctx context.Context, id string, params *UpdateParams) (*clerk.Organization, error) {
 	return getClient().Update(ctx, id, params)
 }
@@ -34,6 +40,14 @@ func Update(ctx context.Context, id string, params *UpdateParams) (*clerk.Organi
 // provided values with the existing ones.
 func UpdateMetadata(ctx context.Context, id string, params *UpdateMetadataParams) (*clerk.Organization, error) {
 	return getClient().UpdateMetadata(ctx, id, params)
+}
+
+// ReplaceMetadata replaces the organization's metadata. Each metadata
+// field included in the request overwrites the stored value (rather than
+// merging with it). Fields omitted from the request are left untouched.
+// To clear a column, pass an empty object ({}) for that field.
+func ReplaceMetadata(ctx context.Context, id string, params *ReplaceMetadataParams) (*clerk.Organization, error) {
+	return getClient().ReplaceMetadata(ctx, id, params)
 }
 
 // Delete deletes an organization.

--- a/organization/client.go
+++ b/organization/client.go
@@ -91,14 +91,50 @@ type UpdateParams struct {
 	MaxAllowedMemberships *int64  `json:"max_allowed_memberships,omitempty"`
 	// RoleSetKey is a preview field and is not available yet for all customers.
 	// The use of this field will cause an error to be returned.
-	RoleSetKey         *string          `json:"role_set_key,omitempty"`
-	PublicMetadata     *json.RawMessage `json:"public_metadata,omitempty"`
+	RoleSetKey *string `json:"role_set_key,omitempty"`
+	// Deprecated: Use ReplaceMetadata (replace) or UpdateMetadata (merge) instead.
+	// When set on UpdateParams, the SDK routes this field through PUT /organizations/{id}/metadata.
+	PublicMetadata *json.RawMessage `json:"public_metadata,omitempty"`
+	// Deprecated: Use ReplaceMetadata (replace) or UpdateMetadata (merge) instead.
+	// When set on UpdateParams, the SDK routes this field through PUT /organizations/{id}/metadata.
 	PrivateMetadata    *json.RawMessage `json:"private_metadata,omitempty"`
 	AdminDeleteEnabled *bool            `json:"admin_delete_enabled,omitempty"`
 }
 
 // Update updates an organization.
+//
+// If any of the deprecated metadata fields on UpdateParams is set, the
+// SDK splits the call: non-metadata fields are sent via PATCH /organizations/{id}
+// and the metadata fields are then sent via PUT /organizations/{id}/metadata (the dedicated metadata endpoint).
+// When only metadata fields are set, the PATCH call is skipped. The returned organization
+// reflects the response of the final call made.
 func (c *Client) Update(ctx context.Context, id string, params *UpdateParams) (*clerk.Organization, error) {
+	hasMetadata := params != nil && (params.PublicMetadata != nil || params.PrivateMetadata != nil)
+
+	if !hasMetadata {
+		return c.updateOrganization(ctx, id, params)
+	}
+
+	metadataParams := &ReplaceMetadataParams{
+		APIParams:       params.APIParams,
+		PublicMetadata:  params.PublicMetadata,
+		PrivateMetadata: params.PrivateMetadata,
+	}
+
+	stripped := *params
+	stripped.PublicMetadata = nil
+	stripped.PrivateMetadata = nil
+
+	if hasNonMetadataUpdateFields(&stripped) {
+		if _, err := c.updateOrganization(ctx, id, &stripped); err != nil {
+			return nil, err
+		}
+	}
+
+	return c.ReplaceMetadata(ctx, id, metadataParams)
+}
+
+func (c *Client) updateOrganization(ctx context.Context, id string, params *UpdateParams) (*clerk.Organization, error) {
 	path, err := clerk.JoinPath(path, id)
 	if err != nil {
 		return nil, err
@@ -108,6 +144,14 @@ func (c *Client) Update(ctx context.Context, id string, params *UpdateParams) (*
 	organization := &clerk.Organization{}
 	err = c.Backend.Call(ctx, req, organization)
 	return organization, err
+}
+
+func hasNonMetadataUpdateFields(p *UpdateParams) bool {
+	return p.Name != nil ||
+		p.Slug != nil ||
+		p.MaxAllowedMemberships != nil ||
+		p.RoleSetKey != nil ||
+		p.AdminDeleteEnabled != nil
 }
 
 type UpdateMetadataParams struct {
@@ -124,6 +168,27 @@ func (c *Client) UpdateMetadata(ctx context.Context, id string, params *UpdateMe
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodPatch, path)
+	req.SetParams(params)
+	organization := &clerk.Organization{}
+	err = c.Backend.Call(ctx, req, organization)
+	return organization, err
+}
+
+type ReplaceMetadataParams struct {
+	clerk.APIParams
+	PublicMetadata  *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
+}
+
+// ReplaceMetadata replaces the organization's metadata. Each metadata
+// field included in the request overwrites the stored value (rather than
+// merging with it).
+func (c *Client) ReplaceMetadata(ctx context.Context, id string, params *ReplaceMetadataParams) (*clerk.Organization, error) {
+	path, err := clerk.JoinPath(path, id, "/metadata")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPut, path)
 	req.SetParams(params)
 	organization := &clerk.Organization{}
 	err = c.Backend.Call(ctx, req, organization)

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -317,4 +319,135 @@ func TestOrganizationClientUpdateMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, organization.ID)
 	require.JSONEq(t, metadata, string(organization.PrivateMetadata))
+}
+
+func TestOrganizationClientReplaceMetadata(t *testing.T) {
+	t.Parallel()
+	id := "org_123"
+	metadata := `{"foo":"bar"}`
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"private_metadata":%s}`, metadata)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","private_metadata":%s}`, id, metadata)),
+			Method: http.MethodPut,
+			Path:   "/v1/organizations/" + id + "/metadata",
+		},
+	}
+	client := NewClient(config)
+	metadataParam := json.RawMessage(metadata)
+	organization, err := client.ReplaceMetadata(context.Background(), id, &ReplaceMetadataParams{
+		PrivateMetadata: &metadataParam,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, organization.ID)
+	require.JSONEq(t, metadata, string(organization.PrivateMetadata))
+}
+
+type recordedRequest struct {
+	method string
+	path   string
+	body   string
+}
+
+func newUpdateRoutingServer(t *testing.T, recorded *[]recordedRequest, patchStatus int, putStatus int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		*recorded = append(*recorded, recordedRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			body:   string(buf),
+		})
+		switch r.Method {
+		case http.MethodPut:
+			w.WriteHeader(putStatus)
+		case http.MethodPatch:
+			w.WriteHeader(patchStatus)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+		_, err = w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+}
+
+func TestOrganizationClientUpdate_OnlyMetadataRoutesToPut(t *testing.T) {
+	t.Parallel()
+	id := "org_123"
+	metadata := json.RawMessage(`{"foo":"bar"}`)
+	var recorded []recordedRequest
+	ts := newUpdateRoutingServer(t, &recorded, http.StatusOK, http.StatusOK,
+		fmt.Sprintf(`{"id":"%s","public_metadata":%s}`, id, string(metadata)))
+	defer ts.Close()
+
+	config := &clerk.ClientConfig{}
+	config.URL = clerk.String(ts.URL)
+	config.HTTPClient = ts.Client()
+	client := NewClient(config)
+	organization, err := client.Update(context.Background(), id, &UpdateParams{
+		PublicMetadata: &metadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, organization.ID)
+	require.Len(t, recorded, 1)
+	require.Equal(t, http.MethodPut, recorded[0].method)
+	require.Equal(t, "/organizations/"+id+"/metadata", recorded[0].path)
+	require.JSONEq(t, fmt.Sprintf(`{"public_metadata":%s}`, string(metadata)), recorded[0].body)
+}
+
+func TestOrganizationClientUpdate_MetadataAndNonMetadataIssuesBothCalls(t *testing.T) {
+	t.Parallel()
+	id := "org_123"
+	name := "Acme Inc"
+	metadata := json.RawMessage(`{"foo":"bar"}`)
+	var recorded []recordedRequest
+	ts := newUpdateRoutingServer(t, &recorded, http.StatusOK, http.StatusOK,
+		fmt.Sprintf(`{"id":"%s","name":"%s","public_metadata":%s}`, id, name, string(metadata)))
+	defer ts.Close()
+
+	config := &clerk.ClientConfig{}
+	config.URL = clerk.String(ts.URL)
+	config.HTTPClient = ts.Client()
+	client := NewClient(config)
+	organization, err := client.Update(context.Background(), id, &UpdateParams{
+		Name:           clerk.String(name),
+		PublicMetadata: &metadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, organization.ID)
+	require.Len(t, recorded, 2)
+
+	require.Equal(t, http.MethodPatch, recorded[0].method)
+	require.Equal(t, "/organizations/"+id, recorded[0].path)
+	require.JSONEq(t, fmt.Sprintf(`{"name":"%s"}`, name), recorded[0].body)
+
+	require.Equal(t, http.MethodPut, recorded[1].method)
+	require.Equal(t, "/organizations/"+id+"/metadata", recorded[1].path)
+	require.JSONEq(t, fmt.Sprintf(`{"public_metadata":%s}`, string(metadata)), recorded[1].body)
+}
+
+func TestOrganizationClientUpdate_MetadataPatchErrorAbortsPut(t *testing.T) {
+	t.Parallel()
+	id := "org_123"
+	name := "Acme Inc"
+	metadata := json.RawMessage(`{"foo":"bar"}`)
+	var recorded []recordedRequest
+	ts := newUpdateRoutingServer(t, &recorded, http.StatusBadRequest, http.StatusOK,
+		`{"errors":[{"code":"bad_request"}]}`)
+	defer ts.Close()
+
+	config := &clerk.ClientConfig{}
+	config.URL = clerk.String(ts.URL)
+	config.HTTPClient = ts.Client()
+	client := NewClient(config)
+	_, err := client.Update(context.Background(), id, &UpdateParams{
+		Name:           clerk.String(name),
+		PublicMetadata: &metadata,
+	})
+	require.Error(t, err)
+	require.Len(t, recorded, 1)
+	require.Equal(t, http.MethodPatch, recorded[0].method)
 }

--- a/user/api.go
+++ b/user/api.go
@@ -19,6 +19,13 @@ func Get(ctx context.Context, id string) (*clerk.User, error) {
 }
 
 // Update updates a user.
+//
+// If any of the deprecated metadata fields on UpdateParams is set, the
+// SDK splits the call: non-metadata fields are sent via PATCH /users/{id}
+// (the historical behavior), and the metadata fields are then sent via
+// PUT /users/{id}/metadata (the dedicated metadata endpoint). When only
+// metadata fields are set, the PATCH call is skipped. The returned user
+// reflects the response of the final call made.
 func Update(ctx context.Context, id string, params *UpdateParams) (*clerk.User, error) {
 	return getClient().Update(ctx, id, params)
 }
@@ -37,6 +44,15 @@ func DeleteProfileImage(ctx context.Context, id string) (*clerk.User, error) {
 // provided values with the existing ones.
 func UpdateMetadata(ctx context.Context, id string, params *UpdateMetadataParams) (*clerk.User, error) {
 	return getClient().UpdateMetadata(ctx, id, params)
+}
+
+// ReplaceMetadata replaces the user's metadata. Each metadata
+// field included in the request overwrites the stored value
+// (rather than merging with it). Fields omitted from the request
+// are left untouched. To clear a column, pass an empty object
+// ({}) for that field.
+func ReplaceMetadata(ctx context.Context, id string, params *ReplaceMetadataParams) (*clerk.User, error) {
+	return getClient().ReplaceMetadata(ctx, id, params)
 }
 
 // Delete deletes a user.

--- a/user/client.go
+++ b/user/client.go
@@ -84,29 +84,35 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.User, error) {
 
 type UpdateParams struct {
 	clerk.APIParams
-	FirstName                        *string          `json:"first_name,omitempty"`
-	LastName                         *string          `json:"last_name,omitempty"`
-	PrimaryEmailAddressID            *string          `json:"primary_email_address_id,omitempty"`
-	NotifyPrimaryEmailAddressChanged *bool            `json:"notify_primary_email_address_changed,omitempty"`
-	PrimaryPhoneNumberID             *string          `json:"primary_phone_number_id,omitempty"`
-	PrimaryWeb3WalletID              *string          `json:"primary_web3_wallet_id,omitempty"`
-	Username                         *string          `json:"username,omitempty"`
-	ProfileImageID                   *string          `json:"profile_image_id,omitempty"`
-	ProfileImage                     *string          `json:"profile_image,omitempty"`
-	Password                         *string          `json:"password,omitempty"`
-	PasswordDigest                   *string          `json:"password_digest,omitempty"`
-	PasswordHasher                   *string          `json:"password_hasher,omitempty"`
-	SkipPasswordChecks               *bool            `json:"skip_password_checks,omitempty"`
-	SignOutOfOtherSessions           *bool            `json:"sign_out_of_other_sessions,omitempty"`
-	ExternalID                       *string          `json:"external_id,omitempty"`
-	PublicMetadata                   *json.RawMessage `json:"public_metadata,omitempty"`
-	PrivateMetadata                  *json.RawMessage `json:"private_metadata,omitempty"`
-	UnsafeMetadata                   *json.RawMessage `json:"unsafe_metadata,omitempty"`
-	TOTPSecret                       *string          `json:"totp_secret,omitempty"`
-	BackupCodes                      *[]string        `json:"backup_codes,omitempty"`
-	DeleteSelfEnabled                *bool            `json:"delete_self_enabled,omitempty"`
-	CreateOrganizationEnabled        *bool            `json:"create_organization_enabled,omitempty"`
-	CreateOrganizationsLimit         *int             `json:"create_organizations_limit,omitempty"`
+	FirstName                        *string `json:"first_name,omitempty"`
+	LastName                         *string `json:"last_name,omitempty"`
+	PrimaryEmailAddressID            *string `json:"primary_email_address_id,omitempty"`
+	NotifyPrimaryEmailAddressChanged *bool   `json:"notify_primary_email_address_changed,omitempty"`
+	PrimaryPhoneNumberID             *string `json:"primary_phone_number_id,omitempty"`
+	PrimaryWeb3WalletID              *string `json:"primary_web3_wallet_id,omitempty"`
+	Username                         *string `json:"username,omitempty"`
+	ProfileImageID                   *string `json:"profile_image_id,omitempty"`
+	ProfileImage                     *string `json:"profile_image,omitempty"`
+	Password                         *string `json:"password,omitempty"`
+	PasswordDigest                   *string `json:"password_digest,omitempty"`
+	PasswordHasher                   *string `json:"password_hasher,omitempty"`
+	SkipPasswordChecks               *bool   `json:"skip_password_checks,omitempty"`
+	SignOutOfOtherSessions           *bool   `json:"sign_out_of_other_sessions,omitempty"`
+	ExternalID                       *string `json:"external_id,omitempty"`
+	// Deprecated: Use ReplaceMetadata (replace) or UpdateMetadata (merge) instead.
+	// When set on UpdateParams, the SDK routes this field through PUT /users/{id}/metadata.
+	PublicMetadata *json.RawMessage `json:"public_metadata,omitempty"`
+	// Deprecated: Use ReplaceMetadata (replace) or UpdateMetadata (merge) instead.
+	// When set on UpdateParams, the SDK routes this field through PUT /users/{id}/metadata.
+	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
+	// Deprecated: Use ReplaceMetadata (replace) or UpdateMetadata (merge) instead.
+	// When set on UpdateParams, the SDK routes this field through PUT /users/{id}/metadata.
+	UnsafeMetadata            *json.RawMessage `json:"unsafe_metadata,omitempty"`
+	TOTPSecret                *string          `json:"totp_secret,omitempty"`
+	BackupCodes               *[]string        `json:"backup_codes,omitempty"`
+	DeleteSelfEnabled         *bool            `json:"delete_self_enabled,omitempty"`
+	CreateOrganizationEnabled *bool            `json:"create_organization_enabled,omitempty"`
+	CreateOrganizationsLimit  *int             `json:"create_organizations_limit,omitempty"`
 	// Specified in RFC3339 format
 	LegalAcceptedAt *string `json:"legal_accepted_at,omitempty"`
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`
@@ -117,7 +123,41 @@ type UpdateParams struct {
 }
 
 // Update updates a user.
+//
+// If any of the deprecated metadata fields on UpdateParams is set, the
+// SDK splits the call: non-metadata fields are sent via PATCH /users/{id}
+// and the metadata fields are then sent via PUT /users/{id}/metadata (the dedicated metadata endpoint).
+// When only metadata fields are set, the PATCH call is skipped. The returned user
+// reflects the response of the final call made.
 func (c *Client) Update(ctx context.Context, id string, params *UpdateParams) (*clerk.User, error) {
+	hasMetadata := params != nil && (params.PublicMetadata != nil || params.PrivateMetadata != nil || params.UnsafeMetadata != nil)
+
+	if !hasMetadata {
+		return c.updateUser(ctx, id, params)
+	}
+
+	metadataParams := &ReplaceMetadataParams{
+		APIParams:       params.APIParams,
+		PublicMetadata:  params.PublicMetadata,
+		PrivateMetadata: params.PrivateMetadata,
+		UnsafeMetadata:  params.UnsafeMetadata,
+	}
+
+	stripped := *params
+	stripped.PublicMetadata = nil
+	stripped.PrivateMetadata = nil
+	stripped.UnsafeMetadata = nil
+
+	if hasNonMetadataUpdateFields(&stripped) {
+		if _, err := c.updateUser(ctx, id, &stripped); err != nil {
+			return nil, err
+		}
+	}
+
+	return c.ReplaceMetadata(ctx, id, metadataParams)
+}
+
+func (c *Client) updateUser(ctx context.Context, id string, params *UpdateParams) (*clerk.User, error) {
 	path, err := clerk.JoinPath(path, id)
 	if err != nil {
 		return nil, err
@@ -127,6 +167,33 @@ func (c *Client) Update(ctx context.Context, id string, params *UpdateParams) (*
 	resource := &clerk.User{}
 	err = c.Backend.Call(ctx, req, resource)
 	return resource, err
+}
+
+func hasNonMetadataUpdateFields(p *UpdateParams) bool {
+	return p.FirstName != nil ||
+		p.LastName != nil ||
+		p.PrimaryEmailAddressID != nil ||
+		p.NotifyPrimaryEmailAddressChanged != nil ||
+		p.PrimaryPhoneNumberID != nil ||
+		p.PrimaryWeb3WalletID != nil ||
+		p.Username != nil ||
+		p.ProfileImageID != nil ||
+		p.ProfileImage != nil ||
+		p.Password != nil ||
+		p.PasswordDigest != nil ||
+		p.PasswordHasher != nil ||
+		p.SkipPasswordChecks != nil ||
+		p.SignOutOfOtherSessions != nil ||
+		p.ExternalID != nil ||
+		p.TOTPSecret != nil ||
+		p.BackupCodes != nil ||
+		p.DeleteSelfEnabled != nil ||
+		p.CreateOrganizationEnabled != nil ||
+		p.CreateOrganizationsLimit != nil ||
+		p.LegalAcceptedAt != nil ||
+		p.SkipLegalChecks != nil ||
+		p.CreatedAt != nil ||
+		p.Locale != nil
 }
 
 type UpdateProfileImageParams struct {
@@ -195,6 +262,30 @@ func (c *Client) UpdateMetadata(ctx context.Context, id string, params *UpdateMe
 		return nil, err
 	}
 	req := clerk.NewAPIRequest(http.MethodPatch, path)
+	req.SetParams(params)
+	resource := &clerk.User{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}
+
+type ReplaceMetadataParams struct {
+	clerk.APIParams
+	PublicMetadata  *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata *json.RawMessage `json:"private_metadata,omitempty"`
+	UnsafeMetadata  *json.RawMessage `json:"unsafe_metadata,omitempty"`
+}
+
+// ReplaceMetadata replaces the user's metadata. Each metadata
+// field included in the request overwrites the stored value
+// (rather than merging with it). Fields omitted from the request
+// are left untouched. To clear metadata, pass an empty object
+// ({}) for that field.
+func (c *Client) ReplaceMetadata(ctx context.Context, id string, params *ReplaceMetadataParams) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, id, "/metadata")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPut, path)
 	req.SetParams(params)
 	resource := &clerk.User{}
 	err = c.Backend.Call(ctx, req, resource)

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -319,6 +320,136 @@ func TestUserClientUpdateMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, user.ID)
 	require.JSONEq(t, string(metadata), string(user.PrivateMetadata))
+}
+
+func TestUserClientReplaceMetadata(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	metadata := json.RawMessage(`{"foo":"bar"}`)
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"private_metadata":%s}`, string(metadata))),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","private_metadata":%s}`, id, string(metadata))),
+			Method: http.MethodPut,
+			Path:   "/v1/users/" + id + "/metadata",
+		},
+	}
+	client := NewClient(config)
+	user, err := client.ReplaceMetadata(context.Background(), id, &ReplaceMetadataParams{
+		PrivateMetadata: &metadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, user.ID)
+	require.JSONEq(t, string(metadata), string(user.PrivateMetadata))
+}
+
+type recordedRequest struct {
+	method string
+	path   string
+	body   string
+}
+
+func newUpdateRoutingServer(t *testing.T, recorded *[]recordedRequest, patchStatus int, putStatus int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		*recorded = append(*recorded, recordedRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			body:   string(buf),
+		})
+		switch r.Method {
+		case http.MethodPut:
+			w.WriteHeader(putStatus)
+		case http.MethodPatch:
+			w.WriteHeader(patchStatus)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+		_, err = w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+}
+
+func TestUserClientUpdate_OnlyMetadataRoutesToPut(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	metadata := json.RawMessage(`{"foo":"bar"}`)
+	var recorded []recordedRequest
+	ts := newUpdateRoutingServer(t, &recorded, http.StatusOK, http.StatusOK,
+		fmt.Sprintf(`{"id":"%s","public_metadata":%s}`, id, string(metadata)))
+	defer ts.Close()
+
+	config := &clerk.ClientConfig{}
+	config.URL = clerk.String(ts.URL)
+	config.HTTPClient = ts.Client()
+	client := NewClient(config)
+	user, err := client.Update(context.Background(), id, &UpdateParams{
+		PublicMetadata: &metadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, user.ID)
+	require.Len(t, recorded, 1)
+	require.Equal(t, http.MethodPut, recorded[0].method)
+	require.Equal(t, "/users/"+id+"/metadata", recorded[0].path)
+	require.JSONEq(t, fmt.Sprintf(`{"public_metadata":%s}`, string(metadata)), recorded[0].body)
+}
+
+func TestUserClientUpdate_MetadataAndNonMetadataIssuesBothCalls(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	username := "username"
+	metadata := json.RawMessage(`{"foo":"bar"}`)
+	var recorded []recordedRequest
+	ts := newUpdateRoutingServer(t, &recorded, http.StatusOK, http.StatusOK,
+		fmt.Sprintf(`{"id":"%s","username":"%s","public_metadata":%s}`, id, username, string(metadata)))
+	defer ts.Close()
+
+	config := &clerk.ClientConfig{}
+	config.URL = clerk.String(ts.URL)
+	config.HTTPClient = ts.Client()
+	client := NewClient(config)
+	user, err := client.Update(context.Background(), id, &UpdateParams{
+		Username:       clerk.String(username),
+		PublicMetadata: &metadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, user.ID)
+	require.Len(t, recorded, 2)
+
+	require.Equal(t, http.MethodPatch, recorded[0].method)
+	require.Equal(t, "/users/"+id, recorded[0].path)
+	require.JSONEq(t, fmt.Sprintf(`{"username":"%s"}`, username), recorded[0].body)
+
+	require.Equal(t, http.MethodPut, recorded[1].method)
+	require.Equal(t, "/users/"+id+"/metadata", recorded[1].path)
+	require.JSONEq(t, fmt.Sprintf(`{"public_metadata":%s}`, string(metadata)), recorded[1].body)
+}
+
+func TestUserClientUpdate_MetadataPatchErrorAbortsPut(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	username := "username"
+	metadata := json.RawMessage(`{"foo":"bar"}`)
+	var recorded []recordedRequest
+	ts := newUpdateRoutingServer(t, &recorded, http.StatusBadRequest, http.StatusOK,
+		`{"errors":[{"code":"bad_request"}]}`)
+	defer ts.Close()
+
+	config := &clerk.ClientConfig{}
+	config.URL = clerk.String(ts.URL)
+	config.HTTPClient = ts.Client()
+	client := NewClient(config)
+	_, err := client.Update(context.Background(), id, &UpdateParams{
+		Username:       clerk.String(username),
+		PublicMetadata: &metadata,
+	})
+	require.Error(t, err)
+	require.Len(t, recorded, 1)
+	require.Equal(t, http.MethodPatch, recorded[0].method)
 }
 
 func TestUserClientListOAuthAccessTokens(t *testing.T) {


### PR DESCRIPTION
This PR deprecates metadata fields on the user  and organization client `Update` method in favor of `ReplaceMetadata` or `UpdateMetadata`

- [x] update api version - 2026-05-12 is the official latest version