### PR TITLE
feat(organization): add SelfServeSSOEnabled preview field

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -4,25 +4,28 @@ import "encoding/json"
 
 type Organization struct {
 	APIResource
-	Object                               string          `json:"object"`
-	ID                                   string          `json:"id"`
-	Name                                 string          `json:"name"`
-	Slug                                 string          `json:"slug"`
-	ImageURL                             *string         `json:"image_url"`
-	HasImage                             bool            `json:"has_image"`
-	MembersCount                         *int64          `json:"members_count,omitempty"`
-	RoleSet                              *RoleSet        `json:"role_set,omitempty"`
-	MissingMemberWithElevatedPermissions *bool           `json:"missing_member_with_elevated_permissions,omitempty"`
-	PendingInvitationsCount              *int64          `json:"pending_invitations_count,omitempty"`
-	MaxAllowedMemberships                int64           `json:"max_allowed_memberships"`
-	MembershipLimitSetBy                 *string         `json:"membership_limit_set_by,omitempty"`
-	AdminDeleteEnabled                   bool            `json:"admin_delete_enabled"`
-	RoleSetKey                           *string         `json:"role_set_key,omitempty"`
-	PublicMetadata                       json.RawMessage `json:"public_metadata"`
-	PrivateMetadata                      json.RawMessage `json:"private_metadata"`
-	CreatedBy                            string          `json:"created_by"`
-	CreatedAt                            int64           `json:"created_at"`
-	UpdatedAt                            int64           `json:"updated_at"`
+	Object                               string   `json:"object"`
+	ID                                   string   `json:"id"`
+	Name                                 string   `json:"name"`
+	Slug                                 string   `json:"slug"`
+	ImageURL                             *string  `json:"image_url"`
+	HasImage                             bool     `json:"has_image"`
+	MembersCount                         *int64   `json:"members_count,omitempty"`
+	RoleSet                              *RoleSet `json:"role_set,omitempty"`
+	MissingMemberWithElevatedPermissions *bool    `json:"missing_member_with_elevated_permissions,omitempty"`
+	PendingInvitationsCount              *int64   `json:"pending_invitations_count,omitempty"`
+	MaxAllowedMemberships                int64    `json:"max_allowed_memberships"`
+	MembershipLimitSetBy                 *string  `json:"membership_limit_set_by,omitempty"`
+	AdminDeleteEnabled                   bool     `json:"admin_delete_enabled"`
+	RoleSetKey                           *string  `json:"role_set_key,omitempty"`
+	// SelfServeSSOEnabled is a preview field and is not available yet for all customers.
+	// It is only returned when the instance has self-serve SSO enabled.
+	SelfServeSSOEnabled *bool           `json:"self_serve_sso_enabled,omitempty"`
+	PublicMetadata      json.RawMessage `json:"public_metadata"`
+	PrivateMetadata     json.RawMessage `json:"private_metadata"`
+	CreatedBy           string          `json:"created_by"`
+	CreatedAt           int64           `json:"created_at"`
+	UpdatedAt           int64           `json:"updated_at"`
 }
 
 type OrganizationList struct {

--- a/organization/client.go
+++ b/organization/client.go
@@ -90,6 +90,11 @@ type UpdateParams struct {
 	// The use of this field will cause an error to be returned.
 	RoleSetKey           *string                     `json:"role_set_key,omitempty"`
 	ReassignmentMappings *clerk.ReassignmentMappings `json:"reassignment_mappings,omitempty"`
+	// SelfServeSSOEnabled toggles per-organization self-serve SSO. This is a preview
+	// field and is not available yet for all customers. The instance must have
+	// self-serve SSO enabled for the value to be honored; otherwise the request
+	// will fail.
+	SelfServeSSOEnabled *bool `json:"self_serve_sso_enabled,omitempty"`
 }
 
 // Update updates an organization.

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -160,6 +160,29 @@ func TestOrganizationClientUpdate(t *testing.T) {
 	require.Equal(t, name, organization.Name)
 }
 
+func TestOrganizationClientUpdateSelfServeSSO(t *testing.T) {
+	t.Parallel()
+	id := "org_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"self_serve_sso_enabled":true}`),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","self_serve_sso_enabled":true}`, id)),
+			Method: http.MethodPatch,
+			Path:   "/v1/organizations/" + id,
+		},
+	}
+	client := NewClient(config)
+	organization, err := client.Update(context.Background(), id, &UpdateParams{
+		SelfServeSSOEnabled: clerk.Bool(true),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, organization.ID)
+	require.NotNil(t, organization.SelfServeSSOEnabled)
+	require.True(t, *organization.SelfServeSSOEnabled)
+}
+
 func TestOrganizationClientUpdate_Error(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}


### PR DESCRIPTION
## Summary

Surfaces the new per-org self-serve SSO toggle landed in `clerk_go` BAPI (ORGS-1564 / ORGS-1565):

- `Organization.SelfServeSSOEnabled` (`*bool`, omitempty) — present in responses when the instance has self-serve SSO enabled.
- `organization.UpdateParams.SelfServeSSOEnabled` — optional `self_serve_sso_enabled` body field on `PATCH /v1/organizations/{id}`.

Marked as preview in doc comments — the BAPI field is `x-internal` in OpenAPI today and is gated server-side by `Instance.HasSelfServeSSO()`. Calling with the flag against a non-entitled instance returns a 4xx; gating mirrors the existing `RoleSetKey` / `ReassignmentMappings` preview pattern in this client.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./organization/...` (13 passed, including new `TestOrganizationClientUpdateSelfServeSSO`)