### PR TITLE
feat(organizationdomain): add VerifyOwnership method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add support for fetching an organization with its members count, via a new `organizations.GetWithParams` method.
 - Add support for session reverification with `SessionClaims.NeedsReverification()`, `SessionReverificationPolicy`, predefined policies like `SessionReverificationStrict`, and middleware via `http.NeedsSessionReverification()`.
 - Add support for OR-ing audit log list filters via `audit_logs.ListParams.FilterMatch`. Pass `clerk.AuditLogFilterMatchAny` to match events that satisfy any one of `Subject`, `Type`, `Actor`, `TraceID`, `ClientID`, or `ImpersonatorUserID`. Defaults to `clerk.AuditLogFilterMatchAll` (AND) when omitted, preserving existing behavior.
+- Add support for marking an organization domain's ownership as verified via the `organizationdomain.VerifyOwnership` method. The `OrganizationDomain` type now exposes `OwnershipVerification` and `AffiliationVerification`; the existing `Verification` field is deprecated in favor of `AffiliationVerification`.
 
 ## 2.2.0
 

--- a/organization_domain.go
+++ b/organization_domain.go
@@ -1,20 +1,33 @@
 package clerk
 
 type OrganizationDomainVerification struct {
-	Status   string `json:"status"`
-	Strategy string `json:"strategy"`
-	Attempts int64  `json:"attempts"`
-	ExpireAt *int64 `json:"expire_at"`
+	Status     string `json:"status"`
+	Strategy   string `json:"strategy"`
+	Attempts   int64  `json:"attempts"`
+	ExpireAt   *int64 `json:"expire_at"`
+	VerifiedAt *int64 `json:"verified_at"`
+}
+
+// OrganizationDomainOwnershipVerification describes how ownership of the
+// underlying DNS domain was proven (e.g. via a DNS TXT challenge). The TXT
+// record fields are populated only while a DNS challenge is pending.
+type OrganizationDomainOwnershipVerification struct {
+	OrganizationDomainVerification
+	TXTRecordName  *string `json:"txt_record_name"`
+	TXTRecordValue *string `json:"txt_record_value"`
 }
 
 type OrganizationDomain struct {
 	APIResource
-	Object                  string                          `json:"object"`
-	ID                      string                          `json:"id"`
-	OrganizationID          string                          `json:"organization_id"`
-	Name                    string                          `json:"name"`
-	EnrollmentMode          string                          `json:"enrollment_mode"`
-	AffiliationEmailAddress *string                         `json:"affiliation_email_address"`
+	Object                  string                                   `json:"object"`
+	ID                      string                                   `json:"id"`
+	OrganizationID          string                                   `json:"organization_id"`
+	Name                    string                                   `json:"name"`
+	EnrollmentMode          string                                   `json:"enrollment_mode"`
+	AffiliationEmailAddress *string                                  `json:"affiliation_email_address"`
+	AffiliationVerification *OrganizationDomainVerification          `json:"affiliation_verification"`
+	OwnershipVerification   *OrganizationDomainOwnershipVerification `json:"ownership_verification"`
+	// Deprecated: use AffiliationVerification instead.
 	Verification            *OrganizationDomainVerification `json:"verification"`
 	TotalPendingInvitations int64                           `json:"total_pending_invitations"`
 	TotalPendingSuggestions int64                           `json:"total_pending_suggestions"`

--- a/organizationdomain/api.go
+++ b/organizationdomain/api.go
@@ -33,6 +33,11 @@ func ListAllFromInstance(ctx context.Context, params *ListAllFromInstanceParams)
 	return getClient().ListAllFromInstance(ctx, params)
 }
 
+// VerifyOwnership marks the organization domain's ownership as verified.
+func VerifyOwnership(ctx context.Context, params *VerifyOwnershipParams) (*clerk.OrganizationDomain, error) {
+	return getClient().VerifyOwnership(ctx, params)
+}
+
 func getClient() *Client {
 	return &Client{
 		Backend: clerk.GetBackend(),

--- a/organizationdomain/client.go
+++ b/organizationdomain/client.go
@@ -175,3 +175,22 @@ func (c *Client) ListAllFromInstance(ctx context.Context, params *ListAllFromIns
 	err = c.Backend.Call(ctx, req, domains)
 	return domains, err
 }
+
+type VerifyOwnershipParams struct {
+	clerk.APIParams
+	OrganizationID string `json:"-"`
+	DomainID       string `json:"-"`
+}
+
+// VerifyOwnership marks the organization domain's ownership as verified.
+func (c *Client) VerifyOwnership(ctx context.Context, params *VerifyOwnershipParams) (*clerk.OrganizationDomain, error) {
+	path, err := clerk.JoinPath(path, params.OrganizationID, "/domains", params.DomainID, "/verify_ownership")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPost, path)
+	req.SetParams(params)
+	domain := &clerk.OrganizationDomain{}
+	err = c.Backend.Call(ctx, req, domain)
+	return domain, err
+}

--- a/organizationdomain/client_test.go
+++ b/organizationdomain/client_test.go
@@ -25,7 +25,7 @@ func TestOrganizationDomainClientCreate(t *testing.T) {
 		Transport: &clerktest.RoundTripper{
 			T:  t,
 			In: json.RawMessage(fmt.Sprintf(`{"name": "%s", "enrollment_mode": "automatic_invitation", "verified": %s}`, domain, strconv.FormatBool(verified))),
-			Out: json.RawMessage(fmt.Sprintf(`{"enrollment_mode":"automatic_invitation","id":"%s","name":"%s","object":"organization_domain","organization_id":"%s","verification":{"status":"unverified"}}`,
+			Out: json.RawMessage(fmt.Sprintf(`{"enrollment_mode":"automatic_invitation","id":"%s","name":"%s","object":"organization_domain","organization_id":"%s","affiliation_verification":{"status":"unverified"}}`,
 				id, domain, organizationID)),
 			Method: http.MethodPost,
 			Path:   "/v1/organizations/" + organizationID + "/domains",
@@ -41,7 +41,7 @@ func TestOrganizationDomainClientCreate(t *testing.T) {
 	require.Equal(t, id, response.ID)
 	require.Equal(t, domain, response.Name)
 	require.Equal(t, "automatic_invitation", response.EnrollmentMode)
-	require.Equal(t, "unverified", response.Verification.Status)
+	require.Equal(t, "unverified", response.AffiliationVerification.Status)
 }
 
 func TestOrganizationDomainClientCreate_Error(t *testing.T) {
@@ -79,7 +79,7 @@ func TestOrganizationDomainClientUpdate(t *testing.T) {
 		Transport: &clerktest.RoundTripper{
 			T:      t,
 			In:     json.RawMessage(fmt.Sprintf(`{"verified": %s}`, strconv.FormatBool(verified))),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","verification":{"status": "verified"}}`, id)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","affiliation_verification":{"status": "verified"}}`, id)),
 			Method: http.MethodPatch,
 			Path:   "/v1/organizations/" + organizationID + "/domains/" + id,
 		},
@@ -92,7 +92,7 @@ func TestOrganizationDomainClientUpdate(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, id, domain.ID)
-	require.Equal(t, "verified", domain.Verification.Status)
+	require.Equal(t, "verified", domain.AffiliationVerification.Status)
 }
 
 func TestOrganizationDomainClientUpdate_Error(t *testing.T) {
@@ -118,6 +118,57 @@ func TestOrganizationDomainClientUpdate_Error(t *testing.T) {
 	require.Equal(t, "update-trace-id", apiErr.TraceID)
 	require.Equal(t, 1, len(apiErr.Errors))
 	require.Equal(t, "update-error-code", apiErr.Errors[0].Code)
+}
+
+func TestOrganizationDomainClientVerifyOwnership(t *testing.T) {
+	t.Parallel()
+	id := "orgdm_123"
+	organizationID := "org_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"organization_domain","organization_id":"%s","affiliation_verification":null,"ownership_verification":{"status":"verified","strategy":"manual_override","attempts":0,"expire_at":null,"verified_at":1700000000000,"txt_record_name":null,"txt_record_value":null}}`, id, organizationID)),
+			Method: http.MethodPost,
+			Path:   "/v1/organizations/" + organizationID + "/domains/" + id + "/verify_ownership",
+		},
+	}
+	client := NewClient(config)
+	response, err := client.VerifyOwnership(context.Background(), &VerifyOwnershipParams{
+		OrganizationID: organizationID,
+		DomainID:       id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, response.ID)
+	require.NotNil(t, response.OwnershipVerification)
+	require.Equal(t, "verified", response.OwnershipVerification.Status)
+	require.Equal(t, "manual_override", response.OwnershipVerification.Strategy)
+	require.Nil(t, response.OwnershipVerification.TXTRecordName)
+}
+
+func TestOrganizationDomainClientVerifyOwnership_Error(t *testing.T) {
+	t.Parallel()
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Status: http.StatusNotFound,
+			Out: json.RawMessage(`{
+  "errors":[{
+		"code":"verify-ownership-error-code"
+	}],
+	"clerk_trace_id":"verify-ownership-trace-id"
+}`),
+		},
+	}
+	client := NewClient(config)
+	_, err := client.VerifyOwnership(context.Background(), &VerifyOwnershipParams{})
+	require.Error(t, err)
+	apiErr, ok := err.(*clerk.APIErrorResponse)
+	require.True(t, ok)
+	require.Equal(t, "verify-ownership-trace-id", apiErr.TraceID)
+	require.Equal(t, 1, len(apiErr.Errors))
+	require.Equal(t, "verify-ownership-error-code", apiErr.Errors[0].Code)
 }
 
 func TestOrganizationDomainClientDelete(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a client for the BAPI endpoint that marks an organization domain's ownership as verified:

`POST /organizations/{organization_id}/domains/{domain_id}/verify_ownership`

This flips a domain's ownership state to verified without going through the self-serve DNS TXT challenge. The endpoint takes no request body, only the path IDs, and returns the updated `organization_domain` object.

## Changes

- **`organizationdomain.VerifyOwnership`** — new `Client` method + package-level convenience function. `VerifyOwnershipParams` carries only the path IDs (`OrganizationID`, `DomainID`).
- **`OrganizationDomain` type** now mirrors the current response shape:
  - `OwnershipVerification` — new `OrganizationDomainOwnershipVerification` type that extends the base verification block with the DNS TXT record fields (`txt_record_name`, `txt_record_value`).
  - `AffiliationVerification` — the verification block establishing the org⇄domain affiliation.
  - `Verification` — kept for backwards compatibility, now **deprecated** in favor of `AffiliationVerification`.
  - Added `verified_at` to the base verification block.

## Test plan

- [x] `VerifyOwnership` happy path: POSTs to the correct path, surfaces `ownership_verification` (status + strategy + null TXT fields) on the response.
- [x] `VerifyOwnership` error path (404) returns an `APIErrorResponse`.
- [x] Existing org-domain tests migrated off the deprecated `Verification` field.
- [x] `gofmt`, `go vet`, `go test -race`, `staticcheck` all clean.