### PR TITLE
feat: Support new users param, new email and phone PUT

### DIFF
--- a/emailaddress/api.go
+++ b/emailaddress/api.go
@@ -23,6 +23,15 @@ func Update(ctx context.Context, id string, params *UpdateParams) (*clerk.EmailA
 	return getClient().Update(ctx, id, params)
 }
 
+// ReplaceForUser replaces all of the user's email addresses with a single
+// verified, primary email address. The new email address is created with the
+// admin verification strategy and any existing email addresses are deleted. If
+// an existing email address is linked to a connected account, the request is
+// rejected; remove the connected account first.
+func ReplaceForUser(ctx context.Context, params *ReplaceForUserParams) (*clerk.EmailAddress, error) {
+	return getClient().ReplaceForUser(ctx, params)
+}
+
 // Delete deletes an email address.
 func Delete(ctx context.Context, id string) (*clerk.DeletedResource, error) {
 	return getClient().Delete(ctx, id)

--- a/emailaddress/client.go
+++ b/emailaddress/client.go
@@ -71,6 +71,29 @@ func (c *Client) Update(ctx context.Context, id string, params *UpdateParams) (*
 	return emailAddress, err
 }
 
+type ReplaceForUserParams struct {
+	clerk.APIParams
+	UserID       string  `json:"-"`
+	EmailAddress *string `json:"email_address,omitempty"`
+}
+
+// ReplaceForUser replaces all of the user's email addresses with a single
+// verified, primary email address. The new email address is created with the
+// admin verification strategy and any existing email addresses are deleted. If
+// an existing email address is linked to a connected account, the request is
+// rejected; remove the connected account first.
+func (c *Client) ReplaceForUser(ctx context.Context, params *ReplaceForUserParams) (*clerk.EmailAddress, error) {
+	path, err := clerk.JoinPath("/users", params.UserID, "/email_address")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPut, path)
+	req.SetParams(params)
+	emailAddress := &clerk.EmailAddress{}
+	err = c.Backend.Call(ctx, req, emailAddress)
+	return emailAddress, err
+}
+
 // Delete deletes an email address.
 func (c *Client) Delete(ctx context.Context, id string) (*clerk.DeletedResource, error) {
 	path, err := clerk.JoinPath(path, id)

--- a/emailaddress/client_test.go
+++ b/emailaddress/client_test.go
@@ -110,6 +110,31 @@ func TestEmailAddressClientUpdate_Error(t *testing.T) {
 	require.Equal(t, "update-error-code", apiErr.Errors[0].Code)
 }
 
+func TestEmailAddressClientReplaceForUser(t *testing.T) {
+	t.Parallel()
+	email := "foo@bar.com"
+	userID := "user_123"
+	id := "idn_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"email_address":"%s"}`, email)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","email_address":"%s"}`, id, email)),
+			Method: http.MethodPut,
+			Path:   "/v1/users/" + userID + "/email_address",
+		},
+	}
+	client := NewClient(config)
+	emailAddress, err := client.ReplaceForUser(context.Background(), &ReplaceForUserParams{
+		UserID:       userID,
+		EmailAddress: clerk.String(email),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, emailAddress.ID)
+	require.Equal(t, email, emailAddress.EmailAddress)
+}
+
 func TestEmailAddressClientGet(t *testing.T) {
 	t.Parallel()
 	id := "idn_123"

--- a/phonenumber/api.go
+++ b/phonenumber/api.go
@@ -23,6 +23,15 @@ func Update(ctx context.Context, id string, params *UpdateParams) (*clerk.PhoneN
 	return getClient().Update(ctx, id, params)
 }
 
+// ReplaceForUser replaces all of the user's phone numbers with a single
+// verified, primary phone number. The new phone number is created with the
+// admin verification strategy and is not reserved for second factor. Any
+// existing phone numbers are deleted; replacing a phone number that is reserved
+// for second factor disables the user's MFA.
+func ReplaceForUser(ctx context.Context, params *ReplaceForUserParams) (*clerk.PhoneNumber, error) {
+	return getClient().ReplaceForUser(ctx, params)
+}
+
 // Delete deletes a phone number.
 func Delete(ctx context.Context, id string) (*clerk.DeletedResource, error) {
 	return getClient().Delete(ctx, id)

--- a/phonenumber/client.go
+++ b/phonenumber/client.go
@@ -72,6 +72,29 @@ func (c *Client) Update(ctx context.Context, id string, params *UpdateParams) (*
 	return resource, err
 }
 
+type ReplaceForUserParams struct {
+	clerk.APIParams
+	UserID      string  `json:"-"`
+	PhoneNumber *string `json:"phone_number,omitempty"`
+}
+
+// ReplaceForUser replaces all of the user's phone numbers with a single
+// verified, primary phone number. The new phone number is created with the
+// admin verification strategy and is not reserved for second factor. Any
+// existing phone numbers are deleted; replacing a phone number that is reserved
+// for second factor disables the user's MFA.
+func (c *Client) ReplaceForUser(ctx context.Context, params *ReplaceForUserParams) (*clerk.PhoneNumber, error) {
+	path, err := clerk.JoinPath("/users", params.UserID, "/phone_number")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPut, path)
+	req.SetParams(params)
+	resource := &clerk.PhoneNumber{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}
+
 // Delete deletes a phone number.
 func (c *Client) Delete(ctx context.Context, id string) (*clerk.DeletedResource, error) {
 	path, err := clerk.JoinPath(path, id)

--- a/phonenumber/client_test.go
+++ b/phonenumber/client_test.go
@@ -62,6 +62,31 @@ func TestPhoneNumberClientUpdate(t *testing.T) {
 	require.Equal(t, true, phoneNumber.ReservedForSecondFactor)
 }
 
+func TestPhoneNumberClientReplaceForUser(t *testing.T) {
+	t.Parallel()
+	phone := "+10123456789"
+	userID := "user_123"
+	id := "idn_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"phone_number":"%s"}`, phone)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","phone_number":"%s"}`, id, phone)),
+			Method: http.MethodPut,
+			Path:   "/v1/users/" + userID + "/phone_number",
+		},
+	}
+	client := NewClient(config)
+	phoneNumber, err := client.ReplaceForUser(context.Background(), &ReplaceForUserParams{
+		UserID:      userID,
+		PhoneNumber: clerk.String(phone),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, phoneNumber.ID)
+	require.Equal(t, phone, phoneNumber.PhoneNumber)
+}
+
 func TestPhoneNumberClientGet(t *testing.T) {
 	t.Parallel()
 	id := "idn_123"

--- a/user/client.go
+++ b/user/client.go
@@ -32,27 +32,34 @@ func NewClient(config *clerk.ClientConfig) *Client {
 
 type CreateParams struct {
 	clerk.APIParams
-	EmailAddresses            *[]string        `json:"email_address,omitempty"`
-	PhoneNumbers              *[]string        `json:"phone_number,omitempty"`
-	Web3Wallets               *[]string        `json:"web3_wallet,omitempty"`
-	Username                  *string          `json:"username,omitempty"`
-	Password                  *string          `json:"password,omitempty"`
-	FirstName                 *string          `json:"first_name,omitempty"`
-	LastName                  *string          `json:"last_name,omitempty"`
-	ExternalID                *string          `json:"external_id,omitempty"`
-	UnsafeMetadata            *json.RawMessage `json:"unsafe_metadata,omitempty"`
-	PublicMetadata            *json.RawMessage `json:"public_metadata,omitempty"`
-	PrivateMetadata           *json.RawMessage `json:"private_metadata,omitempty"`
-	PasswordDigest            *string          `json:"password_digest,omitempty"`
-	PasswordHasher            *string          `json:"password_hasher,omitempty"`
-	SkipPasswordRequirement   *bool            `json:"skip_password_requirement,omitempty"`
-	SkipPasswordChecks        *bool            `json:"skip_password_checks,omitempty"`
-	TOTPSecret                *string          `json:"totp_secret,omitempty"`
-	BackupCodes               *[]string        `json:"backup_codes,omitempty"`
-	DeleteSelfEnabled         *bool            `json:"delete_self_enabled,omitempty"`
-	BypassClientTrust         *bool            `json:"bypass_client_trust,omitempty"`
-	CreateOrganizationEnabled *bool            `json:"create_organization_enabled,omitempty"`
-	CreateOrganizationsLimit  *int             `json:"create_organizations_limit,omitempty"`
+	EmailAddresses          *[]string        `json:"email_address,omitempty"`
+	PhoneNumbers            *[]string        `json:"phone_number,omitempty"`
+	Web3Wallets             *[]string        `json:"web3_wallet,omitempty"`
+	Username                *string          `json:"username,omitempty"`
+	Password                *string          `json:"password,omitempty"`
+	FirstName               *string          `json:"first_name,omitempty"`
+	LastName                *string          `json:"last_name,omitempty"`
+	ExternalID              *string          `json:"external_id,omitempty"`
+	UnsafeMetadata          *json.RawMessage `json:"unsafe_metadata,omitempty"`
+	PublicMetadata          *json.RawMessage `json:"public_metadata,omitempty"`
+	PrivateMetadata         *json.RawMessage `json:"private_metadata,omitempty"`
+	PasswordDigest          *string          `json:"password_digest,omitempty"`
+	PasswordHasher          *string          `json:"password_hasher,omitempty"`
+	SkipPasswordRequirement *bool            `json:"skip_password_requirement,omitempty"`
+	SkipPasswordChecks      *bool            `json:"skip_password_checks,omitempty"`
+	TOTPSecret              *string          `json:"totp_secret,omitempty"`
+	BackupCodes             *[]string        `json:"backup_codes,omitempty"`
+	// Banned, when set to true, creates the user already banned, saving a
+	// follow-up call to the /ban endpoint. Requires the same plan support as
+	// the ban user endpoint.
+	Banned *bool `json:"banned,omitempty"`
+	// Locked, when set to true, creates the user already locked. Requires the
+	// user lockout feature to be enabled on the instance.
+	Locked                    *bool `json:"locked,omitempty"`
+	DeleteSelfEnabled         *bool `json:"delete_self_enabled,omitempty"`
+	BypassClientTrust         *bool `json:"bypass_client_trust,omitempty"`
+	CreateOrganizationEnabled *bool `json:"create_organization_enabled,omitempty"`
+	CreateOrganizationsLimit  *int  `json:"create_organizations_limit,omitempty"`
 	// Specified in RFC3339 format
 	LegalAcceptedAt *string `json:"legal_accepted_at,omitempty"`
 	SkipLegalChecks *bool   `json:"skip_legal_checks,omitempty"`


### PR DESCRIPTION
Support new email and phone `PUT` endpoints to replace all emails or phones on an account.

Also support `locked` and `banned` params when creating users. Since this is a tiny change I just included this in this PR.