### PR TITLE
fix(domain): include secondary flag in create params

### DIFF
--- a/domain/client.go
+++ b/domain/client.go
@@ -28,6 +28,7 @@ type CreateParams struct {
 	Name        *string `json:"name,omitempty"`
 	ProxyURL    *string `json:"proxy_url,omitempty"`
 	IsSatellite *bool   `json:"is_satellite,omitempty"`
+	IsSecondary *bool   `json:"is_secondary,omitempty"`
 }
 
 // Create creates a new domain.


### PR DESCRIPTION
## Summary

Adds `is_secondary` to `domain.CreateParams` in the v3 SDK.

## Why

`clerk_go`'s Dashboard domain-create pass-through needs to preserve the secondary-domain flag when creating the first custom domain after a provider domain. BAPI already accepts the field; this SDK change keeps the request shape intact.

## Validation

- `go test ./domain -count=1`
