### PR TITLE
feat: add disable_jit to enterprise + saml connection update params and responses

### DIFF
--- a/enterprise_connection.go
+++ b/enterprise_connection.go
@@ -20,6 +20,7 @@ type EnterpriseConnection struct {
 	ForceAuthn                       bool     `json:"force_authn"`
 	AllowOrganizationAccountLinking  bool     `json:"allow_organization_account_linking"`
 	Authenticatable                  bool     `json:"authenticatable"`
+	DisableJIT                       bool     `json:"disable_jit"`
 	CreatedAt                        int64    `json:"created_at"`
 	UpdatedAt                        int64    `json:"updated_at"`
 

--- a/enterpriseconnection/client.go
+++ b/enterpriseconnection/client.go
@@ -134,6 +134,7 @@ type UpdateParams struct {
 	DisableAdditionalIdentifications *bool             `json:"disable_additional_identifications,omitempty"`
 	AllowOrganizationAccountLinking  *bool             `json:"allow_organization_account_linking,omitempty"`
 	Authenticatable                  *bool             `json:"authenticatable,omitempty"`
+	DisableJIT                       *bool             `json:"disable_jit,omitempty"`
 	Saml                             *UpdateParamsSaml `json:"saml,omitempty"`
 	Oidc                             *UpdateParamsOidc `json:"oidc,omitempty"`
 }

--- a/enterpriseconnection/client_test.go
+++ b/enterpriseconnection/client_test.go
@@ -104,6 +104,31 @@ func TestEnterpriseConnectionClientUpdate(t *testing.T) {
 	require.Equal(t, name, conn.Name)
 }
 
+// TestEnterpriseConnectionClientUpdate_WithDisableJIT verifies the enterprise
+// connection update endpoint sends the top-level `disable_jit` flag and parses
+// it back from the response.
+func TestEnterpriseConnectionClientUpdate_WithDisableJIT(t *testing.T) {
+	t.Parallel()
+	id := "entconn_jit"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"disable_jit":true}`),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","object":"enterprise_connection","protocol":"saml","provider":"okta","active":true,"disable_jit":true}`, id)),
+			Method: http.MethodPatch,
+			Path:   "/v1/enterprise_connections/" + id,
+		},
+	}
+	client := NewClient(config)
+	conn, err := client.Update(context.Background(), id, &UpdateParams{
+		DisableJIT: clerk.Bool(true),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, conn.ID)
+	require.True(t, conn.DisableJIT)
+}
+
 // TestEnterpriseConnectionClientCreate_WithMultiValuedCustomAttributes verifies the
 // SAML enterprise connection create endpoint accepts custom attributes that carry
 // the `multi_valued` flag, covering both true and false values.

--- a/saml_connection.go
+++ b/saml_connection.go
@@ -38,6 +38,7 @@ type SAMLConnection struct {
 	AllowOrganizationAccountLinking  bool                           `json:"allow_organization_account_linking"`
 	CustomAttributes                 *[]CustomAttribute             `json:"custom_attributes,omitempty"`
 	Authenticatable                  bool                           `json:"authenticatable"`
+	DisableJIT                       bool                           `json:"disable_jit"`
 	CreatedAt                        int64                          `json:"created_at"`
 	UpdatedAt                        int64                          `json:"updated_at"`
 }

--- a/samlconnection/client.go
+++ b/samlconnection/client.go
@@ -121,6 +121,7 @@ type UpdateParams struct {
 	ForceAuthn                       *bool                   `json:"force_authn,omitempty"`
 	ConsentVerifiedDomainsDeletion   *bool                   `json:"consent_verified_domains_deletion,omitempty"`
 	Authenticatable                  *bool                   `json:"authenticatable,omitempty"`
+	DisableJIT                       *bool                   `json:"disable_jit,omitempty"`
 	// CustomAttributes is an Experimental feature, not available for all customers.
 	CustomAttributes *[]clerk.CustomAttribute `json:"custom_attributes,omitempty"`
 }

--- a/samlconnection/client_test.go
+++ b/samlconnection/client_test.go
@@ -219,6 +219,31 @@ func TestSAMLConnectionClientUpdate(t *testing.T) {
 	require.Equal(t, forceAuthn, samlConnection.ForceAuthn)
 }
 
+// TestSAMLConnectionClientUpdate_WithDisableJIT verifies the SAML connection
+// update endpoint sends the top-level `disable_jit` flag and parses it back
+// from the response.
+func TestSAMLConnectionClientUpdate_WithDisableJIT(t *testing.T) {
+	t.Parallel()
+	id := "samlc__jit"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"disable_jit":true}`),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","disable_jit":true}`, id)),
+			Method: http.MethodPatch,
+			Path:   "/v1/saml_connections/" + id,
+		},
+	}
+	client := NewClient(config)
+	samlConnection, err := client.Update(context.Background(), id, &UpdateParams{
+		DisableJIT: clerk.Bool(true),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, samlConnection.ID)
+	require.True(t, samlConnection.DisableJIT)
+}
+
 func TestSAMLConnectionClientUpdate_Error(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}


### PR DESCRIPTION
## What

Adds `disable_jit` support to the Enterprise Connections and (legacy) SAML Connections Backend API bindings.

When `disable_jit` is set on an enterprise connection, JIT (Just-In-Time) provisioning is disabled for SAML sign-in: users without an existing account receive `ExternalAccountNotFound` instead of being auto-provisioned. It is a self-serve, per-connection setting managed via the BAPI update endpoints.

## Changes

- `EnterpriseConnection.DisableJIT` and `SAMLConnection.DisableJIT` (`bool`) — read field on the response structs.
- `enterpriseconnection.UpdateParams.DisableJIT` and `samlconnection.UpdateParams.DisableJIT` (`*bool`, json `disable_jit,omitempty`) — top-level update param on both packages.
- Round-trip tests for both `Update` methods (request body contains `"disable_jit":true`; response deserializes into `DisableJIT == true`).

## Notes

- Targets `v3`.
- Not added to `CreateParams` — the BAPI only accepts `disable_jit` on update.

## Backend

Backend counterpart (column + BAPI + serializer): clerk/clerk_go#19496