### PR TITLE
ORGS-1645: add ExclusiveMembership preview field on organizations

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -20,7 +20,10 @@ type Organization struct {
 	RoleSetKey                           *string  `json:"role_set_key,omitempty"`
 	// SelfServeSSOEnabled is a preview field and is not available yet for all customers.
 	// It is only returned when the instance has self-serve SSO enabled.
-	SelfServeSSOEnabled *bool           `json:"self_serve_sso_enabled,omitempty"`
+	SelfServeSSOEnabled *bool `json:"self_serve_sso_enabled,omitempty"`
+	// ExclusiveMembership, when true, prevents members of this organization from
+	// belonging to any other organization in the instance.
+	ExclusiveMembership bool            `json:"exclusive_membership"`
 	PublicMetadata      json.RawMessage `json:"public_metadata"`
 	PrivateMetadata     json.RawMessage `json:"private_metadata"`
 	CreatedBy           string          `json:"created_by"`

--- a/organization.go
+++ b/organization.go
@@ -23,6 +23,9 @@ type Organization struct {
 	SelfServeSSOEnabled *bool `json:"self_serve_sso_enabled,omitempty"`
 	// ExclusiveMembership, when true, prevents members of this organization from
 	// belonging to any other organization in the instance.
+	//
+	// ExclusiveMembership is a preview field and is not available yet for all customers.
+	// It is only returned when the instance has exclusive membership enabled.
 	ExclusiveMembership bool            `json:"exclusive_membership"`
 	PublicMetadata      json.RawMessage `json:"public_metadata"`
 	PrivateMetadata     json.RawMessage `json:"private_metadata"`

--- a/organization/client.go
+++ b/organization/client.go
@@ -94,7 +94,9 @@ type UpdateParams struct {
 	// will fail.
 	SelfServeSSOEnabled *bool `json:"self_serve_sso_enabled,omitempty"`
 	// ExclusiveMembership, when true, prevents members of this organization from
-	// belonging to any other organization in the instance.
+	// belonging to any other organization in the instance. This is a preview field
+	// and is not available yet for all customers. The instance must have exclusive
+	// membership enabled for the value to be honored; otherwise the request will fail.
 	ExclusiveMembership *bool `json:"exclusive_membership,omitempty"`
 }
 

--- a/organization/client.go
+++ b/organization/client.go
@@ -93,6 +93,9 @@ type UpdateParams struct {
 	// self-serve SSO enabled for the value to be honored; otherwise the request
 	// will fail.
 	SelfServeSSOEnabled *bool `json:"self_serve_sso_enabled,omitempty"`
+	// ExclusiveMembership, when true, prevents members of this organization from
+	// belonging to any other organization in the instance.
+	ExclusiveMembership *bool `json:"exclusive_membership,omitempty"`
 }
 
 // Update updates an organization.

--- a/organization/client_test.go
+++ b/organization/client_test.go
@@ -183,6 +183,28 @@ func TestOrganizationClientUpdateSelfServeSSO(t *testing.T) {
 	require.True(t, *organization.SelfServeSSOEnabled)
 }
 
+func TestOrganizationClientUpdateExclusiveMembership(t *testing.T) {
+	t.Parallel()
+	id := "org_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(`{"exclusive_membership":true}`),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","exclusive_membership":true}`, id)),
+			Method: http.MethodPatch,
+			Path:   "/v1/organizations/" + id,
+		},
+	}
+	client := NewClient(config)
+	organization, err := client.Update(context.Background(), id, &UpdateParams{
+		ExclusiveMembership: clerk.Bool(true),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, organization.ID)
+	require.True(t, organization.ExclusiveMembership)
+}
+
 func TestOrganizationClientUpdate_Error(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}


### PR DESCRIPTION
Adds `ExclusiveMembership` to the Organization response struct and to organization.UpdateParams so callers can read and toggle the flag. Mirrors the SelfServeSSOEnabled pattern.