### PR TITLE
feat(backend): add OAuth application token revocation

### DIFF
--- a/oauthapplication/api.go
+++ b/oauthapplication/api.go
@@ -38,6 +38,11 @@ func RotateClientSecret(ctx context.Context, id string) (*clerk.OAuthApplication
 	return getClient().RotateClientSecret(ctx, id)
 }
 
+// RevokeToken revokes an OAuth application's access token or refresh token.
+func RevokeToken(ctx context.Context, id string, params *RevokeTokenParams) error {
+	return getClient().RevokeToken(ctx, id, params)
+}
+
 func getClient() *Client {
 	return &Client{
 		Backend: clerk.GetBackend(),

--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -133,3 +133,19 @@ func (c *Client) RotateClientSecret(ctx context.Context, id string) (*clerk.OAut
 	err = c.Backend.Call(ctx, req, authApplication)
 	return authApplication, err
 }
+
+type RevokeTokenParams struct {
+	clerk.APIParams
+	Token string `json:"token"`
+}
+
+// RevokeToken revokes an OAuth application's access token or refresh token.
+func (c *Client) RevokeToken(ctx context.Context, id string, params *RevokeTokenParams) error {
+	path, err := clerk.JoinPath(path, id, "revoke_token")
+	if err != nil {
+		return err
+	}
+	req := clerk.NewAPIRequest(http.MethodPost, path)
+	req.SetParams(params)
+	return c.Backend.Call(ctx, req, &clerk.APIResource{})
+}

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -234,3 +234,22 @@ func TestOAuthApplicationClientRotateClientSecret(t *testing.T) {
 	require.Equal(t, id, updatedApp.ID)
 	require.Equal(t, newSecret, *updatedApp.ClientSecret)
 }
+
+func TestOAuthApplicationClientRevokeToken(t *testing.T) {
+	t.Parallel()
+	id := "oauth_app_123"
+	token := "oat_123"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Status: http.StatusNoContent,
+			In:     json.RawMessage(fmt.Sprintf(`{"token":"%s"}`, token)),
+			Method: http.MethodPost,
+			Path:   "/v1/oauth_applications/" + id + "/revoke_token",
+		},
+	}
+	client := NewClient(config)
+	err := client.RevokeToken(context.Background(), id, &RevokeTokenParams{Token: token})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Adds SDK support for the new OAuth application [token revocation endpoint](https://clerk.com/docs/reference/backend-api/2025-11-10/tag/oauth-applications/POST/oauth_applications/%7Boauth_application_id%7D/revoke_token) and documents the backend SDK method.

Validation run:
- go test ./oauthapplication
- pnpm --filter @clerk/backend test:node src/api/__tests__/OAuthApplicationsApi.test.ts
- pnpm --filter @clerk/backend test:edge-runtime src/api/__tests__/OAuthApplicationsApi.test.ts
- pnpm --filter @clerk/backend lint
- pnpm run build:tsx in clerk-docs
- pnpm run lint in clerk-docs

## Changes in this repo

Adds oauthapplication.RevokeToken and Client.RevokeToken with RevokeTokenParams, plus a focused client test for the revoke_token endpoint.

<!-- clk:companion-prs -->
## Companion PRs

- **clerk-docs**: https://github.com/clerk/clerk-docs/pull/3484
- **javascript**: https://github.com/clerk/javascript/pull/9040
<!-- /clk:companion-prs -->
