### PR TITLE
fix(readme): make the README code samples compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ clerk.SetKey("sk_live_XXX")
 resource, err := $resource$.Create(ctx, &$resource$.CreateParams{})
 
 // Get
-resource, err := $resource$.Get(ctx, id)
+resource, err = $resource$.Get(ctx, id)
 
 // Update
-resource, err := $resource$.Update(ctx, id, &$resource$.UpdateParams{})
+resource, err = $resource$.Update(ctx, id, &$resource$.UpdateParams{})
 
 // Delete
-resource, err := $resource$.Delete(ctx, id)
+deletedResource, err := $resource$.Delete(ctx, id)
 
 // List
 list, err := $resource$.List(ctx, &$resource$.ListParams{})
@@ -109,20 +109,20 @@ ctx := context.Background()
 
 // Initialize a client with an API key
 config := &clerk.ClientConfig{}
-config.Key = "sk_live_XXX"
+config.Key = clerk.String("sk_live_XXX")
 client := $resource$.NewClient(config)
 
 // Create
 resource, err := client.Create(ctx, &$resource$.CreateParams{})
 
 // Get
-resource, err := client.Get(ctx, id)
+resource, err = client.Get(ctx, id)
 
 // Update
-resource, err := client.Update(ctx, id, &$resource$.UpdateParams{})
+resource, err = client.Update(ctx, id, &$resource$.UpdateParams{})
 
 // Delete
-resource, err := client.Delete(ctx, id)
+deletedResource, err := client.Delete(ctx, id)
 
 // List
 list, err := client.List(ctx, &$resource$.ListParams{})
@@ -135,6 +135,9 @@ Here's an example of how the above operations would look like for specific APIs.
 
 ```go
 import (
+    "context"
+    "fmt"
+
     "github.com/clerk/clerk-sdk-go/v2"
     "github.com/clerk/clerk-sdk-go/v2/organization"
     "github.com/clerk/clerk-sdk-go/v2/organizationmembership"
@@ -152,23 +155,42 @@ func main() {
     org, err := organization.Create(ctx, &organization.CreateParams{
         Name: clerk.String("Clerk Inc"),
     })
+    if err != nil {
+        // handle the error
+        panic(err)
+    }
 
     // Update the organization
     org, err = organization.Update(ctx, org.ID, &organization.UpdateParams{
         Slug: clerk.String("clerk"),
     })
+    if err != nil {
+        // handle the error
+        panic(err)
+    }
 
-    // List organization memberships
-    listParams := organizationmembership.ListParams{}
+    // List the organization's memberships
+    listParams := organizationmembership.ListParams{
+        OrganizationID: org.ID,
+    }
     listParams.Limit = clerk.Int64(10)
-    memberships, err := organizationmembership.List(ctx, params)
-    if memberships.TotalCount < 0 {
+    memberships, err := organizationmembership.List(ctx, &listParams)
+    if err != nil {
+        // handle the error
+        panic(err)
+    }
+    if memberships.TotalCount == 0 {
         return
     }
-    membership := memberships[0]
+    membership := memberships.OrganizationMemberships[0]
 
-    // Get a user
-    usr, err := user.Get(ctx, membership.UserID)
+    // Get more details about the membership's user
+    usr, err := user.Get(ctx, membership.PublicUserData.UserID)
+    if err != nil {
+        // handle the error
+        panic(err)
+    }
+    fmt.Println(usr.ID)
 }
 ```
 
@@ -183,8 +205,11 @@ documentation for available fields and methods.
 
 ```go
 dmn, err := domain.Create(context.Background(), &domain.CreateParams{})
+if err != nil {
+    // handle the error
+}
 if !dmn.Response.Success() {
-    dmn.Response.TraceID
+    fmt.Println(dmn.Response.TraceID)
 }
 ```
 
@@ -201,9 +226,9 @@ See the [APIErrorResponse](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2#A
 ```go
 _, err := user.List(context.Background(), &user.ListParams{})
 if apiErr, ok := err.(*clerk.APIErrorResponse); ok {
-    apiErr.TraceID
-    apiErr.Error()
-    apiErr.Response.RawJSON
+    fmt.Println(apiErr.TraceID)
+    fmt.Println(apiErr.Error())
+    fmt.Println(string(apiErr.Response.RawJSON))
 }
 ```
 
@@ -290,8 +315,9 @@ func TestWithCustomTransport(t *testing.T) {
 
 type mockRoundTripper struct {}
 // Implement the http.RoundTripper interface.
-func (r *mockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+func (m *mockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
     // Construct and return the http.Response.
+    return &http.Response{}, nil
 }
 ```
 
@@ -327,6 +353,7 @@ type customBackend struct {}
 func (b *customBackend) Call(ctx context.Context, r *clerk.APIRequest, reader clerk.ResponseReader) error {
     // Construct a clerk.APIResponse and use the reader's Read method.
     reader.Read(&clerk.APIResponse{})
+    return nil
 }
 ```
 
@@ -345,12 +372,15 @@ func TestWithCustomTransport(t *testing.T) {
         Transport: &mockRoundTripper{},
     }
     client := user.NewClient(config)
+    // Requests will be handled by the mock round tripper.
+    client.Get(context.Background(), "user_id")
 }
 
 type mockRoundTripper struct {}
 // Implement the http.RoundTripper interface.
-func (r *mockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+func (m *mockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
     // Construct and return the http.Response.
+    return &http.Response{}, nil
 }
 ```
 
@@ -369,6 +399,8 @@ func TestWithMockServer(t *testing.T) {
     config.HTTPClient = ts.Client()
     config.URL = &ts.URL
     client := user.NewClient(config)
+    // Requests will be handled by the test server.
+    client.Get(context.Background(), "user_id")
 }
 ```
 
@@ -384,9 +416,10 @@ func TestWithCustomBackend(t *testing.T) {
 
 type customBackend struct {}
 // Implement the Backend interface
-func (b *customBackend) Call(ctx context.Context, r *clerk.APIRequest, reader *clerk.ResponseReader) error {
+func (b *customBackend) Call(ctx context.Context, r *clerk.APIRequest, reader clerk.ResponseReader) error {
     // Construct a clerk.APIResponse and use the reader's Read method.
     reader.Read(&clerk.APIResponse{})
+    return nil
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ func main() {
 Each resource that is returned by an API operation has a `Response` field which
 contains information about the response that was sent from the Clerk Backend API.
 
-The `Response` contains fields like the the raw HTTP response's headers,
+The `Response` contains fields like the raw HTTP response's headers,
 the status and the raw response body. See the [APIResponse](https://pkg.go.dev/github.com/clerk/clerk-sdk-go/v2#APIResponse)
 documentation for available fields and methods.
 


### PR DESCRIPTION
### Summary

Follow-up to https://github.com/clerk/clerk/pull/2891, which fixed the same issues on the [Go quickstart docs page](https://clerk.com/docs/go/getting-started/quickstart) and flagged this README as having the same `config.Key = "sk_live_XXX"` bug. `clerk.ClientConfig` embeds `BackendConfig`, whose `Key` field is a `*string`, so the snippet didn't compile. Auditing the rest of the README's Go snippets turned up several more compile errors, fixed here as well.

### Changes

- **Usage with a client**: `config.Key = "sk_live_XXX"` → `config.Key = clerk.String("sk_live_XXX")` (`Key` is a `*string`).
- **Both `$resource$` usage templates**: repeated `resource, err := ...` redeclarations → `=` for Get/Update; Delete now uses `deletedResource, err :=` since `Delete` returns `*clerk.DeletedResource`, not the resource type.
- **Concrete organization/user example**: added missing `context` and `fmt` imports; `organizationmembership.List(ctx, params)` passed an undefined variable → `&listParams`; `ListParams.OrganizationID` is required (it builds the `/organizations/{id}/memberships` path) and is now set to `org.ID`; `memberships.TotalCount < 0` can never be true → `== 0`; `memberships[0]` indexed a struct → `memberships.OrganizationMemberships[0]`; `membership.UserID` doesn't exist → `membership.PublicUserData.UserID`; added error handling and a final `fmt.Println(usr.ID)` so `err` and `usr` are no longer declared-and-not-used.
- **Accessing API responses / Errors**: bare expression statements (`dmn.Response.TraceID`, `apiErr.TraceID`, `apiErr.Response.RawJSON`) are "evaluated but not used" compile errors → printed with `fmt.Println`.
- **Testing snippets**: `func (r *mockRoundTripper) RoundTrip(r *http.Request)` reused `r` for receiver and parameter (duplicate argument) → receiver renamed to `m`; stub bodies were missing `return` statements → minimal returns added; the last custom backend took `reader *clerk.ResponseReader` (pointer to interface, doesn't satisfy `clerk.Backend`) → `clerk.ResponseReader`; the two client-based tests declared `client` without using it → a `client.Get` call added.

The two `$resource$` usage blocks stay illustrative fragments by design — beyond the `$resource$` placeholder they hold top-level statements (`ctx := ...`, `clerk.SetKey(...)`) that aren't valid at Go file scope, so they don't compile standalone even with a real resource substituted. They teach the CRUD shape; the reader drops them into a function and uses the results (the `// do something with the resource` comment marks that). The complete, compile-clean runnable example immediately follows them. This PR removes their genuine compile bugs (the `:=` redeclarations and the wrong `Delete` return binding) without turning the concise shape illustrations into full programs.

### Verification

All 13 `go` fences were extracted from the edited README into a scaffold module (each snippet in its own package, fragments wrapped with the minimal `package`/`func` boilerplate a reader would supply, `$resource$` substituted with `user`) requiring `github.com/clerk/clerk-sdk-go/v2` at this branch's HEAD. `go build ./...` and `go vet ./...` both pass. As a negative control, the same harness against the unedited README produces 20 compile-error lines.

### References

- https://github.com/clerk/clerk/pull/2891 — the docs-page fix this follows up on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

