### PR TITLE
feat(audit_logs): add IPAddress filter to ListParams

### DIFF
--- a/audit_logs/client.go
+++ b/audit_logs/client.go
@@ -47,8 +47,12 @@ type ListParams struct {
 	ClientID *string `json:"client_id,omitempty"`
 	// Filter audit logs by impersonator user ID.
 	ImpersonatorUserID *string `json:"impersonator_user_id,omitempty"`
-	// FilterMatch controls how Subject, Type, Actor, TraceID, ClientID, and
-	// ImpersonatorUserID are combined when more than one is supplied.
+	// Filter audit logs by device IP address (exact match against
+	// device_info_ip_address).
+	IPAddress *string `json:"ip_address,omitempty"`
+	// FilterMatch controls how Subject, Type, Actor, TraceID, ClientID,
+	// ImpersonatorUserID, and IPAddress are combined when more than one
+	// is supplied.
 	//
 	//   - AuditLogFilterMatchAll (default, also when nil): every supplied
 	//     filter must match (AND).
@@ -97,6 +101,9 @@ func (params *ListParams) ToQuery() url.Values {
 	}
 	if params.ImpersonatorUserID != nil {
 		q.Add("impersonator_user_id", *params.ImpersonatorUserID)
+	}
+	if params.IPAddress != nil {
+		q.Add("ip_address", *params.IPAddress)
 	}
 	if params.FilterMatch != nil {
 		q.Add("filter_match", string(*params.FilterMatch))

--- a/audit_logs/client_test.go
+++ b/audit_logs/client_test.go
@@ -333,6 +333,18 @@ func filterMatchPtr(v clerk.AuditLogFilterMatch) *clerk.AuditLogFilterMatch {
 	return &v
 }
 
+// TestListParams_ToQuery_IPAddress locks the wire name for the IP filter
+// so the SDK stays in sync with the ip_address query parameter accepted by
+// the audit_logs list endpoint.
+func TestListParams_ToQuery_IPAddress(t *testing.T) {
+	t.Parallel()
+
+	params := &ListParams{IPAddress: clerk.String("203.0.113.10")}
+	require.Equal(t, []string{"203.0.113.10"}, params.ToQuery()["ip_address"])
+
+	require.Empty(t, (&ListParams{}).ToQuery()["ip_address"], "nil IPAddress should be omitted")
+}
+
 func TestList_RetentionLimitReached(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Adds `IPAddress *string \`json:"ip_address,omitempty"\`` to `audit_logs.ListParams` and its `ToQuery` mapping so SDK callers can filter audit logs by device IP.
- Locks the wire name via a new `TestListParams_ToQuery_IPAddress`.

Paired with the clerk_go side that adds the `ip_address` query param on `GET /v1/audit_logs` (bapi) and `GET /v1/instances/{instanceID}/application_logs` (dapi).

## Test plan
- [x] `go test ./audit_logs/...`