### PR TITLE
feat(scimdirectory): add credentials method for pull-provider directories

### DIFF
--- a/scimdirectory/api.go
+++ b/scimdirectory/api.go
@@ -39,11 +39,11 @@ func RotateAPIKey(ctx context.Context, id string) (*clerk.SCIMDirectory, error) 
 	return getClient().RotateAPIKey(ctx, id)
 }
 
-// Credentials uploads pull-provider credentials (e.g. a Google service-account
+// AddCredentials adds pull-provider credentials (e.g. a Google service-account
 // key and subject email) for a SCIM directory. They are validated and sealed
 // server-side; on success the directory is enabled.
-func Credentials(ctx context.Context, id string, params *CredentialsParams) (*clerk.SCIMDirectory, error) {
-	return getClient().Credentials(ctx, id, params)
+func AddCredentials(ctx context.Context, id string, params *CredentialsParams) (*clerk.SCIMDirectory, error) {
+	return getClient().AddCredentials(ctx, id, params)
 }
 
 func getClient() *Client {

--- a/scimdirectory/api.go
+++ b/scimdirectory/api.go
@@ -39,6 +39,13 @@ func RotateAPIKey(ctx context.Context, id string) (*clerk.SCIMDirectory, error) 
 	return getClient().RotateAPIKey(ctx, id)
 }
 
+// Credentials uploads pull-provider credentials (e.g. a Google service-account
+// key and subject email) for a SCIM directory. They are validated and sealed
+// server-side; on success the directory is enabled.
+func Credentials(ctx context.Context, id string, params *CredentialsParams) (*clerk.SCIMDirectory, error) {
+	return getClient().Credentials(ctx, id, params)
+}
+
 func getClient() *Client {
 	return &Client{
 		Backend: clerk.GetBackend(),

--- a/scimdirectory/client.go
+++ b/scimdirectory/client.go
@@ -130,3 +130,24 @@ func (c *Client) RotateAPIKey(ctx context.Context, id string) (*clerk.SCIMDirect
 	err = c.Backend.Call(ctx, req, resource)
 	return resource, err
 }
+
+type CredentialsParams struct {
+	clerk.APIParams
+	ServiceAccountJSON *string `json:"service_account_json,omitempty"`
+	SubjectEmail       *string `json:"subject_email,omitempty"`
+}
+
+// Credentials uploads pull-provider credentials (e.g. a Google service-account
+// key and subject email) for a SCIM directory. They are validated and sealed
+// server-side; on success the directory is enabled.
+func (c *Client) Credentials(ctx context.Context, id string, params *CredentialsParams) (*clerk.SCIMDirectory, error) {
+	path, err := clerk.JoinPath(path, id, "credentials")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPost, path)
+	req.SetParams(params)
+	resource := &clerk.SCIMDirectory{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}

--- a/scimdirectory/client.go
+++ b/scimdirectory/client.go
@@ -137,10 +137,10 @@ type CredentialsParams struct {
 	SubjectEmail       *string `json:"subject_email,omitempty"`
 }
 
-// Credentials uploads pull-provider credentials (e.g. a Google service-account
+// AddCredentials adds pull-provider credentials (e.g. a Google service-account
 // key and subject email) for a SCIM directory. They are validated and sealed
 // server-side; on success the directory is enabled.
-func (c *Client) Credentials(ctx context.Context, id string, params *CredentialsParams) (*clerk.SCIMDirectory, error) {
+func (c *Client) AddCredentials(ctx context.Context, id string, params *CredentialsParams) (*clerk.SCIMDirectory, error) {
 	path, err := clerk.JoinPath(path, id, "credentials")
 	if err != nil {
 		return nil, err

--- a/scimdirectory/client_test.go
+++ b/scimdirectory/client_test.go
@@ -365,7 +365,7 @@ func TestRotateAPIKey(t *testing.T) {
 	assert.Equal(t, "sk_new_rotated_key", *scimDirectory.APIKey)
 }
 
-func TestCredentials(t *testing.T) {
+func TestAddCredentials(t *testing.T) {
 	t.Parallel()
 
 	response := map[string]interface{}{
@@ -392,7 +392,7 @@ func TestCredentials(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	scimDirectory, err := client.Credentials(context.Background(), "scim_test123", &CredentialsParams{
+	scimDirectory, err := client.AddCredentials(context.Background(), "scim_test123", &CredentialsParams{
 		ServiceAccountJSON: clerk.String(`{"type":"service_account"}`),
 		SubjectEmail:       clerk.String("admin@example.com"),
 	})

--- a/scimdirectory/client_test.go
+++ b/scimdirectory/client_test.go
@@ -364,3 +364,39 @@ func TestRotateAPIKey(t *testing.T) {
 	assert.Equal(t, "Test SCIM Directory", scimDirectory.Name)
 	assert.Equal(t, "sk_new_rotated_key", *scimDirectory.APIKey)
 }
+
+func TestCredentials(t *testing.T) {
+	t.Parallel()
+
+	response := map[string]interface{}{
+		"object":                   "scim_directory",
+		"id":                       "scim_test123",
+		"name":                     "Test SCIM Directory",
+		"enterprise_connection_id": "entc_123",
+		"provider":                 "google",
+		"enabled":                  true,
+		"created_at":               1640995200,
+		"updated_at":               1640995200,
+	}
+
+	responseJSON, _ := json.Marshal(response)
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(responseJSON),
+			Method: http.MethodPost,
+			Path:   "/v1/scim_directories/scim_test123/credentials",
+		},
+	}
+
+	client := NewClient(config)
+	scimDirectory, err := client.Credentials(context.Background(), "scim_test123", &CredentialsParams{
+		ServiceAccountJSON: clerk.String(`{"type":"service_account"}`),
+		SubjectEmail:       clerk.String("admin@example.com"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "scim_test123", scimDirectory.ID)
+	assert.True(t, scimDirectory.Enabled)
+}


### PR DESCRIPTION
  ## Summary

  Adds a `Credentials` method to the `scimdirectory` client for uploading pull-provider credentials (e.g. a Google service-account key + subject email) to a directory. Backs the BAPI credentials endpoint used to enable pull-based directories.

  ## Changes

  - Add `CredentialsParams{ServiceAccountJSON, SubjectEmail}` and `Client.Credentials(ctx, id, params)` → `POST /scim_directories/{id}/credentials`, returning the updated `SCIMDirectory`.
  - Regenerate the package-level `Credentials` wrapper in `api.go`.
  - Add `TestCredentials` covering the request path and response mapping.
