### PR TITLE
feat(signintoken): support organization-scoped sign-in tokens

### DIFF
--- a/signintoken/client.go
+++ b/signintoken/client.go
@@ -26,6 +26,7 @@ func NewClient(config *clerk.ClientConfig) *Client {
 type CreateParams struct {
 	clerk.APIParams
 	UserID           *string `json:"user_id,omitempty"`
+	OrganizationID   *string `json:"org_id,omitempty"`
 	ExpiresInSeconds *int64  `json:"expires_in_seconds,omitempty"`
 }
 

--- a/signintoken/sign_in_tokens_test.go
+++ b/signintoken/sign_in_tokens_test.go
@@ -14,12 +14,13 @@ import (
 
 func TestSignInTokenTokenCreate(t *testing.T) {
 	userID := "usr_123"
+	organizationID := "org_123"
 	id := "sign_123"
 	clerk.SetBackend(clerk.NewBackend(&clerk.BackendConfig{
 		HTTPClient: &http.Client{
 			Transport: &clerktest.RoundTripper{
 				T:      t,
-				In:     json.RawMessage(fmt.Sprintf(`{"user_id":"%s"}`, userID)),
+				In:     json.RawMessage(fmt.Sprintf(`{"user_id":"%s","org_id":"%s"}`, userID, organizationID)),
 				Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","user_id":"%s"}`, id, userID)),
 				Path:   "/v1/sign_in_tokens",
 				Method: http.MethodPost,
@@ -28,7 +29,8 @@ func TestSignInTokenTokenCreate(t *testing.T) {
 	}))
 
 	signInToken, err := Create(context.Background(), &CreateParams{
-		UserID: clerk.String(userID),
+		UserID:         clerk.String(userID),
+		OrganizationID: clerk.String(organizationID),
 	})
 	require.NoError(t, err)
 	require.Equal(t, id, signInToken.ID)


### PR DESCRIPTION
## Summary

- add an optional `OrganizationID` field to sign-in token creation parameters
- serialize the value as `org_id`
- verify the organization ID is included in the request body

## Context

Supports the organization-scoped sign-in token API introduced in [clerk/clerk_go#20464](https://github.com/clerk/clerk_go/pull/20464).

Related SDK and docs work:

- [clerk/javascript#9192](https://github.com/clerk/javascript/pull/9192)
- [clerk/clerk#2977](https://github.com/clerk/clerk/pull/2977)

## Validation

- `go test ./...`
- `go test -race ./signintoken`
- `go vet ./...`
- `gofmt -d -s signintoken`
