### PR TITLE
feat(scimdirectory): add Sync and credentials_configured

### DIFF
--- a/scim_directory.go
+++ b/scim_directory.go
@@ -3,18 +3,22 @@ package clerk
 // SCIMDirectory represents a SCIM directory resource.
 type SCIMDirectory struct {
 	APIResource
-	Object                  string            `json:"object"`
-	ID                      string            `json:"id"`
-	Name                    string            `json:"name"`
-	EnterpriseConnectionID  *string           `json:"enterprise_connection_id"`
-	EndpointURL             string            `json:"endpoint_url"`
-	Provider                string            `json:"provider"`
-	Enabled                 bool              `json:"enabled"`
-	GroupRoleMappingEnabled bool              `json:"group_role_mapping_enabled"`
-	APIKey                  *string           `json:"api_key,omitempty"`
-	CreatedAt               int64             `json:"created_at"`
-	UpdatedAt               int64             `json:"updated_at"`
-	AttributeMapping        map[string]string `json:"attribute_mapping,omitempty"`
+	Object                  string  `json:"object"`
+	ID                      string  `json:"id"`
+	Name                    string  `json:"name"`
+	EnterpriseConnectionID  *string `json:"enterprise_connection_id"`
+	EndpointURL             string  `json:"endpoint_url"`
+	Provider                string  `json:"provider"`
+	Enabled                 bool    `json:"enabled"`
+	GroupRoleMappingEnabled bool    `json:"group_role_mapping_enabled"`
+	// CredentialsConfigured is only returned for pull-based directories
+	// (e.g. Google Workspace): whether validated provider credentials are
+	// stored for the directory.
+	CredentialsConfigured *bool             `json:"credentials_configured,omitempty"`
+	APIKey                *string           `json:"api_key,omitempty"`
+	CreatedAt             int64             `json:"created_at"`
+	UpdatedAt             int64             `json:"updated_at"`
+	AttributeMapping      map[string]string `json:"attribute_mapping,omitempty"`
 }
 
 // SCIMDirectoryList represents a paginated list of SCIM directories.

--- a/scimdirectory/api.go
+++ b/scimdirectory/api.go
@@ -46,6 +46,11 @@ func AddCredentials(ctx context.Context, id string, params *CredentialsParams) (
 	return getClient().AddCredentials(ctx, id, params)
 }
 
+// Sync enqueues a sync run for a pull-based SCIM directory.
+func Sync(ctx context.Context, id string) error {
+	return getClient().Sync(ctx, id)
+}
+
 func getClient() *Client {
 	return &Client{
 		Backend: clerk.GetBackend(),

--- a/scimdirectory/client.go
+++ b/scimdirectory/client.go
@@ -131,6 +131,17 @@ func (c *Client) RotateAPIKey(ctx context.Context, id string) (*clerk.SCIMDirect
 	return resource, err
 }
 
+// Sync enqueues a sync run for a pull-based SCIM directory. The server
+// responds 202 Accepted; the run itself is asynchronous.
+func (c *Client) Sync(ctx context.Context, id string) error {
+	path, err := clerk.JoinPath(path, id, "sync")
+	if err != nil {
+		return err
+	}
+	req := clerk.NewAPIRequest(http.MethodPost, path)
+	return c.Backend.Call(ctx, req, &clerk.APIResource{})
+}
+
 type CredentialsParams struct {
 	clerk.APIParams
 	ServiceAccountJSON *string `json:"service_account_json,omitempty"`

--- a/scimdirectory/client_test.go
+++ b/scimdirectory/client_test.go
@@ -375,6 +375,7 @@ func TestAddCredentials(t *testing.T) {
 		"enterprise_connection_id": "entc_123",
 		"provider":                 "google",
 		"enabled":                  true,
+		"credentials_configured":   true,
 		"created_at":               1640995200,
 		"updated_at":               1640995200,
 	}
@@ -399,4 +400,24 @@ func TestAddCredentials(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "scim_test123", scimDirectory.ID)
 	assert.True(t, scimDirectory.Enabled)
+	require.NotNil(t, scimDirectory.CredentialsConfigured)
+	assert.True(t, *scimDirectory.CredentialsConfigured)
+}
+
+func TestSync(t *testing.T) {
+	t.Parallel()
+
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			Out:    json.RawMessage(`{}`),
+			Method: http.MethodPost,
+			Path:   "/v1/scim_directories/scim_test123/sync",
+		},
+	}
+
+	client := NewClient(config)
+	err := client.Sync(context.Background(), "scim_test123")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

The `SCIMDirectory` type is missing the `credentials_configured` field the API returns for pull-based directories, so any proxy built on the SDK (Clerk's own DAPI included) silently strips it from responses — in the Dashboard this leaves the credentials card claiming no key is set right after a successful upload. There's also no method for triggering a sync run, which the Dashboard's upcoming Sync now button needs.

## Changes

- Add `CredentialsConfigured *bool` to `clerk.SCIMDirectory` (only returned for pull-based directories)
- Add `Client.Sync` / package-level `Sync` for `POST /v1/scim_directories/{id}/sync` (202 Accepted, run is asynchronous)
- Extend `TestAddCredentials` with the new field; add `TestSync`

## Test plan

- [x] `go test ./scimdirectory/`