### PR TITLE
fix(fva): Fail closed on omitted fva

### DIFF
--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -396,3 +396,47 @@ func TestNeedsSessionReverification(t *testing.T) {
 		})
 	}
 }
+
+// TestNeedsSessionReverification_NoFactorVerificationAge tests that a route
+// gated on reverification rejects a token that carries no 'fva' claim, rather
+// than treating the absent claim as a fresh verification. The claims are
+// decoded from a payload rather than built in Go, because it's the decoding
+// that has to supply the "not set" sentinel. A JWT template token is the
+// example here: it authenticates as its subject, but describes no step-up.
+func TestNeedsSessionReverification_NoFactorVerificationAge(t *testing.T) {
+	for _, policy := range []clerk.SessionReverificationPolicy{
+		clerk.SessionReverificationStrictMFA,
+		clerk.SessionReverificationStrict,
+	} {
+		t.Run(string(policy.Level), func(t *testing.T) {
+			includeSessionClaims := func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					claims := &clerk.SessionClaims{}
+					require.NoError(t, json.Unmarshal([]byte(`{"sid":"sess_123","sub":"user_123"}`), claims))
+					ctx := clerk.ContextWithSessionClaims(r.Context(), claims)
+					next.ServeHTTP(w, r.WithContext(ctx))
+				})
+			}
+
+			// This is the user's server, gating a sensitive route on reverification.
+			ts := httptest.NewServer(includeSessionClaims(NeedsSessionReverification(policy)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte("{}"))
+				require.NoError(t, err)
+			}))))
+			defer ts.Close()
+
+			req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := ts.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+			var errResp ClerkErrorResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+			require.Equal(t, "reverification-error", errResp.ClerkError.Reason)
+		})
+	}
+}

--- a/jwt.go
+++ b/jwt.go
@@ -74,9 +74,9 @@ func (s *SessionClaims) HasRole(role string) bool {
 func (s *SessionClaims) NeedsReverification(policy SessionReverificationPolicy) bool {
 	firstFactorAgeMinutes, secondFactorAgeMinutes := s.FactorVerificationAge[0], s.FactorVerificationAge[1]
 
-	firstFactorNeedsReverification := firstFactorAgeMinutes == -1 ||
+	firstFactorNeedsReverification := firstFactorAgeMinutes == factorVerificationAgeNotEnabled ||
 		policy.AfterMinutes < firstFactorAgeMinutes
-	isSecondFactorEnabled := secondFactorAgeMinutes != -1
+	isSecondFactorEnabled := secondFactorAgeMinutes != factorVerificationAgeNotEnabled
 	secondFactorNeedsReverification := isSecondFactorEnabled &&
 		policy.AfterMinutes < secondFactorAgeMinutes
 
@@ -154,6 +154,49 @@ type Claims struct {
 	ActiveOrganizationPermissions []string        `json:"org_permissions"`
 	Actor                         json.RawMessage `json:"act,omitempty"`
 	FactorVerificationAge         [2]int64        `json:"fva"`
+}
+
+// factorVerificationAgeNotEnabled is the value Clerk uses in either 'fva' slot
+// for a factor group that isn't enabled.
+const factorVerificationAgeNotEnabled int64 = -1
+
+// UnmarshalJSON decodes Clerk's private claims, handling omitted 'fva'.
+//
+// This is necessary because an omitted 'fva' otherwise marshals to [0, 0]. The
+// zero value here would satisfy every reverification check, which is not intended.
+// Plenty of Clerk-signed JWTs carry no 'fva' claim at all (JWT template
+// tokens, OIDC ID tokens and machine tokens, none of which describe a session
+// step-up), but this should not entail that we just completed reverification.
+func (c *Claims) UnmarshalJSON(data []byte) error {
+	// The alias has the same fields but no methods, so this doesn't recurse.
+	type alias Claims
+	if err := json.Unmarshal(data, (*alias)(c)); err != nil {
+		return err
+	}
+
+	// Decode 'fva' again, into a slice this time. By now c.FactorVerificationAge
+	// has been zero-filled, and a [2]int64 can't tell us whether that came from
+	// the token or from Go. A slice can: nil means the claim wasn't there.
+	var raw struct {
+		FactorVerificationAge []int64 `json:"fva"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	c.FactorVerificationAge = [2]int64{factorVerificationAgeNotEnabled, factorVerificationAgeNotEnabled}
+	if len(raw.FactorVerificationAge) == 2 &&
+		isValidFactorVerificationAge(raw.FactorVerificationAge[0]) &&
+		isValidFactorVerificationAge(raw.FactorVerificationAge[1]) {
+		c.FactorVerificationAge = [2]int64(raw.FactorVerificationAge)
+	}
+	return nil
+}
+
+// isValidFactorVerificationAge reports whether age is a usable 'fva' entry:
+// either an age in minutes, or the sentinel for a factor that is not set.
+func isValidFactorVerificationAge(age int64) bool {
+	return age == factorVerificationAgeNotEnabled || age >= 0
 }
 
 // UnverifiedToken holds the result of a JWT decoding without any

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -225,6 +225,40 @@ func TestVerify_PublicClaimsVersion2(t *testing.T) {
 	require.Equal(t, int64(-1), claims.FactorVerificationAge[1])
 }
 
+// TestVerify_NoFactorVerificationAge tests that a genuine Clerk-signed token
+// which carries no 'fva' claim verifies successfully, but is reported as
+// needing reverification instead of as freshly verified. JWT template tokens,
+// OIDC ID tokens and machine tokens all omit the claim.
+func TestVerify_NoFactorVerificationAge(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kid := "kid"
+
+	tokenClaims := map[string]any{
+		"sid": "sess_123",
+		"sub": "user_123",
+		"iss": "https://clerk.com",
+		"nbf": time.Now().Add(-10 * time.Hour).Unix(),
+		"exp": time.Now().Add(10 * time.Hour).Unix(),
+	}
+	token, pubKey := clerktest.GenerateJWT(t, tokenClaims, kid)
+	claims, err := Verify(ctx, &VerifyParams{
+		Token: token,
+		JWK: &clerk.JSONWebKey{
+			Key:       pubKey,
+			KeyID:     kid,
+			Algorithm: string(jose.RS256),
+			Use:       "sig",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "sess_123", claims.SessionID)
+	require.Equal(t, int64(-1), claims.FactorVerificationAge[0])
+	require.Equal(t, int64(-1), claims.FactorVerificationAge[1])
+	require.True(t, claims.NeedsReverification(clerk.SessionReverificationStrictMFA))
+	require.True(t, claims.NeedsReverification(clerk.SessionReverificationStrict))
+}
+
 // TestVerify_TimeValues tests that Verify validates that the token's
 // not before (nbf) and expiry (exp) claims are respected.
 func TestVerify_TimeValues(t *testing.T) {

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -1,6 +1,7 @@
 package clerk
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,6 +57,98 @@ func TestSessionClaimsHasPermission(t *testing.T) {
 		claims := SessionClaims{}
 		claims.ActiveOrganizationPermissions = tc.active
 		require.Equal(t, claims.HasPermission(tc.permission), tc.want)
+	}
+}
+
+// TestSessionClaimsUnmarshalJSONFactorVerificationAge tests that a token which
+// carries no usable 'fva' claim decodes to the "not set" sentinel instead of
+// Go's zero value, which NeedsReverification would read as "verified just now".
+func TestSessionClaimsUnmarshalJSONFactorVerificationAge(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		payload string
+		want    [2]int64
+	}{
+		{
+			name:    "claim present",
+			payload: `{"sid":"sess_123","fva":[10,5]}`,
+			want:    [2]int64{10, 5},
+		},
+		{
+			name:    "claim present, second factor not enrolled",
+			payload: `{"sid":"sess_123","fva":[10,-1]}`,
+			want:    [2]int64{10, -1},
+		},
+		{
+			name:    "claim present, both factors just verified",
+			payload: `{"sid":"sess_123","fva":[0,0]}`,
+			want:    [2]int64{0, 0},
+		},
+		{
+			// JWT template tokens, OIDC ID tokens and machine tokens.
+			name:    "claim absent",
+			payload: `{"sid":"sess_123"}`,
+			want:    [2]int64{-1, -1},
+		},
+		{
+			name:    "claim null",
+			payload: `{"sid":"sess_123","fva":null}`,
+			want:    [2]int64{-1, -1},
+		},
+		{
+			name:    "claim empty",
+			payload: `{"sid":"sess_123","fva":[]}`,
+			want:    [2]int64{-1, -1},
+		},
+		{
+			// Go would zero-fill the missing element to [5, 0], marking the
+			// second factor enrolled and freshly verified.
+			name:    "claim too short",
+			payload: `{"sid":"sess_123","fva":[5]}`,
+			want:    [2]int64{-1, -1},
+		},
+		{
+			name:    "claim too long",
+			payload: `{"sid":"sess_123","fva":[5,10,15]}`,
+			want:    [2]int64{-1, -1},
+		},
+		{
+			// Negative ages other than the sentinel compare as fresher than
+			// any policy threshold.
+			name:    "claim with out of range age",
+			payload: `{"sid":"sess_123","fva":[-5,-5]}`,
+			want:    [2]int64{-1, -1},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			claims := &SessionClaims{}
+			require.NoError(t, json.Unmarshal([]byte(tc.payload), claims))
+			require.Equal(t, tc.want, claims.FactorVerificationAge)
+			// The rest of the claims still decode.
+			require.Equal(t, "sess_123", claims.SessionID)
+		})
+	}
+}
+
+// TestNeedsReverificationWithoutFactorVerificationAge tests that every policy
+// fails closed for a token that carries no 'fva' claim.
+func TestNeedsReverificationWithoutFactorVerificationAge(t *testing.T) {
+	t.Parallel()
+	for name, policy := range map[string]SessionReverificationPolicy{
+		"strict mfa":   SessionReverificationStrictMFA,
+		"strict":       SessionReverificationStrict,
+		"moderate":     SessionReverificationModerate,
+		"lax":          SessionReverificationLax,
+		"first factor": {AfterMinutes: 10, Level: SessionReverificationLevelFirstFactor},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			claims := &SessionClaims{}
+			require.NoError(t, json.Unmarshal([]byte(`{"sid":"sess_123"}`), claims))
+			require.True(t, claims.NeedsReverification(policy))
+		})
 	}
 }
 


### PR DESCRIPTION
Backport of #583 to `v2`.

Some Clerk JWTs don't include a factor verification age (`fva`). When we unmarshal these JWTs into our struct, they get the zero value of [0, 0]. In this case, the zero value in unsafe: It means both first and second factor were reverified within the last minute.

Add custom handling the unmarshaling code to explicitly unmarshal the `fva`. If the claim is not included, set it to the safe sentinel value of [-1, -1] instead of the unsafe zero value.

`jwt.go` is byte-identical to the v3 change. The tests differ in one place: v2's `clerktest.GenerateJWT` generates its signing key internally and there's no `ConvertToJWKS` helper, so the middleware test can't serve a matching JWKS for a real end-to-end request. It drives the reverification gate through the real JSON decode path instead. The `Verify` test in `jwt/jwt_test.go` still uses a genuine signed token, passing the public key via `VerifyParams.JWK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)