### PR TITLE
feat(user): support removing user passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- Add support for removing a user's password with `user.RemovePassword`.
+
 ## 2.3.1
 
 - Fix parsing the org claims in the new JWT session token version.

--- a/user/api.go
+++ b/user/api.go
@@ -143,6 +143,23 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 	return getClient().DeleteExternalAccount(ctx, params)
 }
 
+// RemovePassword removes a user's password without requiring their current password.
+// Password removal is allowed even when the user has no other sign-in method configured.
+// Existing sessions remain active by default. Set SignOutOfOtherSessions to true to revoke them.
+//
+// To keep existing sessions active:
+//
+//	updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{})
+//
+// To revoke existing sessions:
+//
+//	updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{
+//		SignOutOfOtherSessions: clerk.Bool(true),
+//	})
+func RemovePassword(ctx context.Context, userID string, params *RemovePasswordParams) (*clerk.User, error) {
+	return getClient().RemovePassword(ctx, userID, params)
+}
+
 // VerifyPassword verifies a user's password, returns an error if the password is incorrect.
 func VerifyPassword(ctx context.Context, params *VerifyPasswordParams) (*VerifyPasswordResponse, error) {
 	return getClient().VerifyPassword(ctx, params)

--- a/user/api.go
+++ b/user/api.go
@@ -146,16 +146,6 @@ func DeleteExternalAccount(ctx context.Context, params *DeleteExternalAccountPar
 // RemovePassword removes a user's password without requiring their current password.
 // Password removal is allowed even when the user has no other sign-in method configured.
 // Existing sessions remain active by default. Set SignOutOfOtherSessions to true to revoke them.
-//
-// To keep existing sessions active:
-//
-//	updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{})
-//
-// To revoke existing sessions:
-//
-//	updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{
-//		SignOutOfOtherSessions: clerk.Bool(true),
-//	})
 func RemovePassword(ctx context.Context, userID string, params *RemovePasswordParams) (*clerk.User, error) {
 	return getClient().RemovePassword(ctx, userID, params)
 }

--- a/user/client.go
+++ b/user/client.go
@@ -704,16 +704,6 @@ type RemovePasswordParams struct {
 // RemovePassword removes a user's password without requiring their current password.
 // Password removal is allowed even when the user has no other sign-in method configured.
 // Existing sessions remain active by default. Set SignOutOfOtherSessions to true to revoke them.
-//
-// To keep existing sessions active:
-//
-//	updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{})
-//
-// To revoke existing sessions:
-//
-//	updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{
-//		SignOutOfOtherSessions: clerk.Bool(true),
-//	})
 func (c *Client) RemovePassword(ctx context.Context, userID string, params *RemovePasswordParams) (*clerk.User, error) {
 	path, err := clerk.JoinPath(path, userID, "/remove_password")
 	if err != nil {

--- a/user/client.go
+++ b/user/client.go
@@ -693,6 +693,39 @@ type VerifyPasswordParams struct {
 	Password string `json:"password"`
 }
 
+// RemovePasswordParams contains options for removing a user's password.
+type RemovePasswordParams struct {
+	clerk.APIParams
+	// SignOutOfOtherSessions revokes all of the user's active sessions when true.
+	// Existing sessions remain active when omitted or false.
+	SignOutOfOtherSessions *bool `json:"sign_out_of_other_sessions,omitempty"`
+}
+
+// RemovePassword removes a user's password without requiring their current password.
+// Password removal is allowed even when the user has no other sign-in method configured.
+// Existing sessions remain active by default. Set SignOutOfOtherSessions to true to revoke them.
+//
+// To keep existing sessions active:
+//
+//	updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{})
+//
+// To revoke existing sessions:
+//
+//	updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{
+//		SignOutOfOtherSessions: clerk.Bool(true),
+//	})
+func (c *Client) RemovePassword(ctx context.Context, userID string, params *RemovePasswordParams) (*clerk.User, error) {
+	path, err := clerk.JoinPath(path, userID, "/remove_password")
+	if err != nil {
+		return nil, err
+	}
+	req := clerk.NewAPIRequest(http.MethodPost, path)
+	req.SetParams(params)
+	resource := &clerk.User{}
+	err = c.Backend.Call(ctx, req, resource)
+	return resource, err
+}
+
 type VerifyPasswordResponse struct {
 	clerk.APIResource
 	Verified bool `json:"verified"`

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -798,3 +798,47 @@ func TestUserClientVerifyPassword(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, verified.Verified)
 }
+
+func TestUserClientRemovePassword(t *testing.T) {
+	t.Parallel()
+	userID := "user_123"
+	tests := []struct {
+		name   string
+		params *RemovePasswordParams
+		body   json.RawMessage
+	}{
+		{
+			name:   "keeps existing sessions active by default",
+			params: &RemovePasswordParams{},
+			body:   json.RawMessage(`{}`),
+		},
+		{
+			name: "revokes existing sessions when requested",
+			params: &RemovePasswordParams{
+				SignOutOfOtherSessions: clerk.Bool(true),
+			},
+			body: json.RawMessage(`{"sign_out_of_other_sessions":true}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config := &clerk.ClientConfig{}
+			config.HTTPClient = &http.Client{
+				Transport: &clerktest.RoundTripper{
+					T:      t,
+					Method: http.MethodPost,
+					In:     tt.body,
+					Out:    json.RawMessage(fmt.Sprintf(`{"object":"user","id":"%s"}`, userID)),
+					Path:   fmt.Sprintf("/v1/users/%s/remove_password", userID),
+				},
+			}
+			client := NewClient(config)
+			updatedUser, err := client.RemovePassword(context.Background(), userID, tt.params)
+			require.NoError(t, err)
+			require.Equal(t, userID, updatedUser.ID)
+			require.Equal(t, "user", updatedUser.Object)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds support for removing a user's password through the Go SDK, matching the public Backend API operation published in [clerk/openapi-specs#126](https://github.com/clerk/openapi-specs/pull/126) and the JavaScript SDK support in [clerk/javascript#9326](https://github.com/clerk/javascript/pull/9326).

The new API is available through both supported Go SDK styles:

```go
updatedUser, err := user.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{})
```

```go
updatedUser, err := userClient.RemovePassword(ctx, "user_123", &user.RemovePasswordParams{
    SignOutOfOtherSessions: clerk.Bool(true),
})
```

Existing sessions remain active by default. Setting `SignOutOfOtherSessions` to `true` revokes the user's active sessions. The public documentation also calls out that password removal is allowed when the user has no alternate sign-in method configured.
