### PR TITLE
Add typed DNS targets to Go SDK domains

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -10,12 +10,22 @@ type Domain struct {
 	AccountPortalURL  *string       `json:"accounts_portal_url,omitempty"`
 	ProxyURL          *string       `json:"proxy_url,omitempty"`
 	CNAMETargets      []CNAMETarget `json:"cname_targets,omitempty"`
+	DNSTargets        []DNSTarget   `json:"dns_targets,omitempty"`
 	DevelopmentOrigin string        `json:"development_origin"`
 }
 
 type CNAMETarget struct {
-	Host  string `json:"host"`
-	Value string `json:"value"`
+	Host     string `json:"host"`
+	Value    string `json:"value"`
+	Required bool   `json:"required"`
+}
+
+type DNSTarget struct {
+	Host                  string `json:"host"`
+	Value                 string `json:"value"`
+	Required              bool   `json:"required"`
+	RecordType            string `json:"record_type"`
+	AutomationDisposition string `json:"automation_disposition,omitempty"`
 }
 
 type DomainList struct {

--- a/domain.go
+++ b/domain.go
@@ -15,9 +15,8 @@ type Domain struct {
 }
 
 type CNAMETarget struct {
-	Host     string `json:"host"`
-	Value    string `json:"value"`
-	Required bool   `json:"required"`
+	Host  string `json:"host"`
+	Value string `json:"value"`
 }
 
 type DNSTarget struct {

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -15,12 +15,21 @@ import (
 func TestDomainCreate(t *testing.T) {
 	name := "clerk.com"
 	id := "dmn_123"
+	dmarcHost := "_dmarc." + name
 	clerk.SetBackend(clerk.NewBackend(&clerk.BackendConfig{
 		HTTPClient: &http.Client{
 			Transport: &clerktest.RoundTripper{
-				T:      t,
-				In:     json.RawMessage(fmt.Sprintf(`{"name":"%s"}`, name)),
-				Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s"}`, id, name)),
+				T:  t,
+				In: json.RawMessage(fmt.Sprintf(`{"name":"%s"}`, name)),
+				Out: json.RawMessage(fmt.Sprintf(`{
+					"id":"%s",
+					"name":"%s",
+					"cname_targets":[{"host":"clerk.%s","value":"frontend-api.clerk.services","required":false}],
+					"dns_targets":[
+						{"host":"clerk.%s","value":"frontend-api.clerk.services","required":false,"record_type":"CNAME"},
+						{"host":"%s","value":"v=DMARC1; p=none;","required":true,"record_type":"TXT","automation_disposition":"safe_to_create"}
+					]
+				}`, id, name, name, name, dmarcHost)),
 				Path:   "/v1/domains",
 				Method: http.MethodPost,
 			},
@@ -33,6 +42,26 @@ func TestDomainCreate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, dmn.ID)
 	require.Equal(t, name, dmn.Name)
+	require.Equal(t, []clerk.CNAMETarget{{
+		Host:     "clerk." + name,
+		Value:    "frontend-api.clerk.services",
+		Required: false,
+	}}, dmn.CNAMETargets)
+	require.Equal(t, []clerk.DNSTarget{
+		{
+			Host:       "clerk." + name,
+			Value:      "frontend-api.clerk.services",
+			Required:   false,
+			RecordType: "CNAME",
+		},
+		{
+			Host:                  dmarcHost,
+			Value:                 "v=DMARC1; p=none;",
+			Required:              true,
+			RecordType:            "TXT",
+			AutomationDisposition: "safe_to_create",
+		},
+	}, dmn.DNSTargets)
 }
 
 func TestDomainCreate_Error(t *testing.T) {
@@ -63,12 +92,17 @@ func TestDomainCreate_Error(t *testing.T) {
 func TestDomainUpdate(t *testing.T) {
 	id := "dmn_456"
 	name := "clerk.dev"
+	dmarcHost := "_dmarc." + name
 	clerk.SetBackend(clerk.NewBackend(&clerk.BackendConfig{
 		HTTPClient: &http.Client{
 			Transport: &clerktest.RoundTripper{
-				T:      t,
-				In:     json.RawMessage(fmt.Sprintf(`{"name":"%s"}`, name)),
-				Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s"}`, id, name)),
+				T:  t,
+				In: json.RawMessage(fmt.Sprintf(`{"name":"%s"}`, name)),
+				Out: json.RawMessage(fmt.Sprintf(`{
+					"id":"%s",
+					"name":"%s",
+					"dns_targets":[{"host":"%s","value":"v=DMARC1; p=none;","required":true,"record_type":"TXT"}]
+				}`, id, name, dmarcHost)),
 				Path:   fmt.Sprintf("/v1/domains/%s", id),
 				Method: http.MethodPatch,
 			},
@@ -81,6 +115,12 @@ func TestDomainUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, dmn.ID)
 	require.Equal(t, name, dmn.Name)
+	require.Equal(t, []clerk.DNSTarget{{
+		Host:       dmarcHost,
+		Value:      "v=DMARC1; p=none;",
+		Required:   true,
+		RecordType: "TXT",
+	}}, dmn.DNSTargets)
 }
 
 func TestDomainUpdate_Error(t *testing.T) {

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -43,9 +43,8 @@ func TestDomainCreate(t *testing.T) {
 	require.Equal(t, id, dmn.ID)
 	require.Equal(t, name, dmn.Name)
 	require.Equal(t, []clerk.CNAMETarget{{
-		Host:     "clerk." + name,
-		Value:    "frontend-api.clerk.services",
-		Required: false,
+		Host:  "clerk." + name,
+		Value: "frontend-api.clerk.services",
 	}}, dmn.CNAMETargets)
 	require.Equal(t, []clerk.DNSTarget{
 		{


### PR DESCRIPTION
## Summary

Adds the typed DNS response model needed for consumers such as DAPI to preserve Clerk domain DNS contracts, including TXT records, instead of dropping fields not represented by the SDK.

## Changes in this repo

Adds dns_targets with record type, required state, and automation disposition to Domain responses. Create and update client tests cover mixed CNAME and DMARC TXT responses while the legacy cname_targets response shape remains unchanged.

<!-- clk:companion-prs -->
## Companion PRs

- **clerk**: https://github.com/clerk/clerk/pull/3132
- **clerk_go**: https://github.com/clerk/clerk_go/pull/21092
- **cloudflare-workers**: https://github.com/clerk/cloudflare-workers/pull/2594
- **dashboard**: https://github.com/clerk/dashboard/pull/9970
- **clerk_go:domain-intent-contract**: https://github.com/clerk/clerk_go/pull/21093
- **clerk_go:dmarc**: https://github.com/clerk/clerk_go/pull/21094
<!-- /clk:companion-prs -->