### PR TITLE
feat(user): add SkipRestrictionChecks to CreateParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- Add `SkipRestrictionChecks` to `user.CreateParams`. Creating a user now runs the instance's allowlist, blocklist, blocked disposable email domains and blocked email subaddresses, the same as sign-up does; set this to exempt a single create, for a backend creating a user it already trusts.
+
 - Add support for the OAuth Applications API. Added the oauthapplication package for API operations and a clerk.OAuthApplication type.
 - Add support for multiple invitation templates with the `TemplateSlug` field in `invitation.Create`.
 - Add support for listing and creating waitlist entries with the `waitlistentry.List` and `waitlistentry.Create` methods.

--- a/user/client.go
+++ b/user/client.go
@@ -47,8 +47,14 @@ type CreateParams struct {
 	PasswordHasher          *string          `json:"password_hasher,omitempty"`
 	SkipPasswordRequirement *bool            `json:"skip_password_requirement,omitempty"`
 	SkipPasswordChecks      *bool            `json:"skip_password_checks,omitempty"`
-	TOTPSecret              *string          `json:"totp_secret,omitempty"`
-	BackupCodes             *[]string        `json:"backup_codes,omitempty"`
+	// SkipRestrictionChecks exempts this user from the instance's allowlist,
+	// blocklist, blocked disposable email domains and blocked email
+	// subaddresses. Those settings otherwise reject a matching identifier here
+	// just as they do at sign-up, so a backend creating a user it already
+	// trusts sets this rather than editing the instance's own lists.
+	SkipRestrictionChecks *bool     `json:"skip_restriction_checks,omitempty"`
+	TOTPSecret            *string   `json:"totp_secret,omitempty"`
+	BackupCodes           *[]string `json:"backup_codes,omitempty"`
 	// Banned, when set to true, creates the user already banned, saving a
 	// follow-up call to the /ban endpoint. Requires the same plan support as
 	// the ban user endpoint.

--- a/user/client_test.go
+++ b/user/client_test.go
@@ -65,6 +65,53 @@ func TestUserClientCreate_WithLocale(t *testing.T) {
 	require.Equal(t, locale, *user.Locale)
 }
 
+func TestUserClientCreate_WithSkipRestrictionChecks(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	email := "blocked@example.com"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"email_address":["%s"],"skip_restriction_checks":true}`, email)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s"}`, id)),
+			Method: http.MethodPost,
+			Path:   "/v1/users",
+		},
+	}
+	client := NewClient(config)
+	user, err := client.Create(context.Background(), &CreateParams{
+		EmailAddresses:        &[]string{email},
+		SkipRestrictionChecks: clerk.Bool(true),
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, user.ID)
+}
+
+// Omitting the field must leave it out of the payload entirely, so an
+// unrelated create can't be read as asking for an exemption.
+func TestUserClientCreate_WithoutSkipRestrictionChecks(t *testing.T) {
+	t.Parallel()
+	id := "user_123"
+	email := "user@example.com"
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T:      t,
+			In:     json.RawMessage(fmt.Sprintf(`{"email_address":["%s"]}`, email)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s"}`, id)),
+			Method: http.MethodPost,
+			Path:   "/v1/users",
+		},
+	}
+	client := NewClient(config)
+	user, err := client.Create(context.Background(), &CreateParams{
+		EmailAddresses: &[]string{email},
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, user.ID)
+}
+
 func TestUserClientList_Request(t *testing.T) {
 	t.Parallel()
 	config := &clerk.ClientConfig{}


### PR DESCRIPTION
Creating a user through BAPI now runs the instance's restriction settings — allowlist, blocklist, blocked disposable email domains, blocked email subaddresses — which `POST /v1/users` previously skipped entirely ([clerk_go#21232](https://github.com/clerk/clerk_go/pull/21232)). That was a real gap: a customer relying on the blocklist for spam control had no enforcement at all if their backend created users server-side.

The flip side is that callers who legitimately create users those settings would reject — a migration, an admin tool, the Dashboard's own create-user dialog — need a way through. `skip_restriction_checks` is that opt-out, and this adds the field to `user.CreateParams` so SDK consumers can send it.

The Dashboard is the immediate consumer: its create-user flow goes through DAPI into this SDK, and today a customer can use the Dashboard to create a user with a blocklisted email. Without this field that stops working, so this unblocks restoring it as an explicit checkbox.

Mirrors the existing `SkipPasswordRequirement` / `SkipPasswordChecks` / `SkipLegalChecks` fields, and is omitted from the payload entirely when unset.
