### PR TITLE
feat(directory): allow disabling domain gating

### DIFF
--- a/directory.go
+++ b/directory.go
@@ -3,14 +3,15 @@ package clerk
 // Directory represents a directory resource.
 type Directory struct {
 	APIResource
-	Object                  string  `json:"object"`
-	ID                      string  `json:"id"`
-	Name                    string  `json:"name"`
-	EnterpriseConnectionID  *string `json:"enterprise_connection_id"`
-	EndpointURL             string  `json:"endpoint_url"`
-	Provider                string  `json:"provider"`
-	Enabled                 bool    `json:"enabled"`
-	GroupRoleMappingEnabled bool    `json:"group_role_mapping_enabled"`
+	Object                   string  `json:"object"`
+	ID                       string  `json:"id"`
+	Name                     string  `json:"name"`
+	EnterpriseConnectionID   *string `json:"enterprise_connection_id"`
+	EndpointURL              string  `json:"endpoint_url"`
+	Provider                 string  `json:"provider"`
+	Enabled                  bool    `json:"enabled"`
+	GroupRoleMappingEnabled  bool    `json:"group_role_mapping_enabled"`
+	DisableDomainEnforcement bool    `json:"disable_domain_enforcement"`
 	// CredentialsConfigured is only returned for pull-based directories
 	// (e.g. Google Workspace): whether validated provider credentials are
 	// stored for the directory.

--- a/directory/client.go
+++ b/directory/client.go
@@ -57,10 +57,11 @@ func (c *Client) Get(ctx context.Context, id string) (*clerk.Directory, error) {
 
 type UpdateParams struct {
 	clerk.APIParams
-	Name                    *string `json:"name,omitempty"`
-	Provider                *string `json:"provider,omitempty"`
-	Enabled                 *bool   `json:"enabled,omitempty"`
-	GroupRoleMappingEnabled *bool   `json:"group_role_mapping_enabled,omitempty"`
+	Name                     *string `json:"name,omitempty"`
+	Provider                 *string `json:"provider,omitempty"`
+	Enabled                  *bool   `json:"enabled,omitempty"`
+	GroupRoleMappingEnabled  *bool   `json:"group_role_mapping_enabled,omitempty"`
+	DisableDomainEnforcement *bool   `json:"disable_domain_enforcement,omitempty"`
 	// AttributeMapping is a map of directory attributes to Clerk attributes.
 	// The semantics of the PATCH request are as follows:
 	//   - If the attribute is not present in the request, it will be left unchanged.


### PR DESCRIPTION
Domain gating (blocking SCIM/Directory updates from emails domains not in the configured domain list) is on by default and is considered a better security posture for most users. Some customer setups require the users be let through, so we're adding a directory configuration to accommodate those use cases.