### PR TITLE
feat(jwttemplate): support limit/offset pagination in ListParams

### DIFF
--- a/jwttemplate/client.go
+++ b/jwttemplate/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/clerk/clerk-sdk-go/v3"
 )
@@ -95,6 +96,12 @@ func (c *Client) Delete(ctx context.Context, id string) (*clerk.DeletedResource,
 
 type ListParams struct {
 	clerk.APIParams
+	clerk.ListParams
+}
+
+// ToQuery returns query string values from the params.
+func (params *ListParams) ToQuery() url.Values {
+	return params.ListParams.ToQuery()
 }
 
 // List returns a list of JWT templates.

--- a/jwttemplate/client_test.go
+++ b/jwttemplate/client_test.go
@@ -173,3 +173,36 @@ func TestJWTTemplateClientList(t *testing.T) {
 	require.Equal(t, "jtmpl_123", list.JWTTemplates[0].ID)
 	require.Equal(t, "the-name", list.JWTTemplates[0].Name)
 }
+
+func TestJWTTemplateClientList_Pagination(t *testing.T) {
+	t.Parallel()
+	config := &clerk.ClientConfig{}
+	config.HTTPClient = &http.Client{
+		Transport: &clerktest.RoundTripper{
+			T: t,
+			Out: json.RawMessage(`{
+	"data": [{"id":"jtmpl_123","name":"the-name"}],
+	"total_count": 3
+}`),
+			Method: http.MethodGet,
+			Path:   "/v1/jwt_templates",
+			Query: &url.Values{
+				"paginated": []string{"true"},
+				"limit":     []string{"1"},
+				"offset":    []string{"2"},
+			},
+		},
+	}
+	client := NewClient(config)
+	params := &ListParams{
+		ListParams: clerk.ListParams{
+			Limit:  clerk.Int64(1),
+			Offset: clerk.Int64(2),
+		},
+	}
+	list, err := client.List(context.Background(), params)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), list.TotalCount)
+	require.Equal(t, 1, len(list.JWTTemplates))
+	require.Equal(t, "jtmpl_123", list.JWTTemplates[0].ID)
+}


### PR DESCRIPTION
## Summary

DAPI's JWT template list endpoint (`GET /v1/instances/{instanceID}/jwt_templates`) needs to page through templates instead of always returning every row, but the Go SDK's `jwttemplate` package has no way to ask for a page: `Client.List` accepts a `ListParams` that only carries API-level params, not `limit`/`offset`. Every other paginated resource's `ListParams` (SAML connections, OAuth applications, machines, sessions, ...) supports `limit`/`offset`; JWT templates is the one gap. Callers that need pagination today are forced to bypass `Client.List` entirely and hand-build the HTTP request themselves.

This adds `limit`/`offset` support to `jwttemplate.ListParams`, matching the shape every sibling package already uses, so `Client.List` can be called normally for a paginated request. Existing callers are unaffected: params default to unset, which produces the same request as before.

## Test plan
- [x] `go test ./jwttemplate/...`
- [x] `go test ./...`
- [x] `go generate ./jwttemplate` produces no diff to `api.go`