### PR TITLE
Remove the enhanced_email_deliverability API surface

### DIFF
--- a/instancesettings/client.go
+++ b/instancesettings/client.go
@@ -35,12 +35,6 @@ type UpdateParams struct {
 	// By default, this is enabled in all instances.
 	HIBP *bool `json:"hibp,omitempty"`
 
-	// EnhancedEmailDeliverability controls how Clerk delivers emails.
-	// Specifically, when set to true, if the instance is a production
-	// instance, OTP verification emails are sent by the Clerk's shared
-	// domain via Postmark.
-	EnhancedEmailDeliverability *bool `json:"enhanced_email_deliverability,omitempty"`
-
 	// SupportEmail is the contact email address that will be displayed
 	// on the frontend, in case your instance users need support.
 	// If the empty string is provided, the support email that is currently


### PR DESCRIPTION
## Summary

Follow-up to the Postmark send-path removal (clerk_go#21398). That PR deleted the behavior; this one deletes the field.

The setting no longer affects anything: routing, unverified-DNS suppression, template forcing, and the magic-link validator were all removed, and every remaining instance was flipped to `false` in production on 2026-08-26 (20 production + 14 development). What is left is an inert boolean on the API surface, plus dead config.

## Rollout ordering

Only one ordering constraint remains:

1. **clerk_go#21398** (behavior removal) — merged and released.
2. **dashboard#10112 before clerk_go#21613.** #21613 stops DAPI returning `enhanced_email_deliverability`, and the dashboard reads it today for the email-logs banner. The failure mode is soft — the value would just read as `undefined` and the banner would hide — but shipping the consumer first avoids a window where the dashboard reads a field the API no longer returns.
3. **clerk_go#21613.**

Everything else is independent and can land in any order: **backoffice#724** is type-only with no reader, **terraform-app-infra#3193** removes config nothing reads (the cenv constants went out with #21398), **clk#49** is documentation, and the SDK PRs land on their owners' release cadence.

**No released API contract changes.** An earlier revision of clerk_go#21613 removed the field from the base FAPI `Client` schema — which is inherited by all six API versions, so it would have dropped a `required` field from five *stable* versions that clients pin to. FAPI and BAPI now keep serializing it as `false` instead.

## Still outstanding after this

The `ENHANCED_DELIVERABILITY_POSTMARK_SERVER_TOKEN` secrets remain in four SOPS-encrypted files (production and staging, `api_common` and `pubsubworker`). They need someone with sops keys. The Postmark account itself also still needs decommissioning.

## Changes in this repo

Removes the retired `EnhancedEmailDeliverability` field from `instancesettings.UpdateParams`. The doc comment described sending via Postmark through Clerk's shared domain, which no longer happens.

Breaking change to a public struct field, so it needs a version decision from the SDK owners - flagged as draft for that reason. The Backend API still accepts and ignores the key, so existing pinned versions keep working.

<!-- clk:companion-prs -->
## Companion PRs

- **backoffice**: https://github.com/clerk/backoffice/pull/724
- **clerk_go**: https://github.com/clerk/clerk_go/pull/21398
- **dashboard**: https://github.com/clerk/dashboard/pull/10112
- **javascript**: https://github.com/clerk/javascript/pull/9586
- **terraform-app-infra**: https://github.com/clerk/terraform-app-infra/pull/3193
- **clerk_go:api-surface**: https://github.com/clerk/clerk_go/pull/21613
<!-- /clk:companion-prs -->

