### PR TITLE
feat(oauthapplication): expose device authorization grant setting

### DIFF
--- a/oauth_application.go
+++ b/oauth_application.go
@@ -2,27 +2,30 @@ package clerk
 
 type OAuthApplication struct {
 	APIResource
-	Object                string   `json:"object"`
-	ID                    string   `json:"id"`
-	InstanceID            string   `json:"instance_id"`
-	Name                  string   `json:"name"`
-	ClientID              string   `json:"client_id"`
-	ClientSecret          *string  `json:"client_secret,omitempty"`
-	ClientImageURL        *string  `json:"client_image_url"`
-	ClientURL             *string  `json:"client_url"`
-	PKCERequired          bool     `json:"pkce_required"`
-	Public                bool     `json:"public"`
-	DynamicallyRegistered bool     `json:"dynamically_registered"`
-	ConsentScreenEnabled  bool     `json:"consent_screen_enabled"`
-	Scopes                string   `json:"scopes"`
-	RedirectURIs          []string `json:"redirect_uris"`
-	DiscoveryURL          string   `json:"discovery_url"`
-	AuthorizeURL          string   `json:"authorize_url"`
-	TokenFetchURL         string   `json:"token_fetch_url"`
-	UserInfoURL           string   `json:"user_info_url"`
-	TokenIntrospectionURL string   `json:"token_introspection_url"`
-	CreatedAt             int64    `json:"created_at"`
-	UpdatedAt             int64    `json:"updated_at"`
+	Object                string  `json:"object"`
+	ID                    string  `json:"id"`
+	InstanceID            string  `json:"instance_id"`
+	Name                  string  `json:"name"`
+	ClientID              string  `json:"client_id"`
+	ClientSecret          *string `json:"client_secret,omitempty"`
+	ClientImageURL        *string `json:"client_image_url"`
+	ClientURL             *string `json:"client_url"`
+	PKCERequired          bool    `json:"pkce_required"`
+	Public                bool    `json:"public"`
+	DynamicallyRegistered bool    `json:"dynamically_registered"`
+	ConsentScreenEnabled  bool    `json:"consent_screen_enabled"`
+	// Experimental: This feature is not publicly available and requires the
+	// instance to be opted into this feature.
+	DeviceAuthorizationGrantEnabled bool     `json:"device_authorization_grant_enabled"`
+	Scopes                          string   `json:"scopes"`
+	RedirectURIs                    []string `json:"redirect_uris"`
+	DiscoveryURL                    string   `json:"discovery_url"`
+	AuthorizeURL                    string   `json:"authorize_url"`
+	TokenFetchURL                   string   `json:"token_fetch_url"`
+	UserInfoURL                     string   `json:"user_info_url"`
+	TokenIntrospectionURL           string   `json:"token_introspection_url"`
+	CreatedAt                       int64    `json:"created_at"`
+	UpdatedAt                       int64    `json:"updated_at"`
 
 	// AccessTokenTTL is the TTL for access tokens issued by this OAuth application, in seconds. Nil means use default.
 	AccessTokenTTL *int64 `json:"access_token_ttl,omitempty"`

--- a/oauthapplication/client.go
+++ b/oauthapplication/client.go
@@ -79,7 +79,10 @@ type CreateParams struct {
 	Scopes               *string  `json:"scopes,omitempty"`
 	Public               *bool    `json:"public,omitempty"`
 	ConsentScreenEnabled *bool    `json:"consent_screen_enabled"`
-	PKCERequired         *bool    `json:"pkce_required"`
+	// Experimental: This feature is not publicly available and requires the
+	// instance to be opted into this feature.
+	DeviceAuthorizationGrantEnabled *bool `json:"device_authorization_grant_enabled"`
+	PKCERequired                    *bool `json:"pkce_required"`
 
 	// Deprecated: Use RedirectURIs instead
 	CallbackURL *string `json:"callback_url,omitempty"`
@@ -102,6 +105,9 @@ type UpdateParams struct {
 	Public               *bool    `json:"public,omitempty"`
 	PKCERequired         *bool    `json:"pkce_required,omitempty"`
 	ConsentScreenEnabled *bool    `json:"consent_screen_enabled,omitempty"`
+	// Experimental: This feature is not publicly available and requires the
+	// instance to be opted into this feature.
+	DeviceAuthorizationGrantEnabled *bool `json:"device_authorization_grant_enabled,omitempty"`
 
 	// AccessTokenTTL is the TTL for access tokens in seconds. Omit = no change; null = reset to default; number = set. Only used when instance has the feature enabled.
 	AccessTokenTTL optional.Int64 `json:"access_token_ttl,omitzero"`

--- a/oauthapplication/client_test.go
+++ b/oauthapplication/client_test.go
@@ -26,8 +26,8 @@ func TestOAuthApplicationClientCreate(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","callback_url":"https://callback.url","scopes":"read,write","public":true,"consent_screen_enabled":true,"pkce_required":true}`, name)),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","callback_url":"%s","scopes":"%s","public":%t,"client_secret":"%s","consent_screen_enabled":true,"pkce_required":true}`, id, name, callbackURL, scopes, public, clientSecret)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","callback_url":"https://callback.url","scopes":"read,write","public":true,"consent_screen_enabled":true,"device_authorization_grant_enabled":true,"pkce_required":true}`, name)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","callback_url":"%s","scopes":"%s","public":%t,"client_secret":"%s","consent_screen_enabled":true,"device_authorization_grant_enabled":true,"pkce_required":true}`, id, name, callbackURL, scopes, public, clientSecret)),
 			Method: http.MethodPost,
 			Path:   "/v1/oauth_applications",
 		},
@@ -35,12 +35,13 @@ func TestOAuthApplicationClientCreate(t *testing.T) {
 	client := NewClient(config)
 
 	params := &CreateParams{
-		Name:                 name,
-		CallbackURL:          clerk.String(callbackURL),
-		Scopes:               clerk.String(scopes),
-		Public:               clerk.Bool(public),
-		ConsentScreenEnabled: clerk.Bool(true),
-		PKCERequired:         clerk.Bool(true),
+		Name:                            name,
+		CallbackURL:                     clerk.String(callbackURL),
+		Scopes:                          clerk.String(scopes),
+		Public:                          clerk.Bool(public),
+		ConsentScreenEnabled:            clerk.Bool(true),
+		DeviceAuthorizationGrantEnabled: clerk.Bool(true),
+		PKCERequired:                    clerk.Bool(true),
 	}
 	oauthApp, err := client.Create(t.Context(), params)
 	require.NoError(t, err)
@@ -52,6 +53,7 @@ func TestOAuthApplicationClientCreate(t *testing.T) {
 	require.Equal(t, public, oauthApp.Public)
 	require.Equal(t, clientSecret, *oauthApp.ClientSecret)
 	require.Equal(t, true, oauthApp.ConsentScreenEnabled)
+	require.True(t, oauthApp.DeviceAuthorizationGrantEnabled)
 	require.Equal(t, true, oauthApp.PKCERequired)
 }
 
@@ -121,8 +123,8 @@ func TestOAuthApplicationClientUpdate(t *testing.T) {
 	config.HTTPClient = &http.Client{
 		Transport: &clerktest.RoundTripper{
 			T:      t,
-			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","redirect_uris":["%s","%s"], "public":%t,"consent_screen_enabled":%t,"pkce_required":true}`, updatedName, callbackURL1, callbackURL2, public, false)),
-			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","redirect_uris":["%s","%s"],"callback_url":"%s","public":%t,"consent_screen_enabled":%t,"pkce_required":true}`, id, updatedName, callbackURL1, callbackURL2, callbackURL1, public, false)),
+			In:     json.RawMessage(fmt.Sprintf(`{"name":"%s","redirect_uris":["%s","%s"], "public":%t,"consent_screen_enabled":%t,"device_authorization_grant_enabled":false,"pkce_required":true}`, updatedName, callbackURL1, callbackURL2, public, false)),
+			Out:    json.RawMessage(fmt.Sprintf(`{"id":"%s","name":"%s","redirect_uris":["%s","%s"],"callback_url":"%s","public":%t,"consent_screen_enabled":%t,"device_authorization_grant_enabled":false,"pkce_required":true}`, id, updatedName, callbackURL1, callbackURL2, callbackURL1, public, false)),
 			Method: http.MethodPatch,
 			Path:   fmt.Sprintf("/v1/oauth_applications/%s", id),
 		},
@@ -130,11 +132,12 @@ func TestOAuthApplicationClientUpdate(t *testing.T) {
 
 	client := NewClient(config)
 	params := &UpdateParams{
-		Name:                 clerk.String(updatedName),
-		RedirectURIs:         []string{callbackURL1, callbackURL2},
-		Public:               clerk.Bool(public),
-		ConsentScreenEnabled: clerk.Bool(false),
-		PKCERequired:         clerk.Bool(true),
+		Name:                            clerk.String(updatedName),
+		RedirectURIs:                    []string{callbackURL1, callbackURL2},
+		Public:                          clerk.Bool(public),
+		ConsentScreenEnabled:            clerk.Bool(false),
+		DeviceAuthorizationGrantEnabled: clerk.Bool(false),
+		PKCERequired:                    clerk.Bool(true),
 	}
 	oauthApp, err := client.Update(t.Context(), id, params)
 	require.NoError(t, err)
@@ -144,6 +147,7 @@ func TestOAuthApplicationClientUpdate(t *testing.T) {
 	require.Equal(t, callbackURL1, oauthApp.CallbackURL)
 	require.Equal(t, []string{callbackURL1, callbackURL2}, oauthApp.RedirectURIs)
 	require.False(t, oauthApp.ConsentScreenEnabled)
+	require.False(t, oauthApp.DeviceAuthorizationGrantEnabled)
 	require.Equal(t, true, oauthApp.PKCERequired)
 	require.Nil(t, oauthApp.AccessTokenTTL)
 }


### PR DESCRIPTION
## Summary

Adds  `device_authorization_grant_enabled` to OAuth application responses & params

BAPI does not support this yet, but it is backward compatible. 

SDK needs to be updated for DAPI to be compatible with the BAPI changes.  

## Testing

- `go generate ./oauthapplication`
- `go test ./oauthapplication`
- `go test -v -race ./...`
